### PR TITLE
Fix bug in aws_base64_encode based on byte buffer change

### DIFF
--- a/source/encoding.c
+++ b/source/encoding.c
@@ -284,7 +284,7 @@ int aws_base64_decode(const struct aws_byte_buf *AWS_RESTRICT to_decode, struct 
         return AWS_OP_ERR;
     }
 
-    if (output->len < decoded_length) {
+    if (output->size < decoded_length) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
     }
 
@@ -327,7 +327,7 @@ int aws_base64_decode(const struct aws_byte_buf *AWS_RESTRICT to_decode, struct 
             }
         }
     }
-
+    output->len = decoded_length;
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
