### PR TITLE
Setup linux clang codebuild to fail on clang-tidy errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-valist.Uninitialized'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*'
 WarningsAsErrors: '*'
+HeaderFilterRegex: '\./*'
 CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '1'

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -12,7 +12,6 @@ cppcheck                                                    \
 --suppress=unusedFunction                                   \
 --suppress=missingInclude                                   \
 --suppress=memleak:tests/hash_table_test.c                  \
---suppress=unreadVariable:tests/hash_table_test.c           \
 --suppress=staticStringCompare:tests/assert_test.c          \
                                                             \
 -q .

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -672,6 +672,7 @@ static int test_hash_churn_fn(struct aws_allocator *alloc, void *ctx) {
         if (e->is_removed) {
             int was_present;
             err_code = aws_hash_table_remove(&hash_table, e->key, NULL, &was_present);
+            ASSERT_SUCCESS(err_code, "Unexpected failure removing element");
             if (i == 0 && entries[i - 1].key == e->key && entries[i - 1].is_removed) {
                 ASSERT_INT_EQUALS(0, was_present,"Expected item to be missing");
             } else {

--- a/tests/mutex_test.c
+++ b/tests/mutex_test.c
@@ -86,8 +86,7 @@ static int test_mutex_is_actually_mutex(struct aws_allocator *allocator, void *c
         }
         else {
             finished = 1;
-            break;
-        }   
+        }
         aws_mutex_unlock(&mutex_data.mutex);
 
     }


### PR DESCRIPTION
This PR enables clang-tidy to run on the test files, and fixes any errors found. The CI should now be reliable with regard to clang-tidy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
