### PR TITLE
Fuzzer

### DIFF
--- a/cmake/LibFuzzer.cmake
+++ b/cmake/LibFuzzer.cmake
@@ -1,0 +1,45 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+include(CTest)
+include(Sanitizers)
+
+option(ENABLE_FUZZ_TESTS "Build and run fuzz tests" OFF)
+set(FUZZ_TESTS_MAX_TIME 60 CACHE STRING "Max time to run each fuzz test")
+
+# Adds fuzz tests to ctest
+# Options:
+#  fuzz_files: The list of fuzz test files
+#  other_files: Other files to link into each fuzz test
+function(aws_add_fuzz_tests fuzz_files other_files)
+    if(ENABLE_FUZZ_TESTS)
+        aws_check_sanitizer(fuzzer)
+        if (NOT HAS_SANITIZER_fuzzer)
+            message(FATAL_ERROR "ENABLE_FUZZ_TESTS is set but the current compiler (${CMAKE_CXX_COMPILER_ID}) doesn't support -fsanitize=fuzzer")
+        endif()
+
+        foreach(test_file ${fuzz_files})
+            get_filename_component(TEST_FILE_NAME ${test_file} NAME_WE)
+
+            set(FUZZ_BINARY_NAME ${CMAKE_PROJECT_NAME}-fuzz-${TEST_FILE_NAME})
+            add_executable(${FUZZ_BINARY_NAME} ${test_file} ${other_files})
+            target_link_libraries(${FUZZ_BINARY_NAME} ${CMAKE_PROJECT_NAME})
+            aws_set_common_properties(${FUZZ_BINARY_NAME})
+            aws_add_sanitizers(${FUZZ_BINARY_NAME} SANITIZERS "${${CMAKE_PROJECT_NAME}_SANITIZERS};fuzzer")
+            target_compile_definitions(${FUZZ_BINARY_NAME} PRIVATE AWS_UNSTABLE_TESTING_API=1)
+            target_include_directories(${FUZZ_BINARY_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+            add_test(NAME fuzz_${TEST_FILE_NAME} COMMAND ${FUZZ_BINARY_NAME} -timeout=1 -max_total_time=${FUZZ_TESTS_MAX_TIME})
+        endforeach()
+    endif()
+endfunction()

--- a/codebuild/linux-clang6-x64/buildspec.yml
+++ b/codebuild/linux-clang6-x64/buildspec.yml
@@ -1,0 +1,30 @@
+version: 0.2
+#this buildspec assumes the ubuntu 14.04 trusty image
+phases:
+  install:
+    commands:
+      - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+      - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+      - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+      - sudo apt-get update -y
+      - sudo apt-get install clang-6.0 cmake3 cppcheck clang-tidy-6.0 -y -f
+
+  pre_build:
+    commands:
+      - export CC=clang-6.0
+      - export CXX=clang++-6.0
+  build:
+    commands:
+      - echo Build started on `date`
+      - ./cppcheck.sh
+      - mkdir build
+      - cd build
+      - cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_FUZZ_TESTS=ON ../
+      - make
+      - make test
+      - cd ..
+      - clang-tidy-6.0 -p=build **/*.c
+  post_build:
+    commands:
+      - echo Build completed on `date`
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(LibFuzzer)
 enable_testing()
 
 file(GLOB TEST_SRC "main.c")
@@ -178,3 +179,6 @@ add_test(test_lru_cache_overflow_static_members ${TEST_BINARY_NAME} test_lru_cac
 add_test(test_lru_cache_lru_ness_static_members ${TEST_BINARY_NAME} test_lru_cache_lru_ness_static_members)
 add_test(test_lru_cache_entries_cleanup ${TEST_BINARY_NAME} test_lru_cache_entries_cleanup)
 add_test(test_lru_cache_overwrite ${TEST_BINARY_NAME} test_lru_cache_overwrite)
+
+file(GLOB FUZZ_TESTS "fuzz/*.c")
+aws_add_fuzz_tests("${FUZZ_TESTS}" "")

--- a/tests/fuzz/base64_encoding_transitive.c
+++ b/tests/fuzz/base64_encoding_transitive.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/encoding.h>
+
+#include <assert.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+
+    struct aws_allocator *alloc = aws_default_allocator();
+
+    size_t output_size = 0;
+    int result = aws_base64_compute_encoded_len(size, &output_size);
+    assert(result == AWS_OP_SUCCESS);
+
+    struct aws_byte_buf to_encode = aws_byte_buf_from_array(data, size);
+
+    struct aws_byte_buf encode_allocation;
+    result = aws_byte_buf_init(alloc, &encode_allocation, output_size + 2);
+    assert(result == AWS_OP_SUCCESS);
+    memset(encode_allocation.buffer, 0xdd, encode_allocation.capacity);
+    struct aws_byte_buf encode_output = aws_byte_buf_from_array(encode_allocation.buffer + 1, output_size);
+    encode_output.len = 0;
+
+    result = aws_base64_encode(&to_encode, &encode_output);
+    assert(result == AWS_OP_SUCCESS);
+    assert(*encode_allocation.buffer == 0xdd);
+    assert(*(encode_allocation.buffer + output_size + 1) == 0xdd);
+    --encode_output.len; /* Remove null terminator */
+
+    result = aws_base64_compute_decoded_len((const char *)encode_output.buffer, output_size - 1, &output_size);
+    assert(result == AWS_OP_SUCCESS);
+    assert(output_size == size);
+
+    struct aws_byte_buf decode_allocation;
+    result = aws_byte_buf_init(alloc, &decode_allocation, output_size + 2);
+    assert(result == AWS_OP_SUCCESS);
+    memset(decode_allocation.buffer, 0xdd, decode_allocation.capacity);
+    struct aws_byte_buf decode_output = aws_byte_buf_from_array(decode_allocation.buffer + 1, output_size);
+    decode_output.len = 0;
+
+    result = aws_base64_decode(&encode_output, &decode_output);
+    assert(result == AWS_OP_SUCCESS);
+
+    assert(*decode_allocation.buffer == 0xdd);
+    assert(*(decode_allocation.buffer + output_size + 1) == 0xdd);
+
+    assert(output_size == decode_output.len);
+    assert(memcmp(decode_output.buffer, data, size) == 0);
+
+    aws_byte_buf_clean_up(&encode_allocation);
+    aws_byte_buf_clean_up(&decode_allocation);
+
+    return 0;
+}

--- a/tests/fuzz/base64_encoding_transitive.c
+++ b/tests/fuzz/base64_encoding_transitive.c
@@ -27,41 +27,29 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     struct aws_byte_buf to_encode = aws_byte_buf_from_array(data, size);
 
-    struct aws_byte_buf encode_allocation;
-    result = aws_byte_buf_init(alloc, &encode_allocation, output_size + 2);
+    struct aws_byte_buf encode_output;
+    result = aws_byte_buf_init(alloc, &encode_output, output_size);
     assert(result == AWS_OP_SUCCESS);
-    memset(encode_allocation.buffer, 0xdd, encode_allocation.capacity);
-    struct aws_byte_buf encode_output = aws_byte_buf_from_array(encode_allocation.buffer + 1, output_size);
-    encode_output.len = 0;
 
     result = aws_base64_encode(&to_encode, &encode_output);
     assert(result == AWS_OP_SUCCESS);
-    assert(*encode_allocation.buffer == 0xdd);
-    assert(*(encode_allocation.buffer + output_size + 1) == 0xdd);
     --encode_output.len; /* Remove null terminator */
 
-    result = aws_base64_compute_decoded_len((const char *)encode_output.buffer, output_size - 1, &output_size);
+    result = aws_base64_compute_decoded_len((const char *)encode_output.buffer, encode_output.len, &output_size);
     assert(result == AWS_OP_SUCCESS);
     assert(output_size == size);
 
-    struct aws_byte_buf decode_allocation;
-    result = aws_byte_buf_init(alloc, &decode_allocation, output_size + 2);
+    struct aws_byte_buf decode_output;
+    result = aws_byte_buf_init(alloc, &decode_output, output_size);
     assert(result == AWS_OP_SUCCESS);
-    memset(decode_allocation.buffer, 0xdd, decode_allocation.capacity);
-    struct aws_byte_buf decode_output = aws_byte_buf_from_array(decode_allocation.buffer + 1, output_size);
-    decode_output.len = 0;
 
     result = aws_base64_decode(&encode_output, &decode_output);
     assert(result == AWS_OP_SUCCESS);
-
-    assert(*decode_allocation.buffer == 0xdd);
-    assert(*(decode_allocation.buffer + output_size + 1) == 0xdd);
-
     assert(output_size == decode_output.len);
     assert(memcmp(decode_output.buffer, data, size) == 0);
 
-    aws_byte_buf_clean_up(&encode_allocation);
-    aws_byte_buf_clean_up(&decode_allocation);
+    aws_byte_buf_clean_up(&encode_output);
+    aws_byte_buf_clean_up(&decode_output);
 
     return 0;
 }

