### PR TITLE
Make aws_byte_buf_cat accept 0 or 1 arguments.

### DIFF
--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -108,7 +108,6 @@ int aws_byte_buf_split_on_char(struct aws_byte_buf *input_str, char split_on, st
 
 int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...) {
     assert(dest);
-    assert(number_of_args > 1);
 
     va_list ap;
     va_start(ap, number_of_args);

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -35,6 +35,15 @@ static int s_test_buffer_cat_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_INT_EQUALS(strlen(expected) + 10, destination.capacity);
     ASSERT_BIN_ARRAYS_EQUALS(expected, strlen(expected), destination.buffer, destination.len);
 
+    destination.len = 0;
+    ASSERT_SUCCESS(aws_byte_buf_cat(&destination, 1, &str1));
+    ASSERT_INT_EQUALS(str1.len, destination.len);
+    ASSERT_BIN_ARRAYS_EQUALS(str1.buffer, str1.len, destination.buffer, destination.len);
+
+    destination.len = 0;
+    ASSERT_SUCCESS(aws_byte_buf_cat(&destination, 0));
+    ASSERT_INT_EQUALS(0, destination.len);
+
     aws_byte_buf_clean_up(&destination);
 
     return 0;


### PR DESCRIPTION
There's no real reason to require 2 or more arguments here, and having
byte_buf_cat accept 1 is convenient when you want to copy the contents of a
buffer, but don't want to bother creating a cursor first.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
