### PR TITLE
change type names that start with 'aws_common_' prefix to 'aws_'

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -95,7 +95,7 @@ AWS_COMMON_API void aws_load_error_strings(void);
 #define AWS_OP_SUCCESS 0
 #define AWS_OP_ERR -1
 
-typedef enum aws_error {
+typedef enum aws_common_error {
     AWS_ERROR_SUCCESS = 0,
     AWS_ERROR_OOM,
     AWS_ERROR_UNKNOWN,
@@ -130,7 +130,7 @@ typedef enum aws_error {
     AWS_ERROR_HASHTBL_ITEM_NOT_FOUND,
 
     AWS_ERROR_END_COMMON_RANGE = 0x03FF
-} aws_error;
+} aws_common_error;
 
 #define AWS_LIB_NAME "libaws-c-common"
 

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -95,7 +95,7 @@ AWS_COMMON_API void aws_load_error_strings(void);
 #define AWS_OP_SUCCESS 0
 #define AWS_OP_ERR -1
 
-typedef enum aws_common_error {
+typedef enum aws_error {
     AWS_ERROR_SUCCESS = 0,
     AWS_ERROR_OOM,
     AWS_ERROR_UNKNOWN,
@@ -130,7 +130,7 @@ typedef enum aws_common_error {
     AWS_ERROR_HASHTBL_ITEM_NOT_FOUND,
 
     AWS_ERROR_END_COMMON_RANGE = 0x03FF
-} aws_common_error;
+} aws_error;
 
 #define AWS_LIB_NAME "libaws-c-common"
 

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -55,7 +55,7 @@
  * memory barrier must be used when transitioning from single-threaded mutating
  * usage to multithreaded usage.
  */
-struct aws_common_hash_table {
+struct aws_hash_table {
     void *pImpl;
 };
 
@@ -70,7 +70,7 @@ struct aws_common_hash_table {
  * delete, clear, and clean_up), regardless of whether the number of elements
  * actually changes.
  */
-struct aws_common_hash_element {
+struct aws_hash_element {
     const void *key;
     void *value;
 };
@@ -94,7 +94,7 @@ typedef int (*aws_equals_fn_t)(const void *a, const void *b);
  * calling code, calling code must destroy it.
  */
 typedef void (*aws_hash_element_destroy_t)(
-    struct aws_common_hash_element element
+    struct aws_hash_element element
 );
 
 #ifdef __cplusplus
@@ -109,8 +109,8 @@ extern "C" {
      * callback is not desired in this case.
      */
 
-    AWS_COMMON_API int aws_common_hash_table_init(
-        struct aws_common_hash_table *map,
+    AWS_COMMON_API int aws_hash_table_init(
+        struct aws_hash_table *map,
         struct aws_allocator *alloc, size_t size,
         aws_hash_fn_t hash_fn,
         aws_equals_fn_t equals_fn,
@@ -118,11 +118,11 @@ extern "C" {
 
     /**
      * Deletes every element from map and frees all associated memory.
-     * destroy_fn will be called for each element.  aws_common_hash_table_init
+     * destroy_fn will be called for each element.  aws_hash_table_init
      * must be called before reusing the hash table.
      */
-    AWS_COMMON_API void aws_common_hash_table_clean_up(
-        struct aws_common_hash_table *map);
+    AWS_COMMON_API void aws_hash_table_clean_up(
+        struct aws_hash_table *map);
 
     /**
      * Attempts to locate an element at key.  If the element is found, a
@@ -139,9 +139,9 @@ extern "C" {
      * _clean_up.
      */
 
-    AWS_COMMON_API int aws_common_hash_table_find(
-        struct aws_common_hash_table *map,
-        const void *key, struct aws_common_hash_element **pElem);
+    AWS_COMMON_API int aws_hash_table_find(
+        const struct aws_hash_table *map,
+        const void *key, struct aws_hash_element **pElem);
 
     /**
      * Attempts to locate an element at key. If no such element was found,
@@ -155,9 +155,9 @@ extern "C" {
      * Raises AWS_ERROR_OOM if hash table expansion was required and memory
      * allocation failed.
      */
-    AWS_COMMON_API int aws_common_hash_table_create(
-        struct aws_common_hash_table *map,
-        const void *key, struct aws_common_hash_element **pElem,
+    AWS_COMMON_API int aws_hash_table_create(
+        struct aws_hash_table *map,
+        const void *key, struct aws_hash_element **pElem,
         int *was_created
     );
 
@@ -172,9 +172,9 @@ extern "C" {
      * If was_present is non-NULL, it is set to 0 if the element was
      * not present, or 1 if it was present (and is now removed).
      */
-    AWS_COMMON_API int aws_common_hash_table_remove(
-        struct aws_common_hash_table *map,
-        const void *key, struct aws_common_hash_element *pValue,
+    AWS_COMMON_API int aws_hash_table_remove(
+        struct aws_hash_table *map,
+        const void *key, struct aws_hash_element *pValue,
         int *was_present
     );
 
@@ -206,39 +206,39 @@ extern "C" {
      * and is safe to invoke in parallel with other non-mutating operations.
      */
 
-    AWS_COMMON_API int aws_common_hash_table_foreach(
-        struct aws_common_hash_table *map,
-        int (*callback)(void *context, struct aws_common_hash_element *pElement),
+    AWS_COMMON_API int aws_hash_table_foreach(
+        struct aws_hash_table *map,
+        int (*callback)(void *context, struct aws_hash_element *pElement),
         void *context);
 
     /**
      * Removes every element from the hash map. destroy_fn will be called for
      * each element.
      */
-    AWS_COMMON_API void aws_common_hash_table_clear(
-        struct aws_common_hash_table *map);
+    AWS_COMMON_API void aws_hash_table_clear(
+        struct aws_hash_table *map);
 
     /**
      * Convenience hash function for NUL-terminated strings
      */
-    AWS_COMMON_API uint64_t aws_common_hash_string(const void *a);
+    AWS_COMMON_API uint64_t aws_hash_string(const void *a);
 
     /**
      * Convenience eq function for NUL-terminated strings
      */
-    AWS_COMMON_API int aws_common_string_eq(const void *a, const void *b);
+    AWS_COMMON_API int aws_string_eq(const void *a, const void *b);
 
     /**
      * Convenience hash function which hashes the pointer value directly,
      * without dereferencing.  This can be used in cases where pointer identity
      * is desired, or where a uintptr_t is encoded into a const void *.
      */
-    AWS_COMMON_API uint64_t aws_common_hash_ptr(const void *a);
+    AWS_COMMON_API uint64_t aws_hash_ptr(const void *a);
 
     /**
      * Equality function which compares pointer equality.
      */
-    AWS_COMMON_API int aws_common_ptr_eq(const void *a, const void *b);
+    AWS_COMMON_API int aws_ptr_eq(const void *a, const void *b);
 
 #ifdef _cplusplus
 }

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -28,7 +28,7 @@
  * Multiplies a * b. If the result overflows, returns 2^64 - 1.
  */
 #if (AWS_ENABLE_HW_OPTIMIZATION)
-static inline uint64_t aws_common_mul_u64_saturating(uint64_t a, uint64_t b) {
+static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 #if defined(__x86_64__) && (defined(__GNUC__) || defined(__clang__))
     /* We can use inline assembly to do this efficiently on x86-64 and x86.
 
@@ -59,7 +59,7 @@ static inline uint64_t aws_common_mul_u64_saturating(uint64_t a, uint64_t b) {
  * Multiplies a * b and returns the truncated result in *r. If the result
  * overflows, returns 0, else returns 1.
  */
-static inline int aws_common_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
 #if defined(__x86_64__) && (defined(__GNUC__) || defined(__clang__))
     /* We can use inline assembly to do this efficiently on x86-64 and x86. */
 
@@ -89,7 +89,7 @@ static inline int aws_common_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r
 /**
  * Multiplies a * b. If the result overflows, returns 2^32 - 1.
  */
-static inline uint32_t aws_common_mul_u32_saturating(uint32_t a, uint32_t b) {
+static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 #if (defined(__i386__) || defined(__x86_64__)) && (defined(__GNUC__) || defined(__clang__))
     /* We can use inline assembly to do this efficiently on x86-64 and x86.
 
@@ -121,7 +121,7 @@ static inline uint32_t aws_common_mul_u32_saturating(uint32_t a, uint32_t b) {
  * Multiplies a * b and returns the result in *r. If the result overflows,
  * returns 0, else returns 1.
  */
-static inline int aws_common_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
 #if (defined(__i386__) || defined(__x86_64__)) && (defined(__GNUC__) || defined(__clang__))
     /* We can use inline assembly to do this efficiently on x86-64 and x86. */
     uint32_t result = a;
@@ -156,7 +156,7 @@ static inline int aws_common_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r
 /**
  * Multiplies a * b. If the result overflows, returns 2^64 - 1.
  */
-static inline uint64_t aws_common_mul_u64_saturating(uint64_t a, uint64_t b) {
+static inline uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
     uint64_t x = a * b;
     if (a != 0 && (a > 0xFFFFFFFF || b > 0xFFFFFFFF) && x / a != b) {
         return ~(uint64_t)0;
@@ -169,7 +169,7 @@ static inline uint64_t aws_common_mul_u64_saturating(uint64_t a, uint64_t b) {
  * Multiplies a * b and returns the truncated result in *r. If the result
  * overflows, returns 0, else returns 1.
  */
-static inline int aws_common_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+static inline int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     uint64_t x = a * b;
     *r = x;
     if (a != 0 && (a > 0xFFFFFFFF || b > 0xFFFFFFFF) && x / a != b) {
@@ -182,7 +182,7 @@ static inline int aws_common_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r
 /**
  * Multiplies a * b. If the result overflows, returns 2^32 - 1.
  */
-static inline uint32_t aws_common_mul_u32_saturating(uint32_t a, uint32_t b) {
+static inline uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
     uint32_t x = a * b;
     if (a != 0 && (a > 0xFFFF || b > 0xFFFF) && x / a != b) {
         return ~(uint32_t)0;
@@ -195,7 +195,7 @@ static inline uint32_t aws_common_mul_u32_saturating(uint32_t a, uint32_t b) {
  * Multiplies a * b and returns the result in *r. If the result overflows,
  * returns 0, else returns 1.
  */
-static inline int aws_common_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+static inline int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     uint32_t x = a * b;
     *r = x;
     if (a != 0 && (a > 0xFFFF || b > 0xFFFF) && x / a != b) {
@@ -211,7 +211,7 @@ static inline int aws_common_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r
 #pragma warning(disable:4127) /*Disable "conditional expression is constant" */
 #endif /* _MSC_VER */
 
-static inline size_t aws_common_mul_size_saturating(size_t a, size_t b) {
+static inline size_t aws_mul_size_saturating(size_t a, size_t b) {
     /* static assert: SIZE_MAX == (~(uint32_t)0) || (~(uint64_t)0)*/
     char assert_sizet_is_32_or_64_bit[
         (((uint64_t)SIZE_MAX == (uint64_t)~(uint32_t)0) ||
@@ -224,17 +224,17 @@ static inline size_t aws_common_mul_size_saturating(size_t a, size_t b) {
 
 
     if ((uint64_t)SIZE_MAX == (uint64_t)~(uint32_t)0) {
-        return (size_t)aws_common_mul_u32_saturating((uint32_t)a, (uint32_t)b);
+        return (size_t)aws_mul_u32_saturating((uint32_t)a, (uint32_t)b);
     } else {
-        return (size_t)aws_common_mul_u64_saturating(a, b);
+        return (size_t)aws_mul_u64_saturating(a, b);
     }
 }
 
-static inline int aws_common_mul_size_checked(size_t a, size_t b, size_t *r) {
+static inline int aws_mul_size_checked(size_t a, size_t b, size_t *r) {
     if ((uint64_t)SIZE_MAX == (uint64_t)~(uint32_t)0) {
-        return (int)aws_common_mul_u32_checked((uint32_t)a, (uint32_t)b, (uint32_t*)r);
+        return (int)aws_mul_u32_checked((uint32_t)a, (uint32_t)b, (uint32_t*)r);
     } else {
-        return (int)aws_common_mul_u64_checked((uint32_t)a, (uint32_t)b, (uint64_t*)r);
+        return (int)aws_mul_u64_checked((uint32_t)a, (uint32_t)b, (uint64_t*)r);
     }
 }
 

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -25,16 +25,16 @@ static const char *test_val_str_2 = "value 2";
 
 AWS_TEST_CASE(test_hash_table_put_get, test_hash_table_put_get_fn)
 static int test_hash_table_put_get_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, 10, aws_common_hash_string,
-        aws_common_string_eq, NULL);
-    struct aws_common_hash_element *pElem;
+    struct aws_hash_table hash_table;
+    int err_code = aws_hash_table_init(&hash_table, alloc, 10, aws_hash_string,
+        aws_string_eq, NULL);
+    struct aws_hash_element *pElem;
     int was_created;
 
     ASSERT_SUCCESS(err_code,
         "Hash Map init should have succeeded.");
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, &pElem, &was_created);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, &pElem, &was_created);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     ASSERT_INT_EQUALS(1, was_created,
@@ -42,24 +42,24 @@ static int test_hash_table_put_get_fn(struct aws_allocator *alloc, void *ctx) {
     pElem->value = (void *)test_val_str_1;
 
     /* Try passing a NULL was_created this time */
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     pElem->value = (void *)test_val_str_2;
 
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
     ASSERT_SUCCESS(err_code,
         "Hash Map get should have succeeded.");
     ASSERT_STR_EQUALS(test_val_str_1, (const char *)pElem->value,
         "Returned value for %s, should have been %s", test_str_1, test_val_str_1);
 
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_2, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_2, &pElem);
     ASSERT_SUCCESS(err_code,
         "Hash Map get should have succeeded.");
     ASSERT_BIN_ARRAYS_EQUALS(test_val_str_2, strlen(test_val_str_2) + 1, (const char *)pElem->value, strlen(pElem->value) + 1,
         "Returned value for %s, should have been %s", test_str_2, test_val_str_2);
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
     RETURN_SUCCESS("%s() pass", "test_hash_table_put_get");
 }
 
@@ -69,58 +69,58 @@ static uint64_t hash_collide(const void *a) {
 
 AWS_TEST_CASE(test_hash_table_hash_collision, test_hash_table_hash_collision_fn)
 static int test_hash_table_hash_collision_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    struct aws_common_hash_element *pElem;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, 10, hash_collide,
-        aws_common_string_eq, NULL);
+    struct aws_hash_table hash_table;
+    struct aws_hash_element *pElem;
+    int err_code = aws_hash_table_init(&hash_table, alloc, 10, hash_collide,
+        aws_string_eq, NULL);
 
     ASSERT_SUCCESS(err_code,
         "Hash Map init should have succeeded.");
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, &pElem, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, &pElem, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     pElem->value = (void *)test_val_str_1;
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     pElem->value = (void *)test_val_str_2;
 
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
     ASSERT_SUCCESS(err_code,
         "Hash Map get should have succeeded.");
     ASSERT_STR_EQUALS(test_val_str_1, pElem->value,
         "Returned value for %s, should have been %s", test_str_1, test_val_str_1);
 
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_2, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_2, &pElem);
     ASSERT_SUCCESS(err_code,
         "Hash Map get should have succeeded.");
     ASSERT_STR_EQUALS(test_val_str_2, pElem->value,
         "Returned value for %s, should have been %s", test_str_2, test_val_str_2);
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
     RETURN_SUCCESS("%s() pass", "test_hash_table_hash_collision");
 }
 
 AWS_TEST_CASE(test_hash_table_hash_overwrite, test_hash_table_hash_overwrite_fn)
 static int test_hash_table_hash_overwrite_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    struct aws_common_hash_element *pElem;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, 10, aws_common_hash_string,
-        aws_common_string_eq, NULL);
+    struct aws_hash_table hash_table;
+    struct aws_hash_element *pElem;
+    int err_code = aws_hash_table_init(&hash_table, alloc, 10, aws_hash_string,
+        aws_string_eq, NULL);
     int was_created = 42;
 
     ASSERT_SUCCESS(err_code,
         "Hash Map init should have succeeded.");
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, &pElem, &was_created); //(void *)test_val_str_1);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, &pElem, &was_created); //(void *)test_val_str_1);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     ASSERT_INT_EQUALS(1, was_created, "Hash Map create should have created a new element.");
     pElem->value = (void *)test_val_str_1;
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, &pElem, &was_created);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, &pElem, &was_created);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     ASSERT_INT_EQUALS(0, was_created, "Hash Map create should not have created a new element.");
@@ -128,18 +128,18 @@ static int test_hash_table_hash_overwrite_fn(struct aws_allocator *alloc, void *
     pElem->value = (void *)test_val_str_2;
 
     pElem = NULL;
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
     ASSERT_SUCCESS(err_code,
         "Hash Map get should have succeeded.");
     ASSERT_PTR_EQUALS(test_val_str_2, pElem->value, "The new value should have been preserved on get");
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
     RETURN_SUCCESS("%s() pass", "test_hash_table_hash_overwrite");
 }
 
-static struct aws_common_hash_element last_removed;
+static struct aws_hash_element last_removed;
 static int removal_counter = 0;
-static void destroy_fn(struct aws_common_hash_element element) {
+static void destroy_fn(struct aws_hash_element element) {
     last_removed = element;
     removal_counter++;
 }
@@ -150,10 +150,10 @@ static void reset_destroy_ck() {
 
 AWS_TEST_CASE(test_hash_table_hash_remove, test_hash_table_hash_remove_fn)
 static int test_hash_table_hash_remove_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    struct aws_common_hash_element *pElem, elem;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, 10, aws_common_hash_string,
-        aws_common_string_eq, destroy_fn);
+    struct aws_hash_table hash_table;
+    struct aws_hash_element *pElem, elem;
+    int err_code = aws_hash_table_init(&hash_table, alloc, 10, aws_hash_string,
+        aws_string_eq, destroy_fn);
     int was_present = 42;
 
     reset_destroy_ck();
@@ -161,91 +161,91 @@ static int test_hash_table_hash_remove_fn(struct aws_allocator *alloc, void *ctx
     ASSERT_SUCCESS(err_code,
         "Hash Map init should have succeeded.");
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, NULL, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, NULL, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
     pElem->value = (void *)test_val_str_2;
 
     /* Create a second time; this should not invoke destroy */
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_2, &pElem, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
 
     ASSERT_INT_EQUALS(0, removal_counter, "No elements should be destroyed at this point");
 
-    err_code = aws_common_hash_table_remove(&hash_table, (void *)test_str_1, &elem, &was_present);
+    err_code = aws_hash_table_remove(&hash_table, (void *)test_str_1, &elem, &was_present);
     ASSERT_SUCCESS(err_code,
         "Hash Map remove should have succeeded.");
     ASSERT_INT_EQUALS(0, removal_counter, "No elements should be destroyed at this point");
     ASSERT_INT_EQUALS(1, was_present, "Item should have been removed");
 
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
     ASSERT_SUCCESS(err_code, "Find for nonexistent item should still succeed");
     ASSERT_NULL(pElem, "Expected item to be nonexistent");
 
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_2, &pElem);
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_2, &pElem);
     ASSERT_SUCCESS(err_code,
         "Hash Map get should have succeeded.");
 
     ASSERT_PTR_EQUALS(test_val_str_2, pElem->value, "Wrong value returned from second get");
 
     // If we delete and discard the element, destroy_fn should be invoked
-    err_code = aws_common_hash_table_remove(&hash_table, (void *)test_str_2, NULL, NULL);
+    err_code = aws_hash_table_remove(&hash_table, (void *)test_str_2, NULL, NULL);
     ASSERT_SUCCESS(err_code,
         "Remove should have succeeded.");
     ASSERT_INT_EQUALS(1, removal_counter, "One element should be destroyed at this point");
     ASSERT_PTR_EQUALS(last_removed.value, test_val_str_2, "Wrong element destroyed");
 
     // If we delete an element that's not there, we shouldn't invoke destroy_fn
-    err_code = aws_common_hash_table_remove(&hash_table, (void *)test_str_1, NULL, &was_present);
+    err_code = aws_hash_table_remove(&hash_table, (void *)test_str_1, NULL, &was_present);
     ASSERT_SUCCESS(err_code, "Remove still should succeed on nonexistent items");
     ASSERT_INT_EQUALS(0, was_present, "Remove should indicate item not present");
     ASSERT_INT_EQUALS(1, removal_counter, "We shouldn't delete an item if none was found");
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
     RETURN_SUCCESS("%s() pass", "test_hash_table_hash_remove");
 }
 
 AWS_TEST_CASE(test_hash_table_hash_clear_allows_cleanup, test_hash_table_hash_clear_allows_cleanup_fn)
 static int test_hash_table_hash_clear_allows_cleanup_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, 10, aws_common_hash_string,
-        aws_common_string_eq, destroy_fn);
+    struct aws_hash_table hash_table;
+    int err_code = aws_hash_table_init(&hash_table, alloc, 10, aws_hash_string,
+        aws_string_eq, destroy_fn);
 
     ASSERT_SUCCESS(err_code,
         "Hash Map init should have succeeded.");
 
     reset_destroy_ck();
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, NULL, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, NULL, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_2, NULL, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_2, NULL, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
 
-    aws_common_hash_table_clear(&hash_table);
+    aws_hash_table_clear(&hash_table);
     ASSERT_INT_EQUALS(2, removal_counter, "Clear should destroy all items");
 
-    struct aws_common_hash_element *pElem;
-    err_code = aws_common_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
+    struct aws_hash_element *pElem;
+    err_code = aws_hash_table_find(&hash_table, (void *)test_str_1, &pElem);
     ASSERT_SUCCESS(err_code, "Find should still succeed after clear");
     ASSERT_NULL(pElem, "Element should not be found");
 
     reset_destroy_ck();
 
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_1, NULL, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_1, NULL, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
-    err_code = aws_common_hash_table_create(&hash_table, (void *)test_str_2, NULL, NULL);
+    err_code = aws_hash_table_create(&hash_table, (void *)test_str_2, NULL, NULL);
     ASSERT_SUCCESS(err_code,
         "Hash Map put should have succeeded.");
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
     ASSERT_INT_EQUALS(2, removal_counter, "Cleanup should destroy all items");
 
     RETURN_SUCCESS("%s() pass", "test_hash_table_hash_clear_allows_cleanup");
@@ -253,17 +253,17 @@ static int test_hash_table_hash_clear_allows_cleanup_fn(struct aws_allocator *al
 
 AWS_TEST_CASE(test_hash_table_on_resize_returns_correct_entry, test_hash_table_on_resize_returns_correct_entry_fn)
 static int test_hash_table_on_resize_returns_correct_entry_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, 10, aws_common_hash_ptr,
-        aws_common_ptr_eq, NULL);
+    struct aws_hash_table hash_table;
+    int err_code = aws_hash_table_init(&hash_table, alloc, 10, aws_hash_ptr,
+        aws_ptr_eq, NULL);
 
     ASSERT_SUCCESS(err_code,
         "Hash Map init should have succeeded.");
 
     for (int i = 0; i < 20; i++) {
-        struct aws_common_hash_element *pElem;
+        struct aws_hash_element *pElem;
         int was_created;
-        err_code = aws_common_hash_table_create(&hash_table, (void *)(intptr_t)i, &pElem, &was_created);
+        err_code = aws_hash_table_create(&hash_table, (void *)(intptr_t)i, &pElem, &was_created);
 
         ASSERT_SUCCESS(err_code, "Create should have succeeded");
         ASSERT_INT_EQUALS(1, was_created, "Create should have created new element");
@@ -271,11 +271,11 @@ static int test_hash_table_on_resize_returns_correct_entry_fn(struct aws_allocat
         pElem->value = &hash_table;
     }
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
     RETURN_SUCCESS("%s() pass", "test_hash_table_on_resize_returns_correct_entry");
 }
 
-static int foreach_cb_tomask(void *context, struct aws_common_hash_element *pElement) {
+static int foreach_cb_tomask(void *context, struct aws_hash_element *pElement) {
     int *pMask = context;
     uintptr_t index = (uintptr_t)pElement->key;
 
@@ -285,7 +285,7 @@ static int foreach_cb_tomask(void *context, struct aws_common_hash_element *pEle
 }
 
 static int iter_count = 0;
-static int foreach_cb_deltarget(void *context, struct aws_common_hash_element *pElement) {
+static int foreach_cb_deltarget(void *context, struct aws_hash_element *pElement) {
     void **pTarget = context;
     int rv = AWS_COMMON_HASH_TABLE_ITER_CONTINUE;
 
@@ -297,7 +297,7 @@ static int foreach_cb_deltarget(void *context, struct aws_common_hash_element *p
     return rv;
 }
 
-static int foreach_cb_cutoff(void *context, struct aws_common_hash_element *pElement) {
+static int foreach_cb_cutoff(void *context, struct aws_hash_element *pElement) {
     int *pRemain = context;
     iter_count++;
     if (--*pRemain) {
@@ -306,7 +306,7 @@ static int foreach_cb_cutoff(void *context, struct aws_common_hash_element *pEle
         return 0;
     }
 }
-static int foreach_cb_cutoff_del(void *context, struct aws_common_hash_element *pElement) {
+static int foreach_cb_cutoff_del(void *context, struct aws_hash_element *pElement) {
     int *pRemain = context;
     iter_count++;
     if (--*pRemain) {
@@ -320,38 +320,38 @@ static int foreach_cb_cutoff_del(void *context, struct aws_common_hash_element *
 
 AWS_TEST_CASE(test_hash_table_foreach, test_hash_table_foreach_fn)
 static int test_hash_table_foreach_fn(struct aws_allocator *alloc, void *ctx) {
-    struct aws_common_hash_table hash_table;
-    ASSERT_SUCCESS(aws_common_hash_table_init(&hash_table, alloc, 10, aws_common_hash_ptr, aws_common_ptr_eq, NULL),
+    struct aws_hash_table hash_table;
+    ASSERT_SUCCESS(aws_hash_table_init(&hash_table, alloc, 10, aws_hash_ptr, aws_ptr_eq, NULL),
         "hash table init"
     );
 
     for (int i = 0; i < 8; i++) {
-        struct aws_common_hash_element *pElem;
-        ASSERT_SUCCESS(aws_common_hash_table_create(&hash_table, (void *)(intptr_t)i, &pElem, NULL), "insert element");
+        struct aws_hash_element *pElem;
+        ASSERT_SUCCESS(aws_hash_table_create(&hash_table, (void *)(intptr_t)i, &pElem, NULL), "insert element");
         pElem->value = NULL;
     }
 
     // We should find all four elements
     int mask = 0;
     ASSERT_SUCCESS(
-        aws_common_hash_table_foreach(&hash_table, foreach_cb_tomask, &mask), "foreach invocation");
+        aws_hash_table_foreach(&hash_table, foreach_cb_tomask, &mask), "foreach invocation");
     ASSERT_INT_EQUALS(0xff, mask, "bitmask");
 
     void *target = (void *)(uintptr_t)3;
     iter_count = 0;
     ASSERT_SUCCESS(
-        aws_common_hash_table_foreach(&hash_table, foreach_cb_deltarget, &target), "foreach invocation");
+        aws_hash_table_foreach(&hash_table, foreach_cb_deltarget, &target), "foreach invocation");
     ASSERT_INT_EQUALS(8, iter_count, "iteration should not stop when deleting");
 
     mask = 0;
     ASSERT_SUCCESS(
-        aws_common_hash_table_foreach(&hash_table, foreach_cb_tomask, &mask), "foreach invocation");
+        aws_hash_table_foreach(&hash_table, foreach_cb_tomask, &mask), "foreach invocation");
     ASSERT_INT_EQUALS(0xf7, mask, "element 3 deleted");
 
     iter_count = 0;
     int remain = 4;
     ASSERT_SUCCESS(
-        aws_common_hash_table_foreach(&hash_table, foreach_cb_cutoff, &remain), "foreach invocation");
+        aws_hash_table_foreach(&hash_table, foreach_cb_cutoff, &remain), "foreach invocation");
     ASSERT_INT_EQUALS(0, remain, "no more remaining iterations");
     ASSERT_INT_EQUALS(4, iter_count, "correct iteration count");
 
@@ -359,7 +359,7 @@ static int test_hash_table_foreach_fn(struct aws_allocator *alloc, void *ctx) {
     remain = 4;
 
     ASSERT_SUCCESS(
-        aws_common_hash_table_foreach(&hash_table, foreach_cb_cutoff_del, &remain), "foreach invocation");
+        aws_hash_table_foreach(&hash_table, foreach_cb_cutoff_del, &remain), "foreach invocation");
     ASSERT_INT_EQUALS(4, iter_count, "correct iteration count");
     // we use remain as a side channel to report which element we deleted
     int expected_mask = 0xf7 & ~(1 << remain);
@@ -367,10 +367,10 @@ static int test_hash_table_foreach_fn(struct aws_allocator *alloc, void *ctx) {
 
     mask = 0;
     ASSERT_SUCCESS(
-        aws_common_hash_table_foreach(&hash_table, foreach_cb_tomask, &mask), "foreach invocation");
+        aws_hash_table_foreach(&hash_table, foreach_cb_tomask, &mask), "foreach invocation");
     ASSERT_INT_EQUALS(expected_mask, mask, "stop element deleted");
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
 
     RETURN_SUCCESS("%s() pass", "test_hash_table_foreach");
 }
@@ -408,10 +408,10 @@ static long timestamp() {
 AWS_TEST_CASE(test_hash_churn, test_hash_churn_fn)
 static int test_hash_churn_fn(struct aws_allocator *alloc, void *ctx) {
     int i = 0;
-    struct aws_common_hash_table hash_table;
+    struct aws_hash_table hash_table;
     int nentries = 2 * 512 * 1024;
-    int err_code = aws_common_hash_table_init(&hash_table, alloc, nentries, aws_common_hash_ptr,
-        aws_common_ptr_eq, NULL);
+    int err_code = aws_hash_table_init(&hash_table, alloc, nentries, aws_hash_ptr,
+        aws_ptr_eq, NULL);
 
     if(AWS_ERROR_SUCCESS != err_code) {
         FAIL("hash table creation failed: %d", err_code);
@@ -466,16 +466,16 @@ static int test_hash_churn_fn(struct aws_allocator *alloc, void *ctx) {
         struct churn_entry *e = &entries[i];
         if (e->is_removed) {
             int was_present;
-            err_code = aws_common_hash_table_remove(&hash_table, e->key, NULL, &was_present);
+            err_code = aws_hash_table_remove(&hash_table, e->key, NULL, &was_present);
             if (i == 0 && entries[i - 1].key == e->key && entries[i - 1].is_removed) {
                 ASSERT_INT_EQUALS(0, was_present,"Expected item to be missing");
             } else {
                 ASSERT_INT_EQUALS(1, was_present, "Expected item to be present");
             }
         } else {
-            struct aws_common_hash_element *pElem;
+            struct aws_hash_element *pElem;
             int was_created;
-            err_code = aws_common_hash_table_create(&hash_table, e->key, &pElem, &was_created);
+            err_code = aws_hash_table_create(&hash_table, e->key, &pElem, &was_created);
             ASSERT_SUCCESS(err_code, "Unexpected failure adding element");
 
             pElem->value = e->value;
@@ -493,8 +493,8 @@ static int test_hash_churn_fn(struct aws_allocator *alloc, void *ctx) {
             continue;
         }
 
-        struct aws_common_hash_element *pElem;
-        aws_common_hash_table_find(&hash_table, e->key, &pElem);
+        struct aws_hash_element *pElem;
+        aws_hash_table_find(&hash_table, e->key, &pElem);
 
         if (e->is_removed) {
             ASSERT_NULL(pElem, "expected item to be deleted");
@@ -504,7 +504,7 @@ static int test_hash_churn_fn(struct aws_allocator *alloc, void *ctx) {
         }
     }
 
-    aws_common_hash_table_clean_up(&hash_table);
+    aws_hash_table_clean_up(&hash_table);
 
     long end = timestamp();
 

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -31,45 +31,45 @@
 
 AWS_TEST_CASE(test_u64_saturating, test_u64_saturating_fn)
 static int test_u64_saturating_fn(struct aws_allocator *alloc, void *ctx) {
-    CHECK_SAT(aws_common_mul_u64_saturating, 0, 0, 0);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0, 1, 0);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0, ~0LLU, 0);
-    CHECK_SAT(aws_common_mul_u64_saturating, 4, 5, 20);
-    CHECK_SAT(aws_common_mul_u64_saturating, 1234, 4321, 5332114);
+    CHECK_SAT(aws_mul_u64_saturating, 0, 0, 0);
+    CHECK_SAT(aws_mul_u64_saturating, 0, 1, 0);
+    CHECK_SAT(aws_mul_u64_saturating, 0, ~0LLU, 0);
+    CHECK_SAT(aws_mul_u64_saturating, 4, 5, 20);
+    CHECK_SAT(aws_mul_u64_saturating, 1234, 4321, 5332114);
 
-    CHECK_SAT(aws_common_mul_u64_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0xFFFFFFFF, 0xFFFFFFFF, 0xfffffffe00000001LLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0x100000000, 0xFFFFFFFF, 0xFFFFFFFF00000000LLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0x100000001, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0x100000001, 0xFFFFFFFE, 0xFFFFFFFEFFFFFFFELLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0x100000002, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFCLLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0x100000003, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFFLLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFC00000004LLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, 0x1FFFFFFFF, 0x1FFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
-    CHECK_SAT(aws_common_mul_u64_saturating, ~0LLU, ~0LLU, ~0LLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+    CHECK_SAT(aws_mul_u64_saturating, 0xFFFFFFFF, 0xFFFFFFFF, 0xfffffffe00000001LLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0x100000000, 0xFFFFFFFF, 0xFFFFFFFF00000000LLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0x100000001, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0x100000001, 0xFFFFFFFE, 0xFFFFFFFEFFFFFFFELLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0x100000002, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFCLLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0x100000003, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFC00000004LLU);
+    CHECK_SAT(aws_mul_u64_saturating, 0x1FFFFFFFF, 0x1FFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_SAT(aws_mul_u64_saturating, ~0LLU, ~0LLU, ~0LLU);
 
     return 0;
 }
 
 AWS_TEST_CASE(test_u32_saturating, test_u32_saturating_fn)
 static int test_u32_saturating_fn(struct aws_allocator *alloc, void *ctx) {
-    CHECK_SAT(aws_common_mul_u32_saturating, 0, 0, 0);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0, 1, 0);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0, ~0U, 0);
-    CHECK_SAT(aws_common_mul_u32_saturating, 4, 5, 20);
-    CHECK_SAT(aws_common_mul_u32_saturating, 1234, 4321, 5332114);
+    CHECK_SAT(aws_mul_u32_saturating, 0, 0, 0);
+    CHECK_SAT(aws_mul_u32_saturating, 0, 1, 0);
+    CHECK_SAT(aws_mul_u32_saturating, 0, ~0U, 0);
+    CHECK_SAT(aws_mul_u32_saturating, 4, 5, 20);
+    CHECK_SAT(aws_mul_u32_saturating, 1234, 4321, 5332114);
 
-    CHECK_SAT(aws_common_mul_u32_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0xFFFF, 1, 0xFFFF);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0xFFFF, 0xFFFF, 0xfffe0001);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0x10000, 0xFFFF, 0xFFFF0000U);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0x10001, 0xFFFF, 0xFFFFFFFFU);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0x10001, 0xFFFE, 0xFFFEFFFEU);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0x10002, 0xFFFE, 0xFFFFFFFCU);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0x10003, 0xFFFE, 0xFFFFFFFFU);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0xFFFE, 0xFFFE, 0xFFFC0004U);
-    CHECK_SAT(aws_common_mul_u32_saturating, 0x1FFFF, 0x1FFFF, 0xFFFFFFFFU);
-    CHECK_SAT(aws_common_mul_u32_saturating, ~0U, ~0U, ~0U);
+    CHECK_SAT(aws_mul_u32_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+    CHECK_SAT(aws_mul_u32_saturating, 0xFFFF, 1, 0xFFFF);
+    CHECK_SAT(aws_mul_u32_saturating, 0xFFFF, 0xFFFF, 0xfffe0001);
+    CHECK_SAT(aws_mul_u32_saturating, 0x10000, 0xFFFF, 0xFFFF0000U);
+    CHECK_SAT(aws_mul_u32_saturating, 0x10001, 0xFFFF, 0xFFFFFFFFU);
+    CHECK_SAT(aws_mul_u32_saturating, 0x10001, 0xFFFE, 0xFFFEFFFEU);
+    CHECK_SAT(aws_mul_u32_saturating, 0x10002, 0xFFFE, 0xFFFFFFFCU);
+    CHECK_SAT(aws_mul_u32_saturating, 0x10003, 0xFFFE, 0xFFFFFFFFU);
+    CHECK_SAT(aws_mul_u32_saturating, 0xFFFE, 0xFFFE, 0xFFFC0004U);
+    CHECK_SAT(aws_mul_u32_saturating, 0x1FFFF, 0x1FFFF, 0xFFFFFFFFU);
+    CHECK_SAT(aws_mul_u32_saturating, ~0U, ~0U, ~0U);
 
     return 0;
 }
@@ -109,45 +109,45 @@ static int test_u32_saturating_fn(struct aws_allocator *alloc, void *ctx) {
 
 AWS_TEST_CASE(test_u64_checked, test_u64_checked_fn)
 static int test_u64_checked_fn(struct aws_allocator *alloc, void *ctx) {
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0, 0, 0);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0, 1, 0);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0, ~0LLU, 0);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 4, 5, 20);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 1234, 4321, 5332114);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0, 1, 0);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0, ~0LLU, 0);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 4, 5, 20);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 1234, 4321, 5332114);
 
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0xFFFFFFFFLLU, 1LLU, 0xFFFFFFFFLLU);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0xFFFFFFFFLLU, 0xFFFFFFFFLLU, 0xfffffffe00000001LLU);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0x100000000LLU, 0xFFFFFFFFLLU, 0xFFFFFFFF00000000LLU);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0x100000001LLU, 0xFFFFFFFFLLU, 0xFFFFFFFFFFFFFFFFLLU);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0x100000001LLU, 0xFFFFFFFELLU, 0xFFFFFFFEFFFFFFFELLU);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0x100000002LLU, 0xFFFFFFFELLU, 0xFFFFFFFFFFFFFFFCLLU);
-    CHECK_OVF(aws_common_mul_u64_checked, uint64_t, 0x100000003LLU, 0xFFFFFFFELLU);
-    CHECK_NO_OVF(aws_common_mul_u64_checked, uint64_t, 0xFFFFFFFELLU, 0xFFFFFFFELLU, 0xFFFFFFFC00000004LLU);
-    CHECK_OVF(aws_common_mul_u64_checked, uint64_t, 0x1FFFFFFFFLLU, 0x1FFFFFFFFLLU);
-    CHECK_OVF(aws_common_mul_u64_checked, uint64_t, ~0LLU, ~0LLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0xFFFFFFFFLLU, 1LLU, 0xFFFFFFFFLLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0xFFFFFFFFLLU, 0xFFFFFFFFLLU, 0xfffffffe00000001LLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0x100000000LLU, 0xFFFFFFFFLLU, 0xFFFFFFFF00000000LLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0x100000001LLU, 0xFFFFFFFFLLU, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0x100000001LLU, 0xFFFFFFFELLU, 0xFFFFFFFEFFFFFFFELLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0x100000002LLU, 0xFFFFFFFELLU, 0xFFFFFFFFFFFFFFFCLLU);
+    CHECK_OVF(aws_mul_u64_checked, uint64_t, 0x100000003LLU, 0xFFFFFFFELLU);
+    CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0xFFFFFFFELLU, 0xFFFFFFFELLU, 0xFFFFFFFC00000004LLU);
+    CHECK_OVF(aws_mul_u64_checked, uint64_t, 0x1FFFFFFFFLLU, 0x1FFFFFFFFLLU);
+    CHECK_OVF(aws_mul_u64_checked, uint64_t, ~0LLU, ~0LLU);
 
     return 0;
 }
 
 AWS_TEST_CASE(test_u32_checked, test_u32_checked_fn)
 static int test_u32_checked_fn(struct aws_allocator *alloc, void *ctx) {
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0, 0, 0);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0, 1, 0);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0, ~0u, 0);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 4, 5, 20);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 1234, 4321, 5332114);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0, 1, 0);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0, ~0u, 0);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 4, 5, 20);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 1234, 4321, 5332114);
 
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0xFFFFFFFF, 1, 0xFFFFFFFF);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0xFFFF, 1, 0xFFFF);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0xFFFF, 0xFFFF, 0xfffe0001u);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0x10000, 0xFFFF, 0xFFFF0000u);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0x10001, 0xFFFF, 0xFFFFFFFFu);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0x10001, 0xFFFE, 0xFFFEFFFEu);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0x10002, 0xFFFE, 0xFFFFFFFCu);
-    CHECK_OVF(aws_common_mul_u32_checked, uint32_t, 0x10003, 0xFFFE);
-    CHECK_NO_OVF(aws_common_mul_u32_checked, uint32_t, 0xFFFE, 0xFFFE, 0xFFFC0004u);
-    CHECK_OVF(aws_common_mul_u32_checked, uint32_t, 0x1FFFF, 0x1FFFF);
-    CHECK_OVF(aws_common_mul_u32_checked, uint32_t, ~0u, ~0u);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0xFFFF, 1, 0xFFFF);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0xFFFF, 0xFFFF, 0xfffe0001u);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0x10000, 0xFFFF, 0xFFFF0000u);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0x10001, 0xFFFF, 0xFFFFFFFFu);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0x10001, 0xFFFE, 0xFFFEFFFEu);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0x10002, 0xFFFE, 0xFFFFFFFCu);
+    CHECK_OVF(aws_mul_u32_checked, uint32_t, 0x10003, 0xFFFE);
+    CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0xFFFE, 0xFFFE, 0xFFFC0004u);
+    CHECK_OVF(aws_mul_u32_checked, uint32_t, 0x1FFFF, 0x1FFFF);
+    CHECK_OVF(aws_mul_u32_checked, uint32_t, ~0u, ~0u);
 
     return 0;
 }


### PR DESCRIPTION
also make map arg const in hash table find function


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
