### PR TITLE
Add macros for zeroing memory of a known size

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -221,6 +221,9 @@ static inline void aws_secure_zero(void *pBuf, size_t bufsize) {
 #endif  // #else not windows
 }
 
+#define AWS_ZERO_STRUCT(object) memset(&object, 0, sizeof(object));
+#define AWS_ZERO_ARRAY(array) memset((void *)array, 0, sizeof(array));
+
 #define AWS_LIB_NAME "libaws-c-common"
 
 #define AWS_ENABLE_HW_OPTIMIZATION 1

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -489,7 +489,7 @@ static int remove_entry(struct hash_table_state *state, struct hash_table_entry 
     }
 
     /* Clear the entry we shifted out of */
-    memset(&state->slots[index], 0, sizeof(*entry));
+    AWS_ZERO_STRUCT(state->slots[index]);
 
     return index;
 }


### PR DESCRIPTION
This should help reduce copy-paste errors when zeroing objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
