### PR TITLE
Treat warnings as errors on the test project

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_testing()
 
-file(GLOB TEST_SRC "*.c")
+file(GLOB TEST_SRC "main.c")
 file(GLOB TEST_HDRS "*.h")
 file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
 
@@ -9,8 +9,12 @@ set(TEST_BINARY_NAME ${CMAKE_PROJECT_NAME}-tests)
 add_executable(${TEST_BINARY_NAME} ${TESTS})
 target_link_libraries(${TEST_BINARY_NAME} ${CMAKE_PROJECT_NAME})
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
-
 target_include_directories(${TEST_BINARY_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+if (MSVC)
+    target_compile_options(${TEST_BINARY_NAME} PRIVATE /W4 /WX)
+else ()
+    target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror)
+endif ()
 
 add_test(raise_errors_test ${TEST_BINARY_NAME} raise_errors_test)
 add_test(reset_errors_test ${TEST_BINARY_NAME} reset_errors_test)

--- a/tests/priority_queue_test.c
+++ b/tests/priority_queue_test.c
@@ -103,7 +103,7 @@ static int test_priority_queue_random_values(struct aws_allocator *alloc, void *
     int storage[SIZE], err;
     aws_priority_queue_static_init(&queue, storage, SIZE, sizeof(int), compare_ints);
     int values[SIZE];
-    srand((unsigned)&queue);
+    srand((size_t)&queue);
     for(int i = 0; i < SIZE; i++) {
         values[i] = rand() % 1000;
         err = aws_priority_queue_push(&queue, &values[i]);


### PR DESCRIPTION
*Description of changes:*
Treat warnings as errors in gcc/clang/msvc.
Test source files are #included in main.c so changed CMake to only build main.c instead of globbing all *.c files, otherwise we get many errors/warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