--- a/tests/fuzz/hex_encoding_transitive.c
+++ b/tests/fuzz/hex_encoding_transitive.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/encoding.h>
+
+#include <assert.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+
+    struct aws_allocator *alloc = aws_default_allocator();
+
+    size_t output_size = 0;
+    int result = aws_hex_compute_encoded_len(size, &output_size);
+    assert(result == AWS_OP_SUCCESS);
+
+    struct aws_byte_buf to_encode = aws_byte_buf_from_array(data, size);
+
+    struct aws_byte_buf encode_allocation;
+    result = aws_byte_buf_init(alloc, &encode_allocation, output_size + 2);
+    assert(result == AWS_OP_SUCCESS);
+    memset(encode_allocation.buffer, 0xdd, encode_allocation.capacity);
+    struct aws_byte_buf encode_output = aws_byte_buf_from_array(encode_allocation.buffer + 1, output_size);
+    encode_output.len = 0;
+
+    result = aws_hex_encode(&to_encode, &encode_output);
+    assert(result == AWS_OP_SUCCESS);
+    assert(*encode_allocation.buffer == 0xdd);
+    assert(*(encode_allocation.buffer + output_size + 1) == 0xdd);
+    --encode_output.len; /* Remove null terminator */
+
+    result = aws_hex_compute_decoded_len(output_size - 1, &output_size);
+    assert(result == AWS_OP_SUCCESS);
+    assert(output_size == size);
+
+    struct aws_byte_buf decode_allocation;
+    result = aws_byte_buf_init(alloc, &decode_allocation, output_size + 2);
+    assert(result == AWS_OP_SUCCESS);
+    memset(decode_allocation.buffer, 0xdd, decode_allocation.capacity);
+    struct aws_byte_buf decode_output = aws_byte_buf_from_array(decode_allocation.buffer + 1, output_size);
+    decode_output.len = 0;
+
+    result = aws_hex_decode(&encode_output, &decode_output);
+    assert(result == AWS_OP_SUCCESS);
+
+    assert(*decode_allocation.buffer == 0xdd);
+    assert(*(decode_allocation.buffer + output_size + 1) == 0xdd);
+
+    assert(output_size == decode_output.len);
+    assert(memcmp(decode_output.buffer, data, size) == 0);
+
+    aws_byte_buf_clean_up(&encode_allocation);
+    aws_byte_buf_clean_up(&decode_allocation);
+
+    return 0;
+}


### PR DESCRIPTION
- Add LibFuzzer helper library
- Add fuzz tests for base64 & hex encoding
- Add Linux Clang6 build for running LibFuzzer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
