### PR TITLE
host to network and network to host byte order functions for 16/32/64…

### DIFF
--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -18,85 +18,62 @@
 
 #include <stdint.h>
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <netinet/in.h>
+#endif /*_WIN32 */
+
+
 /**
  * Returns 1 if machine is big endian, 0 if little endian.
  * If you compile with even -O1 optimization, this check is completely optimized out at compile
- * time and code which calls "if (is_big_endian())" will do the right thing without branching.
+ * time and code which calls "if (aws_is_big_endian())" will do the right thing without branching.
  */
-static inline int is_big_endian() {
+static inline int aws_is_big_endian() {
     const uint16_t z = 0x100;
     return *(const uint8_t*)&z;
 }
 
 /**
- * Swaps bytes of 64 bit integer.
- */
-static inline uint64_t byteswap64(uint64_t x) { return
-        (x << 56) | (x >> 56) |
-        ((x & 0x0000ff00ULL) << 40) | ((x >> 40) & 0x0000ff00ULL) |
-        ((x & 0x00ff0000ULL) << 24) | ((x >> 24) & 0x00ff0000ULL) |
-        ((x & 0xff000000ULL) <<  8) | ((x >>  8) & 0xff000000ULL);
-}
-
-/**
- * Swaps bytes of 32 bit integer.
- */
-static inline uint32_t byteswap32(uint32_t x) { return
-        (x << 24) | (x >> 24) |
-        ((x & 0xff00) << 8 ) | ((x >> 8) & 0xff00);
-}
-
-/**
- * Swaps bytes of 16 bit integer.
- */
-static inline uint16_t byteswap16(uint16_t x) { return (x << 8) | (x >> 8); }
-
-/**
  * Convert 64 bit integer from host to network byte order.
  */
-static inline uint64_t hton64(uint64_t x) {
-    if (is_big_endian()) return x;
-    return byteswap64(x);
+static inline uint64_t aws_hton64(uint64_t x) {
+    if (aws_is_big_endian()) return x;
+#if defined(__x86_64__) && (defined(__GNUC__) || defined(__clang__))
+    uint64_t v;
+    __asm__("bswap %q0" : "=r" (v) : "0" (x));
+    return v;
+#else
+    uint32_t low = x;
+    uint32_t high = x >> 32;
+    return ((uint64_t)htonl(low)) << 32 | htonl(high);
+#endif
 }
 
 /**
  * Convert 64 bit integer from network to host byte order.
  */
-static inline uint64_t ntoh64(uint64_t x) {
-    if (is_big_endian()) return x;
-    return byteswap64(x);
-}
+static inline uint64_t aws_ntoh64(uint64_t x) { return aws_hton64(x); }
 
 /**
  * Convert 32 bit integer from host to network byte order.
  */
-static inline uint32_t hton32(uint32_t x) {
-    if (is_big_endian()) return x;
-    return byteswap32(x);
-}
+static inline uint32_t aws_hton32(uint32_t x) { return htonl(x); }
 
 /**
  * Convert 32 bit integer from network to host byte order.
  */
-static inline uint32_t ntoh32(uint32_t x) {
-    if (is_big_endian()) return x;
-    return byteswap32(x);
-}
+static inline uint32_t aws_ntoh32(uint32_t x) { return ntohl(x); }
 
 /**
  * Convert 16 bit integer from host to network byte order.
  */
-static inline uint16_t hton16(uint16_t x) {
-    if (is_big_endian()) return x;
-    return byteswap16(x);
-}
+static inline uint16_t aws_hton16(uint16_t x) { return htons(x); }
 
 /**
  * Convert 16 bit integer from network to host byte order.
  */
-static inline uint16_t ntoh16(uint16_t x) {
-    if (is_big_endian()) return x;
-    return byteswap16(x);
-}
+static inline uint16_t aws_ntoh16(uint16_t x) { return ntohs(x); }
 
 #endif /* AWS_COMMON_BYTE_ORDER_H */

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -1,0 +1,102 @@
+#ifndef AWS_COMMON_BYTE_ORDER_H
+#define AWS_COMMON_BYTE_ORDER_H
+
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stdint.h>
+
+/**
+ * Returns 1 if machine is big endian, 0 if little endian.
+ * If you compile with even -O1 optimization, this check is completely optimized out at compile
+ * time and code which calls "if (is_big_endian())" will do the right thing without branching.
+ */
+static inline int is_big_endian() {
+    const uint16_t z = 0x100;
+    return *(const uint8_t*)&z;
+}
+
+/**
+ * Swaps bytes of 64 bit integer.
+ */
+static inline uint64_t byteswap64(uint64_t x) { return
+        (x << 56) | (x >> 56) |
+        ((x & 0x0000ff00ULL) << 40) | ((x >> 40) & 0x0000ff00ULL) |
+        ((x & 0x00ff0000ULL) << 24) | ((x >> 24) & 0x00ff0000ULL) |
+        ((x & 0xff000000ULL) <<  8) | ((x >>  8) & 0xff000000ULL);
+}
+
+/**
+ * Swaps bytes of 32 bit integer.
+ */
+static inline uint32_t byteswap32(uint32_t x) { return
+        (x << 24) | (x >> 24) |
+        ((x & 0xff00) << 8 ) | ((x >> 8) & 0xff00);
+}
+
+/**
+ * Swaps bytes of 16 bit integer.
+ */
+static inline uint16_t byteswap16(uint16_t x) { return (x << 8) | (x >> 8); }
+
+/**
+ * Convert 64 bit integer from host to network byte order.
+ */
+static inline uint64_t hton64(uint64_t x) {
+    if (is_big_endian()) return x;
+    return byteswap64(x);
+}
+
+/**
+ * Convert 64 bit integer from network to host byte order.
+ */
+static inline uint64_t ntoh64(uint64_t x) {
+    if (is_big_endian()) return x;
+    return byteswap64(x);
+}
+
+/**
+ * Convert 32 bit integer from host to network byte order.
+ */
+static inline uint32_t hton32(uint32_t x) {
+    if (is_big_endian()) return x;
+    return byteswap32(x);
+}
+
+/**
+ * Convert 32 bit integer from network to host byte order.
+ */
+static inline uint32_t ntoh32(uint32_t x) {
+    if (is_big_endian()) return x;
+    return byteswap32(x);
+}
+
+/**
+ * Convert 16 bit integer from host to network byte order.
+ */
+static inline uint16_t hton16(uint16_t x) {
+    if (is_big_endian()) return x;
+    return byteswap16(x);
+}
+
+/**
+ * Convert 16 bit integer from network to host byte order.
+ */
+static inline uint16_t ntoh16(uint16_t x) {
+    if (is_big_endian()) return x;
+    return byteswap16(x);
+}
+
+#endif /* AWS_COMMON_BYTE_ORDER_H */

--- a/include/aws/common/encoding.h
+++ b/include/aws/common/encoding.h
@@ -79,7 +79,7 @@ AWS_COMMON_API int aws_base64_decode(const struct aws_byte_buf *AWS_RESTRICT to_
  * Assumes the buffer size is at least 8 bytes.
  */
 static inline void aws_write_u64(uint8_t *buffer, uint64_t value) {
-    value = hton64(value);
+    value = aws_hton64(value);
 
     memcpy((void *)buffer, &value, sizeof(value));
 }
@@ -92,14 +92,14 @@ static inline uint64_t aws_read_u64(const uint8_t *buffer) {
     uint64_t value = 0;
     memcpy((void *)&value, (void *)buffer, sizeof(value));
 
-    return ntoh64(value);
+    return aws_ntoh64(value);
 }
 
 /* Add a 32 bit unsigned integer to the buffer, ensuring network - byte order
  * Assumes the buffer size is at least 4 bytes.
  */
 static inline void aws_write_u32(uint8_t *buffer, uint32_t value) {
-    value = hton32(value);
+    value = aws_hton32(value);
 
     memcpy((void *)buffer, (void *)&value, sizeof(value));
 }
@@ -112,7 +112,7 @@ static inline uint32_t aws_read_u32(const uint8_t *buffer) {
     uint32_t value = 0;
     memcpy((void *)&value, (void *)buffer, sizeof(value));
 
-    return ntoh32(value);
+    return aws_ntoh32(value);
 }
 
 /* Add a 24 bit unsigned integer to the buffer, ensuring network - byte order
@@ -121,7 +121,7 @@ static inline uint32_t aws_read_u32(const uint8_t *buffer) {
  * Assumes buffer is at least 3 bytes long.
  */
 static inline void aws_write_u24(uint8_t *buffer, uint32_t value) {
-    value = hton32(value);
+    value = aws_hton32(value);
     memcpy((void *)buffer, (void *)((uint8_t *)&value + 1), sizeof(value) - 1);
 }
 
@@ -133,7 +133,7 @@ static inline uint32_t aws_read_u24(const uint8_t *buffer) {
     uint32_t value = 0;
     memcpy((void *)((uint8_t *)&value + 1), (void *)buffer, sizeof(value) - 1);
 
-    return ntoh32(value);
+    return aws_ntoh32(value);
 }
 
 /* Add a 16 bit unsigned integer to the buffer, ensuring network-byte order
@@ -141,7 +141,7 @@ static inline uint32_t aws_read_u24(const uint8_t *buffer) {
  * Assumes buffer is at least 2 bytes long.
  */
 static inline void aws_write_u16(uint8_t *buffer, uint16_t value) {
-    value = hton16(value);
+    value = aws_hton16(value);
 
     memcpy((void *)buffer, (void *)&value, sizeof(value));
 }
@@ -154,7 +154,7 @@ static inline uint16_t aws_read_u16(const uint8_t *buffer) {
     uint16_t value = 0;
     memcpy((void *)&value, (void *)buffer, sizeof(value));
 
-    return ntoh16(value);
+    return aws_ntoh16(value);
 }
 
 #endif /*AWS_COMMON_ENCODING_H*/

--- a/include/aws/common/encoding.h
+++ b/include/aws/common/encoding.h
@@ -18,14 +18,9 @@
 
 #include <aws/common/common.h>
 #include <aws/common/byte_buf.h>
+#include <aws/common/byte_order.h>
 #include <stdint.h>
 #include <memory.h>
-
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-#include <netinet/in.h>
-#endif /*_WIN32 */
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,11 +79,9 @@ AWS_COMMON_API int aws_base64_decode(const struct aws_byte_buf *AWS_RESTRICT to_
  * Assumes the buffer size is at least 8 bytes.
  */
 static inline void aws_write_u64(uint8_t *buffer, uint64_t value) {
+    value = hton64(value);
 
-    uint32_t low = htonl((uint32_t)value);
-    uint32_t high = htonl((uint32_t)(value >> 32));
-    memcpy((void *)buffer, (void *)&high, sizeof(high));
-    memcpy((void *)(buffer + sizeof(high)), (void *)&low, sizeof(low));
+    memcpy((void *)buffer, &value, sizeof(value));
 }
 
 /*
@@ -97,25 +90,18 @@ static inline void aws_write_u64(uint8_t *buffer, uint64_t value) {
  */
 static inline uint64_t aws_read_u64(const uint8_t *buffer) {
     uint64_t value = 0;
+    memcpy((void *)&value, (void *)buffer, sizeof(value));
 
-    uint32_t low = 0;
-    uint32_t high = 0;
-    memcpy((void *)&high, (void *)buffer, sizeof(high));
-    memcpy((void *)&low, (void *)(buffer + sizeof(high)), sizeof(low));
-
-    value = (uint64_t)ntohl(high) << 32;
-    value |= (uint64_t)ntohl(low);
-
-    return value;
+    return ntoh64(value);
 }
 
 /* Add a 32 bit unsigned integer to the buffer, ensuring network - byte order
  * Assumes the buffer size is at least 4 bytes.
  */
 static inline void aws_write_u32(uint8_t *buffer, uint32_t value) {
-    uint32_t be_value = htonl(value);
+    value = hton32(value);
 
-    memcpy((void *)buffer, (void *)&be_value, sizeof(be_value));
+    memcpy((void *)buffer, (void *)&value, sizeof(value));
 }
 
 /*
@@ -126,7 +112,7 @@ static inline uint32_t aws_read_u32(const uint8_t *buffer) {
     uint32_t value = 0;
     memcpy((void *)&value, (void *)buffer, sizeof(value));
 
-    return ntohl(value);
+    return ntoh32(value);
 }
 
 /* Add a 24 bit unsigned integer to the buffer, ensuring network - byte order
@@ -135,8 +121,8 @@ static inline uint32_t aws_read_u32(const uint8_t *buffer) {
  * Assumes buffer is at least 3 bytes long.
  */
 static inline void aws_write_u24(uint8_t *buffer, uint32_t value) {
-    uint32_t be_value = htonl(value);
-    memcpy((void *)buffer, (void *)((uint8_t *)&be_value + 1), sizeof(be_value) - 1);
+    value = hton32(value);
+    memcpy((void *)buffer, (void *)((uint8_t *)&value + 1), sizeof(value) - 1);
 }
 
 /*
@@ -147,7 +133,7 @@ static inline uint32_t aws_read_u24(const uint8_t *buffer) {
     uint32_t value = 0;
     memcpy((void *)((uint8_t *)&value + 1), (void *)buffer, sizeof(value) - 1);
 
-    return ntohl(value);
+    return ntoh32(value);
 }
 
 /* Add a 16 bit unsigned integer to the buffer, ensuring network-byte order
@@ -155,9 +141,9 @@ static inline uint32_t aws_read_u24(const uint8_t *buffer) {
  * Assumes buffer is at least 2 bytes long.
  */
 static inline void aws_write_u16(uint8_t *buffer, uint16_t value) {
-    uint16_t be_value = htons(value);
+    value = hton16(value);
 
-    memcpy((void *)buffer, (void *)&be_value, sizeof(be_value));
+    memcpy((void *)buffer, (void *)&value, sizeof(value));
 }
 
 /*
@@ -168,7 +154,7 @@ static inline uint16_t aws_read_u16(const uint8_t *buffer) {
     uint16_t value = 0;
     memcpy((void *)&value, (void *)buffer, sizeof(value));
 
-    return ntohs(value);
+    return ntoh16(value);
 }
 
 #endif /*AWS_COMMON_ENCODING_H*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,3 +124,5 @@ add_test(test_u64_saturating ${TEST_BINARY_NAME} test_u64_saturating)
 add_test(test_u32_saturating ${TEST_BINARY_NAME} test_u32_saturating)
 add_test(test_u64_checked ${TEST_BINARY_NAME} test_u64_checked)
 add_test(test_u32_checked ${TEST_BINARY_NAME} test_u32_checked)
+
+add_test(byte_swap_test ${TEST_BINARY_NAME} byte_swap_test)

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -17,37 +17,30 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int byte_swap_test_fn(struct aws_allocator *alloc, void *ctx) {
-    uint64_t x = 0x1122334455667788ULL;
-    uint64_t rev_x = 0x8877665544332211ULL;
+    uint64_t ans_x = 0x1122334455667788ULL;
+    uint32_t ans_y = 0xaabbccdd;
+    uint16_t ans_z = 0xeeff;
 
-    uint32_t y = 0xaabbccdd;
-    uint32_t rev_y = 0xddccbbaa;
+    uint8_t x[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    uint8_t y[] = {0xaa, 0xbb, 0xcc, 0xdd};
+    uint8_t z[] = {0xee, 0xff};
 
-    uint16_t z = 0xeeff;
-    uint16_t rev_z = 0xffee;
+    uint64_t x64;
+    uint32_t y32;
+    uint16_t z16;
 
-    // Since I know of no more reliable way to detect endianness
-    // than is_big_endian(), attempts to test it are not helpful.
-    // Instead, we assume it works to test the rest of the functionality.
-    if (is_big_endian()) {
-        ASSERT_UINT_EQUALS(ntoh64(x), x);
-        ASSERT_UINT_EQUALS(hton64(x), x);
+    memcpy(&x64, x, sizeof(x64));
+    memcpy(&y32, y, sizeof(y32));
+    memcpy(&z16, z, sizeof(z16));
 
-        ASSERT_UINT_EQUALS(ntoh32(y), y);
-        ASSERT_UINT_EQUALS(hton32(y), y);
+    ASSERT_UINT_EQUALS(aws_ntoh64(x64), ans_x);
+    ASSERT_UINT_EQUALS(aws_hton64(x64), ans_x);
 
-        ASSERT_UINT_EQUALS(ntoh16(z), z);
-        ASSERT_UINT_EQUALS(hton16(z), z);
-    } else {
-        ASSERT_UINT_EQUALS(ntoh64(x), rev_x);
-        ASSERT_UINT_EQUALS(hton64(x), rev_x);
+    ASSERT_UINT_EQUALS(aws_ntoh32(y32), ans_y);
+    ASSERT_UINT_EQUALS(aws_hton32(y32), ans_y);
 
-        ASSERT_UINT_EQUALS(ntoh32(y), rev_y);
-        ASSERT_UINT_EQUALS(hton32(y), rev_y);
-
-        ASSERT_UINT_EQUALS(ntoh16(z), rev_z);
-        ASSERT_UINT_EQUALS(hton16(z), rev_z);
-    }
+    ASSERT_UINT_EQUALS(aws_ntoh16(z16), ans_z);
+    ASSERT_UINT_EQUALS(aws_hton16(z16), ans_z);
 
     return 0;
 }

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_order.h>
+#include <aws/testing/aws_test_harness.h>
+
+static int byte_swap_test_fn(struct aws_allocator *alloc, void *ctx) {
+    uint64_t x = 0x1122334455667788ULL;
+    uint64_t rev_x = 0x8877665544332211ULL;
+
+    uint32_t y = 0xaabbccdd;
+    uint32_t rev_y = 0xddccbbaa;
+
+    uint16_t z = 0xeeff;
+    uint16_t rev_z = 0xffee;
+
+    // Since I know of no more reliable way to detect endianness
+    // than is_big_endian(), attempts to test it are not helpful.
+    // Instead, we assume it works to test the rest of the functionality.
+    if (is_big_endian()) {
+        ASSERT_UINT_EQUALS(ntoh64(x), x);
+        ASSERT_UINT_EQUALS(hton64(x), x);
+
+        ASSERT_UINT_EQUALS(ntoh32(y), y);
+        ASSERT_UINT_EQUALS(hton32(y), y);
+
+        ASSERT_UINT_EQUALS(ntoh16(z), z);
+        ASSERT_UINT_EQUALS(ntoh16(z), z);
+    } else {
+        ASSERT_UINT_EQUALS(ntoh64(x), rev_x);
+        ASSERT_UINT_EQUALS(hton64(x), rev_x);
+
+        ASSERT_UINT_EQUALS(ntoh32(y), rev_y);
+        ASSERT_UINT_EQUALS(hton32(y), rev_y);
+
+        ASSERT_UINT_EQUALS(ntoh16(z), rev_z);
+        ASSERT_UINT_EQUALS(ntoh16(z), rev_z);
+    }
+
+    return 0;
+}
+AWS_TEST_CASE(byte_swap_test, byte_swap_test_fn);

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -37,7 +37,7 @@ static int byte_swap_test_fn(struct aws_allocator *alloc, void *ctx) {
         ASSERT_UINT_EQUALS(hton32(y), y);
 
         ASSERT_UINT_EQUALS(ntoh16(z), z);
-        ASSERT_UINT_EQUALS(ntoh16(z), z);
+        ASSERT_UINT_EQUALS(hton16(z), z);
     } else {
         ASSERT_UINT_EQUALS(ntoh64(x), rev_x);
         ASSERT_UINT_EQUALS(hton64(x), rev_x);
@@ -46,7 +46,7 @@ static int byte_swap_test_fn(struct aws_allocator *alloc, void *ctx) {
         ASSERT_UINT_EQUALS(hton32(y), rev_y);
 
         ASSERT_UINT_EQUALS(ntoh16(z), rev_z);
-        ASSERT_UINT_EQUALS(ntoh16(z), rev_z);
+        ASSERT_UINT_EQUALS(hton16(z), rev_z);
     }
 
     return 0;

--- a/tests/main.c
+++ b/tests/main.c
@@ -30,6 +30,7 @@
 #include <task_scheduler_test.c>
 #include <hash_table_test.c>
 #include <math_test.c>
+#include <byte_order_test.c>
 
 int main(int argc, char *argv[]) {
 
@@ -117,6 +118,7 @@ int main(int argc, char *argv[]) {
                        &test_u32_checked,
                        &nospec_index_test,
                        &test_byte_cursor_advance,
-                       &test_byte_cursor_advance_nospec
+                       &test_byte_cursor_advance_nospec,
+                       &byte_swap_test
                        );
 }


### PR DESCRIPTION
… bit ints

*Issue #, if available:*

*Description of changes:*
Our own implementation of common byte order swapping functions. This has the advantage of not relying on any preprocessor symbols such as ```__LITTLE_ENDIAN__``` to detect endianness, which are inconsistent across compilers and systems. If compiled at -O1 or higher, it does not introduce any branching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
