### PR TITLE
Fix C++ build error in headers

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -28,7 +28,7 @@ struct aws_byte_buf {
 };
 
 static inline int aws_byte_buf_alloc(struct aws_allocator * allocator, struct aws_byte_buf * buf, size_t len) {
-    buf->buffer = allocator->mem_acquire(allocator, len);
+    buf->buffer = (uint8_t*)allocator->mem_acquire(allocator, len);
     if (!buf->buffer) return aws_raise_error(AWS_ERROR_OOM);
     buf->len = len;
     return AWS_OP_SUCCESS;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was an implicit cast from `void *` to `uint8_t *` in a static inline function, which breaks when including into a C++ translation unit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
