### PR TITLE
RFC: Automatic assert messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 #execute build
 script:
-  - cppcheck --enable=all --std=c99 --language=c --suppress=unusedFunction --suppress=missingInclude -I include --force --error-exitcode=-1 -USELF_TEST  -UCLOCK_MONOTONIC_RAW --suppress=memleak:tests/hash_table_test.c --suppress=unreadVariable:tests/hash_table_test.c -q ./
+  - ./cppcheck.sh
   - mkdir build
   - cd build
   - cmake ..

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -x
+
+cppcheck                                                    \
+                                                            \
+--enable=all --std=c99 --language=c                         \
+--template='[{file}:{line}]: ({severity},{id}){message}'    \
+--force --error-exitcode=-1                                 \
+                                                            \
+-I include                                                  \
+-USELF_TEST  -UCLOCK_MONOTONIC_RAW                          \
+                                                            \
+--suppress=unusedFunction                                   \
+--suppress=missingInclude                                   \
+--suppress=memleak:tests/hash_table_test.c                  \
+--suppress=unreadVariable:tests/hash_table_test.c           \
+                                                            \
+-q .

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -13,5 +13,6 @@ cppcheck                                                    \
 --suppress=missingInclude                                   \
 --suppress=memleak:tests/hash_table_test.c                  \
 --suppress=unreadVariable:tests/hash_table_test.c           \
+--suppress=staticStringCompare:tests/assert_test.c          \
                                                             \
 -q .

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -31,6 +31,10 @@ but you should be aware we make no promises on the stability of this API.  To en
 the AWS_UNSTABLE_TESTING_API compiler flag
 #endif
 
