### PR TITLE
Fixed pthread's condition variable not supporting "wait_for" semantics.

### DIFF
--- a/source/posix/condition_variable.c
+++ b/source/posix/condition_variable.c
@@ -15,6 +15,7 @@
 
 #include <aws/common/condition_variable.h>
 #include <aws/common/mutex.h>
+#include <aws/common/clock.h>
 
 #include <errno.h>
 
@@ -75,6 +76,12 @@ int aws_condition_variable_wait (struct aws_condition_variable *condition_variab
 
 int aws_condition_variable_wait_for(struct aws_condition_variable *condition_variable,
                                     struct aws_mutex *mutex, int64_t time_to_wait) {
+    uint64_t current_sys_time = 0;
+    if (aws_sys_clock_get_ticks(&current_sys_time)) {
+        return AWS_OP_ERR;
+    }
+
+    time_to_wait += current_sys_time;
 
     struct timespec ts;
     ts.tv_sec = time_to_wait / NANOS_PER_SEC;

--- a/source/posix/condition_variable.c
+++ b/source/posix/condition_variable.c
@@ -14,8 +14,8 @@
 */
 
 #include <aws/common/condition_variable.h>
-#include <aws/common/mutex.h>
 #include <aws/common/clock.h>
+#include <aws/common/mutex.h>
 
 #include <errno.h>
 

--- a/tests/condition_variable_test.c
+++ b/tests/condition_variable_test.c
@@ -16,6 +16,7 @@
 #include <aws/testing/aws_test_harness.h>
 #include <aws/common/condition_variable.h>
 #include <aws/common/thread.h>
+#include <aws/common/clock.h>
 
 struct condition_predicate_args {
     int call_count;
@@ -163,10 +164,20 @@ static int test_conditional_wait_timeout_fn(struct aws_allocator *allocator, voi
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
 
+    uint64_t pre_wait_timestamp = 0;
+    ASSERT_SUCCESS(aws_sys_clock_get_ticks(&pre_wait_timestamp));
+    uint64_t wait_ns = 1000000;
+
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
 
-    ASSERT_ERROR(AWS_ERROR_COND_VARIABLE_TIMED_OUT, aws_condition_variable_wait_for_pred(&condition_variable, &mutex, 1000000,
+    ASSERT_ERROR(AWS_ERROR_COND_VARIABLE_TIMED_OUT, aws_condition_variable_wait_for_pred(&condition_variable, &mutex, wait_ns,
                                                                                     conditional_predicate, &predicate_args));
+    uint64_t post_wait_timestamp = 0;
+    ASSERT_SUCCESS(aws_sys_clock_get_ticks(&post_wait_timestamp));
+
+    ASSERT_TRUE(post_wait_timestamp - pre_wait_timestamp >= wait_ns);
+    ASSERT_TRUE(post_wait_timestamp - pre_wait_timestamp < wait_ns * 2);
+
     ASSERT_TRUE(predicate_args.call_count >= 1);
 
     return AWS_OP_SUCCESS;

--- a/tests/condition_variable_test.c
+++ b/tests/condition_variable_test.c
@@ -14,9 +14,10 @@
 */
 
 #include <aws/testing/aws_test_harness.h>
+
 #include <aws/common/condition_variable.h>
-#include <aws/common/thread.h>
 #include <aws/common/clock.h>
+#include <aws/common/thread.h>
 
 struct condition_predicate_args {
     int call_count;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
