### PR TITLE
Clang tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-valist.Uninitialized'
 WarningsAsErrors: '*'
-FormatStyle:     none
 CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '1'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,9 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: '*'
+FormatStyle:     none
+CheckOptions:
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-valist.Uninitialized'
 WarningsAsErrors: '*'
 FormatStyle:     none
 CheckOptions:

--- a/codebuild/linux-clang3-x64/buildspec.yml
+++ b/codebuild/linux-clang3-x64/buildspec.yml
@@ -1,11 +1,13 @@
 version: 0.2
-#this buildspec assumes the ubuntu 14.04 trusty image 
+#this buildspec assumes the ubuntu 14.04 trusty image
 phases:
   install:
     commands:
+      - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+      - sudo apt-add-repository "deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
       - sudo apt-get update -y
       - sudo apt-get update
-      - sudo apt-get install clang cmake3 cppcheck -y 
+      - sudo apt-get install clang-6.0 cmake3 cppcheck -y
   pre_build:
     commands:
       - export CC=clang
@@ -16,9 +18,11 @@ phases:
       - ./cppcheck.sh
       - mkdir build
       - cd build
-      - cmake ../ 
+      - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
       - make
       - make test
+      - cd ..
+      - clang-tidy -p=build **/*.c
   post_build:
     commands:
       - echo Build completed on `date`

--- a/codebuild/linux-clang3-x64/buildspec.yml
+++ b/codebuild/linux-clang3-x64/buildspec.yml
@@ -3,11 +3,9 @@ version: 0.2
 phases:
   install:
     commands:
-      - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
-      - sudo apt-add-repository "deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
       - sudo apt-get update -y
       - sudo apt-get update
-      - sudo apt-get install clang-6.0 cmake3 cppcheck -y
+      - sudo apt-get install clang cmake3 cppcheck clang-tidy-3.9 -y
 
   pre_build:
     commands:
@@ -23,7 +21,7 @@ phases:
       - make
       - make test
       - cd ..
-      - clang-tidy -p=build **/*.c
+      - clang-tidy-3.9 -p=build **/*.c
   post_build:
     commands:
       - echo Build completed on `date`

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -288,6 +288,9 @@ int aws_array_list_set_at(struct aws_array_list *list, const void *val, size_t i
 void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT item2, size_t item_size) {
     enum { SLICE = 128 };
 
+    assert(item1);
+    assert(item2);
+
     /* copy SLICE sized bytes at a time */
     size_t slice_count = item_size / SLICE;
     uint8_t temp[SLICE];
@@ -312,7 +315,7 @@ void aws_array_list_swap(struct aws_array_list *list, size_t a, size_t b) {
         return;
     }
 
-    void *item1 =NULL, *item2 = NULL;
+    void *item1 = NULL, *item2 = NULL;
     aws_array_list_get_at_ptr(list, &item1, a);
     aws_array_list_get_at_ptr(list, &item2, b);
     aws_array_list_mem_swap(item1, item2, list->item_size);

--- a/source/task_scheduler.c
+++ b/source/task_scheduler.c
@@ -17,6 +17,8 @@
 #include <aws/common/thread.h>
 #include <aws/common/priority_queue.h>
 
+#include <assert.h>
+
 static const size_t DEFAULT_QUEUE_SIZE = 7;
 
 struct task_container {
@@ -33,7 +35,7 @@ static int compare_timestamps(const void *a, const void *b) {
 static inline int get_next_task(struct aws_task_scheduler *scheduler, struct aws_task *task, uint64_t run_before,
                                 uint64_t *next_run_time);
 
-int aws_task_scheduler_init(struct aws_task_scheduler *scheduler, struct aws_allocator *alloc, 
+int aws_task_scheduler_init(struct aws_task_scheduler *scheduler, struct aws_allocator *alloc,
         aws_task_scheduler_clock clock) {
     scheduler->alloc = alloc;
     scheduler->clock = clock;
@@ -52,6 +54,7 @@ void aws_task_scheduler_clean_up(struct aws_task_scheduler *scheduler) {
             break;
         }
 
+        assert(task_to_run.fn);
         task_to_run.fn(task_to_run.arg, AWS_TASK_STATUS_CANCELED);
     }
 
@@ -97,7 +100,7 @@ static inline int get_next_task(struct aws_task_scheduler *scheduler, struct aws
     return AWS_OP_SUCCESS;
 }
 
-int aws_task_scheduler_next_task(struct aws_task_scheduler *scheduler, 
+int aws_task_scheduler_next_task(struct aws_task_scheduler *scheduler,
         struct aws_task *task, uint64_t *next_run_time) {
 
     uint64_t now;
@@ -119,7 +122,7 @@ int aws_task_scheduler_schedule_now(struct aws_task_scheduler *scheduler,
     return aws_task_scheduler_schedule_future(scheduler, task, now);
 }
 
-int aws_task_scheduler_schedule_future(struct aws_task_scheduler *scheduler, 
+int aws_task_scheduler_schedule_future(struct aws_task_scheduler *scheduler,
         struct aws_task *task, uint64_t time_to_run) {
 
     struct task_container container;
@@ -168,6 +171,7 @@ int aws_task_scheduler_run_all(struct aws_task_scheduler *scheduler, uint64_t *n
             return AWS_OP_ERR;
         }
 
+        assert(task_to_run.fn);
         task_to_run.fn(task_to_run.arg, AWS_TASK_STATUS_RUN_READY);
     }
 }


### PR DESCRIPTION
- Add .clang-tidy file with default settings
  - Disable valist.Uninitialized, it triggers a false positive.
- Add asserts to aws_array_list_mem_swap to validate parameters.
- task_schedule.c: Add asserts to validate task functions before call.
    This is required because the analyzer doesn't know that
    aws_raise_error() always returns 1, so it can't make
    branch flow assumptions.
- Remove some trailing whitespaces.

After this PR is merged, running cmake with -DCMAKE_C_CLANG_TIDY="clang-tidy" will run clang-tidy as part of the build, and fail on any new errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
