### PR TITLE
fix defines on mac

### DIFF
--- a/source/posix/clock.c
+++ b/source/posix/clock.c
@@ -15,6 +15,11 @@
 
 #include <aws/common/clock.h>
 #include <time.h>
+
+#if defined(__MACH__)
+#include <AvailabilityMacros.h>
+#endif
+
 #if defined(__MACH__) && MAC_OS_X_VERSION_MAX_ALLOWED < 101200
 #include <sys/time.h>
 #endif /*defined(__MACH__) && MAC_OS_X_VERSION_MAX_ALLOWED < 101200*/


### PR DESCRIPTION
Fix includes for mac version detection in clock.c


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