+#ifndef AWS_TESTING_REPORT_FD
+#define AWS_TESTING_REPORT_FD stderr
+#endif
+
 struct memory_test_config {
     void *(*mem_acquire)(struct aws_allocator *config, size_t size);
     void(*mem_release)(struct aws_allocator *config, void *ptr);
@@ -69,21 +73,27 @@ static void mem_release_free(struct aws_allocator *config, void *ptr) {
         .freed = 0                                                                                                     \
   }
 
-/** Prints a message to stdout using printf format that appends the function, file and line number. */
-static void cunit_failure_message(const char *function, const char *file, int line, const char *format, ...) {
+/** Prints a message to stdout using printf format that appends the function, file and line number.
+  * If format is null, returns 0 without printing anything; otherwise returns 1.
+  */
+static int cunit_failure_message0(const char *prefix, const char *function, const char *file, int line, const char *format, ...) {
+    if (!format) return 0;
+
+    fprintf(AWS_TESTING_REPORT_FD, "%s", prefix);
+
     va_list ap;
     va_start(ap, format);
-    char buffer1[4096];
-    vsnprintf(buffer1, sizeof(buffer1), format, ap);
-    buffer1[sizeof(buffer1) - 1] = 0;
+    vfprintf(AWS_TESTING_REPORT_FD, format, ap);
     va_end(ap);
 
-    char buffer2[4096];
-    snprintf(buffer2, sizeof(buffer2), " [%s():%s@#%d]", function, file, line);
-    buffer2[sizeof(buffer2) - 1] = 0;
+    fprintf(AWS_TESTING_REPORT_FD, " [%s():%s@#%d]\n", function, file, line);
 
-    fprintf(stderr, "%s%s\n", buffer1, buffer2);
+    return 1;
 }
+
+#define FAIL_PREFIX "***FAILURE*** "
+#define cunit_failure_message(func, file, line, format, ...) \
+    cunit_failure_message0(FAIL_PREFIX, func, file, line, format, # __VA_ARGS__)
 
 static int total_failures;
 
@@ -91,32 +101,169 @@ static int total_failures;
 #define FAILURE -1
 
 #define RETURN_SUCCESS(format, ...) do { printf(format, ## __VA_ARGS__); printf("\n"); return SUCCESS; } while (0)
-#define FAIL(format, ...) do { cunit_failure_message(__FUNCTION__, __FILE__, __LINE__, "***FAILURE*** " format, ## __VA_ARGS__); total_failures++; return FAILURE; } while (0)
-#define ASSERT_TRUE(condition, format, ...) do { if(!(condition)) { FAIL(format, ## __VA_ARGS__); } } while(0)
-#define ASSERT_FALSE(condition, format, ...) do { if(condition) { FAIL(format, ## __VA_ARGS__); } } while(0)
+#define PRINT_FAIL_INTERNAL(...) \
+    cunit_failure_message(__FUNCTION__, __FILE__, __LINE__, ## __VA_ARGS__, (const char *)NULL)
 
-#define ASSERT_SUCCESS(condition, format, ...) do { if((condition) != AWS_OP_SUCCESS) { FAIL(format, ## __VA_ARGS__); } } while(0)
-#define ASSERT_FAILS(condition, format, ...) do { if((condition) != AWS_OP_ERR) { FAIL(format, ## __VA_ARGS__); } } while(0)
-#define ASSERT_ERROR(error, condition, format, ...) do { if((condition) != AWS_OP_ERR) { FAIL("Expected error but no error occurred: " format, ## __VA_ARGS__); } if(aws_last_error() != (error)) { FAIL("Bad error code; got %d but expected %d: " format, aws_last_error(), (error), ## __VA_ARGS__); } } while(0)
-#define ASSERT_NULL(ptr, format, ...) do { if(ptr) { FAIL(format, ## __VA_ARGS__); } } while(0)
-#define ASSERT_NOT_NULL(ptr, format, ...) do { if(!(ptr)) { FAIL(format, ## __VA_ARGS__); } } while(0)
-#define ASSERT_INT_EQUALS(expected, got, message, ...) do { long long a = (long long) (expected); long long b = (long long) (got); \
-    if (a != b) { FAIL("Expected:%lld got:%lld - " message, a, b, ## __VA_ARGS__); } } while(0)
-#define ASSERT_UINT_EQUALS(expected, got, message, ...) do { unsigned long long a = (unsigned long long) (expected); unsigned long long b = (unsigned long long) (got); \
-    if (a != b) { FAIL("Expected:%llu got:%llu - " message, a, b, ## __VA_ARGS__); } } while(0)
-#define ASSERT_PTR_EQUALS(expected, got, message, ...) do { void *a = (void *) (expected); void *b = (void *) (got); \
-    if (a != b) { FAIL("Expected:%lld got:%lld - " message, a, b, ## __VA_ARGS__); } } while(0)
-#define ASSERT_STR_EQUALS(expected, got, message, ...) do { if (strcmp(expected, got)) { FAIL("Expected:%x got:%x - " message, expected, got, ## __VA_ARGS__); } } while(0)
-#define ASSERT_BYTE_HEX_EQUALS(expected, got, message, ...) do { uint8_t a = (uint8_t) (expected); uint8_t b = (uint8_t) (got); \
-    if (a != b) { FAIL("Expected:%x got:%x - " message, a, b, ## __VA_ARGS__); } } while(0)
-#define ASSERT_HEX_EQUALS(expected, got, message, ...) do { long long a = (long long) (expected); long long b = (long long) (got); \
-    if (a != b) { FAIL("Expected:%llX got:%llX - " message, a, b, ## __VA_ARGS__); } } while(0)
-#define ASSERT_BIN_ARRAYS_EQUALS(expected, expected_size, got, got_size, message, ... ) for (size_t i = 0; i < expected_size; ++i){ \
-    if ((expected)[i] != (got)[i]) {\
-        FAIL("Expected:%02x got:%02x - " message, (expected)[i], (got)[i], ## __VA_ARGS__);\
-    }\
-}
+#define PRINT_FAIL_INTERNAL0(...) \
+    cunit_failure_message0("", __FUNCTION__, __FILE__, __LINE__, ## __VA_ARGS__, (const char *)NULL)
 
+#define POSTFAIL_INTERNAL() do {\
+    total_failures++; \
+    return FAILURE; \
+} while (0)
+
+#define FAIL(format, ...)  \
+    do { PRINT_FAIL_INTERNAL(format, ## __VA_ARGS__); POSTFAIL_INTERNAL(); } while (0)
+
+
+#define ASSERT_TRUE(condition, ...) \
+    do { \
+        if(!(condition)) { \
+            if (!PRINT_FAIL_INTERNAL(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL("Expected condition to be true: " #condition); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while(0)
+
+#define ASSERT_FALSE(condition, ...) \
+    do { \
+        if((condition)) { \
+            if (!PRINT_FAIL_INTERNAL(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL("Expected condition to be false: " #condition); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_SUCCESS(condition, ...) \
+    do { \
+        int assert_rv = (condition); \
+        if (assert_rv != AWS_OP_SUCCESS) { \
+            if (!PRINT_FAIL_INTERNAL(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL("Expected success at %s; got return value %d with last error 0x%04x\n", \
+                    #condition, assert_rv, aws_last_error()); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_FAILS(condition, ...) \
+    do { \
+        int assert_rv = (condition); \
+        if (assert_rv != AWS_OP_ERR) { \
+            if (!PRINT_FAIL_INTERNAL(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL("Expected failure at %s; got return value %d with last error 0x%04x\n", \
+                    #condition, assert_rv, aws_last_error()); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_ERROR(error, condition, ...) \
+    do { \
+        int assert_rv = (condition); \
+        int assert_err = aws_last_error(); \
+        int assert_err_expect = (error); \
+        if (assert_rv != AWS_OP_ERR) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sExpected error but no error occurred; rv=%d, aws_last_error=%04x (expected %04x): ", FAIL_PREFIX, assert_rv, assert_err, assert_err_expect); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("%s", #condition); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+        if (assert_err != assert_err_expect) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sIncorrect error code; aws_last_error=%04x (expected %04x): ", FAIL_PREFIX, assert_err, assert_err_expect); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("%s", #condition); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_NULL(ptr, ...) \
+    do { \
+        /* XXX: Some tests use ASSERT_NULL on ints... */ \
+        void *assert_p = (void *)(uintptr_t)(ptr); \
+        if (assert_p) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sExpected null but got %p: ", FAIL_PREFIX, assert_p); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("%s", #ptr); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_NOT_NULL(ptr, ...) \
+    do { \
+        /* XXX: Some tests use ASSERT_NULL on ints... */ \
+        void *assert_p = (void *)(uintptr_t)(ptr); \
+        if (!assert_p) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sExpected non-null but got null: ", FAIL_PREFIX); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("%s", #ptr); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_TYP_EQUALS(type, formatarg, expected, got, ...) \
+    do { \
+        type assert_expected = (type)(expected); \
+        type assert_actual   = (type)(got); \
+        if (assert_expected != assert_actual) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%s" formatarg " != " formatarg ": ", FAIL_PREFIX, assert_expected, assert_actual); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("%s != %s", #expected, #got); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while (0)
+
+#define ASSERT_INT_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(long long, "%lld", expected, got, __VA_ARGS__)
+#define ASSERT_UINT_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(long long, "%llu", expected, got, __VA_ARGS__)
+#define ASSERT_PTR_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(void *, "%p", expected, got, __VA_ARGS__)
+/* note that uint8_t is promoted to unsigned int in varargs, so %02x is an acceptable format string */
+#define ASSERT_BYTE_HEX_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(uint8_t, "%02X", expected, got, __VA_ARGS__)
+#define ASSERT_HEX_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(unsigned long long, "%llX", expected, got, __VA_ARGS__)
+
+#define ASSERT_STR_EQUALS(expected, got, ...) \
+    do { \
+        const char *assert_expected = (expected); \
+        const char *assert_got = (got); \
+        if (strcmp(assert_expected, assert_got)) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sExpected: \"%s\"; got: \"%s\": ", FAIL_PREFIX, assert_expected, assert_got); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("ASSERT_STR_EQUALS(%s, %s)", #expected, #got); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while(0)
+
+#define ASSERT_BIN_ARRAYS_EQUALS(expected, expected_size, got, got_size, ...) \
+    do { \
+        const uint8_t *assert_ex_p = (const uint8_t *)(expected); \
+        size_t assert_ex_s = (expected_size); \
+        const uint8_t *assert_got_p = (const uint8_t *)(got); \
+        size_t assert_got_s = (got_size); \
+        if (assert_ex_s != assert_got_s) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sSize mismatch: %zu != %zu: ", FAIL_PREFIX, assert_ex_s, assert_got_s); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("ASSERT_BIN_ARRAYS_EQUALS(%s, %s, %s, %s)", \
+                    #expected, #expected_size, #got, #got_size); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+        if (memcmp(assert_ex_p, assert_got_p, assert_got_s)) { \
+            fprintf(AWS_TESTING_REPORT_FD, "%sData mismatch: ", FAIL_PREFIX); \
+            if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) { \
+                PRINT_FAIL_INTERNAL0("ASSERT_BIN_ARRAYS_EQUALS(%s, %s, %s, %s)", \
+                    #expected, #expected_size, #got, #got_size); \
+            } \
+            POSTFAIL_INTERNAL(); \
+        } \
+    } while(0)
+        
 typedef void(*aws_test_before)(struct aws_allocator *allocator, void *ctx);
 typedef int(*aws_test_run)(struct aws_allocator *allocator, void *ctx);
 typedef void(*aws_test_after)(struct aws_allocator *allocator, void *ctx);
@@ -198,7 +345,7 @@ static int aws_run_test_case(struct aws_test_harness *harness) {
     }                                                                                                                  \
                                                                                                                        \
     fflush(stdout);                                                                                                    \
-    fflush(stderr);                                                                                                    \
+    fflush(AWS_TESTING_REPORT_FD);                                                                                                    \
     return ret_val;                                                                                                    \
 
 #endif /* AWS_TEST_HARNESS_H _*/

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -221,7 +221,7 @@ static int total_failures;
     } while (0)
 
 #define ASSERT_INT_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(long long, "%lld", expected, got, __VA_ARGS__)
-#define ASSERT_UINT_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(long long, "%llu", expected, got, __VA_ARGS__)
+#define ASSERT_UINT_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(unsigned long long, "%llu", expected, got, __VA_ARGS__)
 #define ASSERT_PTR_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(void *, "%p", expected, got, __VA_ARGS__)
 /* note that uint8_t is promoted to unsigned int in varargs, so %02x is an acceptable format string */
 #define ASSERT_BYTE_HEX_EQUALS(expected, got, ...) ASSERT_TYP_EQUALS(uint8_t, "%02X", expected, got, __VA_ARGS__)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,23 @@ else ()
     target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror)
 endif ()
 
+file(GLOB META_TESTS "assert_test.c")
+
+set(METATEST_BINARY_NAME ${CMAKE_PROJECT_NAME}-assert-tests)
+
+add_executable(${METATEST_BINARY_NAME} ${META_TESTS})
+target_link_libraries(${METATEST_BINARY_NAME} ${CMAKE_PROJECT_NAME})
+set_target_properties(${METATEST_BINARY_NAME} PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
+target_compile_definitions(${METATEST_BINARY_NAME} PRIVATE AWS_UNSTABLE_TESTING_API=1)
+target_include_directories(${METATEST_BINARY_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+if (MSVC)
+    target_compile_options(${METATEST_BINARY_NAME} PRIVATE /W4 /WX)
+else ()
+    target_compile_options(${METATEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror)
+endif ()
+
+add_test(assert_test ${METATEST_BINARY_NAME} ${CMAKE_CURRENT_BINARY_DIR}/metatest.tmp)
+
 add_test(raise_errors_test ${TEST_BINARY_NAME} raise_errors_test)
 add_test(reset_errors_test ${TEST_BINARY_NAME} reset_errors_test)
 add_test(error_callback_test ${TEST_BINARY_NAME} error_callback_test)

--- a/tests/assert_test.c
+++ b/tests/assert_test.c
@@ -100,9 +100,8 @@ int test_asserts(int *index) {
 
     TEST_SUCCESS(assert_null)    { ASSERT_NULL(NULL); }
     {
-        void *nullp1 = NULL;
         const struct forward_decl *nullp2 = NULL;
-        TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp1); }
+        TEST_SUCCESS(assert_null)    { void *nullp = NULL; ASSERT_NULL(nullp); }
         TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp2); }
         TEST_SUCCESS(assert_null_sideeffects) { ASSERT_NULL((side_effect(), nullp2)); }
     }

--- a/tests/assert_test.c
+++ b/tests/assert_test.c
@@ -1,0 +1,262 @@
+/** This standalone test harness tests that the asserts themselves function properly */
+
+#define AWS_TESTING_REPORT_FD test_filedes
+#include <stdio.h>
+#include <string.h>
+
+FILE *test_filedes;
+
+#include <aws/testing/aws_test_harness.h>
+
+#define NO_MORE_TESTS 12345
+#define BAILED_OUT 98765
+
+const char *test_filename;
+int cur_line;
+int expected_return;
+int bail_out;
+
+#define TEST_SUCCESS(name) \
+    if (bail_out) return BAILED_OUT; \
+    if (begin_test(index, #name, __FILE__, __LINE__, 0))
+
+#define TEST_FAILURE(name) \
+    if (bail_out) return BAILED_OUT; \
+    if (begin_test(index, #name, __FILE__, __LINE__, -1))
+
+const char *cur_testname, *cur_file;
+
+int begin_test(int *index, const char *testname, const char *file, int line, int expected) {
+    if (*index <= line) {
+        *index = line;
+        cur_testname = testname;
+        cur_file = file;
+        cur_line = line;
+        expected_return = expected == 0 ? BAILED_OUT : expected;
+        bail_out = 1;
+        return 1;
+    }
+
+    return 0;
+}
+
+static int side_effect_ctr = 0;
+
+int side_effect() {
+    if (side_effect_ctr++) {
+        fprintf(stderr, "***FAILURE*** Side effects triggered multiple times, after %s:%d (%s)", cur_file, cur_line, cur_testname);
+        abort();
+    }
+
+    return 0;
+}
+
+int test_asserts(int *index) {
+    TEST_SUCCESS(null_test) {}
+    TEST_FAILURE(null_failure_test) {
+        fprintf(AWS_TESTING_REPORT_FD, "***FAILURE*** test\n");
+        return FAILURE;
+    }
+
+    TEST_FAILURE(basic_fail_1) {
+        FAIL("Failed: %d", 42);
+    }
+    TEST_FAILURE(assert_bool) {
+        ASSERT_TRUE(0);
+    }
+    TEST_FAILURE(assert_bool) {
+        ASSERT_TRUE(0, "foo %d", 42);
+    }
+    TEST_FAILURE(assert_bool) {
+        ASSERT_FALSE(1);
+    }
+    TEST_FAILURE(assert_bool) {
+        ASSERT_FALSE(1, "foo %d", 42);
+    }
+    TEST_SUCCESS(assert_bool) {
+        ASSERT_TRUE(1);
+    }
+    TEST_SUCCESS(assert_bool) {
+        ASSERT_TRUE(2);
+    }
+    TEST_SUCCESS(assert_bool) {
+        ASSERT_FALSE(0);
+    }
+    TEST_SUCCESS(assert_success) { ASSERT_SUCCESS(AWS_OP_SUCCESS); }
+    TEST_SUCCESS(assert_success) { ASSERT_SUCCESS(AWS_OP_SUCCESS, "foo"); }
+    TEST_FAILURE(assert_success) { ASSERT_SUCCESS(aws_raise_error(AWS_ERROR_OOM), "foo"); }
+
+    TEST_SUCCESS(assert_fails)   { ASSERT_FAILS(aws_raise_error(AWS_ERROR_OOM)); }
+    TEST_SUCCESS(assert_fails)   { ASSERT_FAILS(aws_raise_error(AWS_ERROR_OOM), "foo"); }
+    TEST_FAILURE(assert_fails)   { ASSERT_FAILS(AWS_OP_SUCCESS, "foo"); }
+
+    TEST_SUCCESS(assert_error)   { ASSERT_ERROR(AWS_ERROR_OOM, aws_raise_error(AWS_ERROR_OOM)); }
+    TEST_SUCCESS(assert_error_side_effect)   { ASSERT_ERROR((side_effect(), AWS_ERROR_OOM), aws_raise_error(AWS_ERROR_OOM)); }
+    TEST_SUCCESS(assert_error_side_effect)   { ASSERT_ERROR(AWS_ERROR_OOM, (side_effect(), aws_raise_error(AWS_ERROR_OOM))); }
+    TEST_SUCCESS(assert_error)   { ASSERT_ERROR(AWS_ERROR_OOM, aws_raise_error(AWS_ERROR_OOM), "foo"); }
+    TEST_FAILURE(assert_error)   { ASSERT_ERROR(AWS_ERROR_CLOCK_FAILURE, aws_raise_error(AWS_ERROR_OOM), "foo"); }
+    aws_raise_error(AWS_ERROR_CLOCK_FAILURE); // set last error
+    TEST_FAILURE(assert_error)   { ASSERT_ERROR(AWS_ERROR_CLOCK_FAILURE, AWS_OP_SUCCESS, "foo"); }
+
+    TEST_SUCCESS(assert_null)    { ASSERT_NULL(NULL); }
+    void *nullp1 = NULL;
+    const struct forward_decl *nullp2 = NULL;
+    TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp1); }
+    TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp2); }
+    TEST_SUCCESS(assert_null_sideeffects) { ASSERT_NULL((side_effect(), nullp2)); }
+    TEST_SUCCESS(assert_null)    { ASSERT_NULL(0, "foo"); }
+    TEST_FAILURE(assert_null)    { ASSERT_NULL("hello world", "foo"); }
+
+    TEST_SUCCESS(inteq)          { ASSERT_INT_EQUALS(4321, 4321); }
+    TEST_SUCCESS(inteq)          { ASSERT_INT_EQUALS(4321, 4321, "foo"); }
+    int increment = 4321;
+    TEST_SUCCESS(inteq_side_effects) {
+        ASSERT_INT_EQUALS(4321, increment++, "foo");
+        ASSERT_INT_EQUALS(4322, increment++, "foo");
+    }
+    TEST_FAILURE(inteq_difference) { ASSERT_INT_EQUALS(0, 1, "foo"); }
+
+    // UINT/PTR/BYTE_HEX/HEX are the same backend, so just test that the format string doesn't break
+    TEST_FAILURE(uinteq) { ASSERT_UINT_EQUALS(0, 1, "Foo"); }
+    TEST_FAILURE(ptreq) { ASSERT_PTR_EQUALS("x", "y", "Foo"); }
+    TEST_FAILURE(bytehex) { ASSERT_BYTE_HEX_EQUALS('a', 'b'); }
+    TEST_FAILURE(hex) { ASSERT_HEX_EQUALS((uint64_t)-1, 0); }
+
+
+    char str_x[2] = "x";
+
+    TEST_SUCCESS(streq) {
+        ASSERT_STR_EQUALS((side_effect(), "x"), "x");
+    }
+    TEST_SUCCESS(streq) {
+        ASSERT_STR_EQUALS("x", (side_effect(), str_x), "foo");
+    }
+    TEST_FAILURE(streq) {
+        ASSERT_STR_EQUALS("x", "xy", "bar");
+    }
+    TEST_FAILURE(streq) {
+        ASSERT_STR_EQUALS("xy", "x");
+    }
+
+    uint8_t bin1[] = { 0, 1, 2 };
+    uint8_t bin2[] = { 0, 1, 2 };
+    uint8_t bin3[] = { 0, 1, 3 };
+
+    TEST_SUCCESS(bineq) {
+        ASSERT_BIN_ARRAYS_EQUALS((side_effect(), bin1), 3, bin2, 3);
+        side_effect_ctr = 0;
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, (side_effect(), 3), bin2, 3);
+        side_effect_ctr = 0;
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, (side_effect(), bin2), 3);
+        side_effect_ctr = 0;
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, bin2, (side_effect(), 3));
+    }
+    TEST_FAILURE(bineq_samesize) {
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, bin3, 3, "foo");
+    }
+    TEST_FAILURE(bineq_diffsize) {
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, bin2, 2);
+    }
+    TEST_FAILURE(bineq_diffsize) {
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 2, bin2, 3);
+    }
+    TEST_SUCCESS(bineq_empty) {
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 0, bin2, 0, "foo");
+    }
+    TEST_SUCCESS(bineq_same) {
+        ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, bin1, 3);
+    }
+
+    return NO_MORE_TESTS;
+}
+
+void reset() {
+    cur_testname = "UNKNOWN";
+    cur_file = "UNKNOWN";
+    bail_out = 0;
+
+    if (test_filedes) {
+        fclose(test_filedes);
+    }
+
+    test_filedes = fopen(test_filename, "w");
+    if (!test_filedes) {
+        perror("***INTERNAL ERROR*** Failed to open temporary file");
+        abort();
+    }
+
+    side_effect_ctr = 0;
+}
+
+int check_failure_output(const char *expected) {
+    fclose(test_filedes);
+    test_filedes = NULL;
+
+    FILE *readfd = fopen(test_filename, "r");
+
+    static char tmpbuf[256];
+    char *rv = fgets(tmpbuf, sizeof(tmpbuf), readfd);
+    fclose(readfd);
+
+    if (!expected) {
+        return rv == NULL;
+    } else {
+        if (!rv) return 0;
+        return !strncmp(tmpbuf, expected, strlen(expected));
+    }
+}
+
+int main(int argc, char **argv) {
+    int index = 0;
+
+    test_filename = argv[1];
+
+    // Suppress unused function warnings
+    (void)mem_acquire_malloc;
+    (void)mem_release_free;
+    (void)aws_run_test_case;
+
+    // Sanity checks for our own test macros
+
+    reset();
+    if (test_asserts(&index) != BAILED_OUT) {
+        fprintf(stderr, "***FAILURE*** Initial case did not succeed; stopped at %s:%d (%s)\n", cur_file, index, cur_testname);
+        return 1;
+    }
+
+    index++;
+    reset();
+    if (test_asserts(&index) != FAILURE) {
+        fprintf(stderr, "***FAILURE*** Second case did not fail; stopped at %s:%d (%s)\n", cur_file, index, cur_testname);
+        return 1;
+    }
+
+    index = 0;
+    int rv = 0;
+    for (;;) {
+        reset();
+        rv = test_asserts(&index);
+        if (rv == NO_MORE_TESTS) {
+            break;
+        }
+        if (rv != expected_return) {
+            fprintf(stderr, "***FAILURE*** Wrong result (%d expected, %d got) after %s:%d (%s)\n", expected_return, rv, cur_file, index, cur_testname);
+            return 1;
+        }
+        if (expected_return == FAILURE) {
+            if (!check_failure_output("***FAILURE*** ")) {
+                fprintf(stderr, "***FAILURE*** Output did not start with ***FAILURE*** after %s:%d (%s)\n", cur_file, index, cur_testname);
+                return 1;
+            }
+        } else {
+            if (!check_failure_output(NULL)) {
+                fprintf(stderr, "***FAILURE*** Output was not empty after %s:%d (%s)\n", cur_file, index, cur_testname);
+                return 1;
+            }
+        }
+
+        index++;
+    }
+
+    return 0;
+}

--- a/tests/assert_test.c
+++ b/tests/assert_test.c
@@ -99,18 +99,20 @@ int test_asserts(int *index) {
     TEST_FAILURE(assert_error)   { ASSERT_ERROR(AWS_ERROR_CLOCK_FAILURE, AWS_OP_SUCCESS, "foo"); }
 
     TEST_SUCCESS(assert_null)    { ASSERT_NULL(NULL); }
-    void *nullp1 = NULL;
-    const struct forward_decl *nullp2 = NULL;
-    TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp1); }
-    TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp2); }
-    TEST_SUCCESS(assert_null_sideeffects) { ASSERT_NULL((side_effect(), nullp2)); }
+    {
+        void *nullp1 = NULL;
+        const struct forward_decl *nullp2 = NULL;
+        TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp1); }
+        TEST_SUCCESS(assert_null)    { ASSERT_NULL(nullp2); }
+        TEST_SUCCESS(assert_null_sideeffects) { ASSERT_NULL((side_effect(), nullp2)); }
+    }
     TEST_SUCCESS(assert_null)    { ASSERT_NULL(0, "foo"); }
     TEST_FAILURE(assert_null)    { ASSERT_NULL("hello world", "foo"); }
 
     TEST_SUCCESS(inteq)          { ASSERT_INT_EQUALS(4321, 4321); }
     TEST_SUCCESS(inteq)          { ASSERT_INT_EQUALS(4321, 4321, "foo"); }
-    int increment = 4321;
     TEST_SUCCESS(inteq_side_effects) {
+        int increment = 4321;
         ASSERT_INT_EQUALS(4321, increment++, "foo");
         ASSERT_INT_EQUALS(4322, increment++, "foo");
     }
@@ -123,12 +125,12 @@ int test_asserts(int *index) {
     TEST_FAILURE(hex) { ASSERT_HEX_EQUALS((uint64_t)-1, 0); }
 
 
-    char str_x[2] = "x";
-
     TEST_SUCCESS(streq) {
         ASSERT_STR_EQUALS((side_effect(), "x"), "x");
     }
     TEST_SUCCESS(streq) {
+        char str_x[2] = "x";
+
         ASSERT_STR_EQUALS("x", (side_effect(), str_x), "foo");
     }
     TEST_FAILURE(streq) {
@@ -140,7 +142,6 @@ int test_asserts(int *index) {
 
     uint8_t bin1[] = { 0, 1, 2 };
     uint8_t bin2[] = { 0, 1, 2 };
-    uint8_t bin3[] = { 0, 1, 3 };
 
     TEST_SUCCESS(bineq) {
         ASSERT_BIN_ARRAYS_EQUALS((side_effect(), bin1), 3, bin2, 3);
@@ -152,6 +153,7 @@ int test_asserts(int *index) {
         ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, bin2, (side_effect(), 3));
     }
     TEST_FAILURE(bineq_samesize) {
+        uint8_t bin3[] = { 0, 1, 3 };
         ASSERT_BIN_ARRAYS_EQUALS(bin1, 3, bin3, 3, "foo");
     }
     TEST_FAILURE(bineq_diffsize) {
@@ -232,10 +234,9 @@ int main(int argc, char **argv) {
     }
 
     index = 0;
-    int rv = 0;
     for (;;) {
         reset();
-        rv = test_asserts(&index);
+        int rv = test_asserts(&index);
         if (rv == NO_MORE_TESTS) {
             break;
         }

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -471,7 +471,7 @@ static int uint64_buffer_non_aligned_test_fn(struct aws_allocator *alloc, void *
     aws_write_u64(buffer + 1, test_value);
 
     uint8_t expected[] = { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 };
-    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 1), sizeof(buffer) - 1, "Uint64_t to buffer failed");
+    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 1), sizeof(expected), "Uint64_t to buffer failed");
 
     uint64_t unmarshalled_value = aws_read_u64(buffer + 1);
     ASSERT_INT_EQUALS(test_value, unmarshalled_value, "After unmarshalling the encoded data, it didn't match");
@@ -510,7 +510,7 @@ static int uint32_buffer_non_aligned_test_fn(struct aws_allocator *alloc, void *
     aws_write_u32(buffer + 5, test_value);
 
     uint8_t expected[] = { 0x10, 0x20, 0x30, 0x40 };
-    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 5), sizeof(buffer) - 5, "Uint32_t to buffer failed");
+    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 5), sizeof(expected), "Uint32_t to buffer failed");
 
     uint64_t unmarshalled_value = aws_read_u32(buffer + 5);
     ASSERT_INT_EQUALS(test_value, unmarshalled_value, "After unmarshalling the encoded data, it didn't match");
@@ -548,7 +548,7 @@ static int uint24_buffer_non_aligned_test_fn(struct aws_allocator *alloc, void *
     aws_write_u24(buffer + 6, test_value);
 
     uint8_t expected[] = { 0x10, 0x20, 0x30 };
-    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 6), sizeof(buffer) - 6, "24 bit int to buffer failed");
+    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 6), sizeof(expected), "24 bit int to buffer failed");
 
     uint32_t unmarshalled_value = aws_read_u24(buffer + 6);
     ASSERT_INT_EQUALS(test_value, unmarshalled_value, "After unmarshalling the encoded data, it didn't match");
@@ -585,7 +585,7 @@ static int uint16_buffer_non_aligned_test_fn(struct aws_allocator *alloc, void *
     aws_write_u16(buffer + 7, test_value);
 
     uint8_t expected[] = { 0x10, 0x20 };
-    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 7), sizeof(buffer) - 7, "16 bit int to buffer failed");
+    ASSERT_BIN_ARRAYS_EQUALS(expected, sizeof(expected), (buffer + 7), sizeof(expected), "16 bit int to buffer failed");
 
     uint16_t unmarshalled_value = aws_read_u16(buffer + 7);
     ASSERT_INT_EQUALS(test_value, unmarshalled_value, "After unmarshalling the encoded data, it didn't match");

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -77,7 +77,7 @@ static int test_u32_saturating_fn(struct aws_allocator *alloc, void *ctx) {
 #define CHECK_OVF_0(fn, type, a, b) \
     do { \
         type result_val; \
-        ASSERT_FALSE(fn((a), (b), &result_val), "Expected overflow"); \
+        ASSERT_FALSE(fn((a), (b), &result_val)); \
     } while (0)
 
 #define CHECK_OVF(fn, type, a, b) \
@@ -90,7 +90,7 @@ static int test_u32_saturating_fn(struct aws_allocator *alloc, void *ctx) {
 #define CHECK_NO_OVF_0(fn, type, a, b, r) \
     do { \
         type result_val; \
-        ASSERT_TRUE(fn((a), (b), &result_val), "Expected no overflow"); \
+        ASSERT_TRUE(fn((a), (b), &result_val)); \
         ASSERT_INT_EQUALS((uint64_t)result_val, (uint64_t)(r), "Expected %s(%016llx, %016llx) = %016llx; got %016llx", \
             #fn, \
             (unsigned long long)(a), \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This demonstrates a technique for making the message/format arguments to
ASSERT_* optional. When a message format is not specified, a default is built
using the expression passed in instead.

I've only converted ASSERT_TRUE and ASSERT_FALSE for now, to see what people
think of this approach before spending too much time on it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
