### PR TITLE
Add AWS_ARRAY_SIZE macro

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -326,6 +326,7 @@ static inline void aws_secure_zero(void *pBuf, size_t bufsize) {
 
 #define AWS_ZERO_STRUCT(object) memset(&object, 0, sizeof(object));
 #define AWS_ZERO_ARRAY(array) memset((void *)array, 0, sizeof(array));
+#define AWS_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #define AWS_ENABLE_HW_OPTIMIZATION 1
 

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -419,7 +419,7 @@ static int s_aws_run_test_case(struct aws_test_harness *harness) {
         test_name = argv[1];                                                                                           \
     }                                                                                                                  \
                                                                                                                        \
-    size_t test_count = sizeof(tests) / sizeof(struct aws_test_harness *);                                             \
+    size_t test_count = AWS_ARRAY_SIZE(tests);                                                                         \
     if (test_name) {                                                                                                   \
         ret_val = -1;                                                                                                  \
         for (size_t i = 0; i < test_count; ++i) {                                                                      \

--- a/source/common.c
+++ b/source/common.c
@@ -291,7 +291,7 @@ static struct aws_error_info errors[] = {
 
 static struct aws_error_info_list s_list = {
     .error_list = errors,
-    .count = sizeof(errors) / sizeof(struct aws_error_info),
+    .count = AWS_ARRAY_SIZE(errors),
 };
 
 void aws_load_error_strings(void) {

--- a/tests/array_list_test.c
+++ b/tests/array_list_test.c
@@ -857,7 +857,7 @@ static int s_array_list_of_strings_sort_fn(struct aws_allocator *allocator, void
     const struct aws_string *strings[] = {
         empty, foo, bar, foobar, foo2, foobaz, bar_food, bar_null_food, bar_null_back};
     const struct aws_string *sorted[] = {empty, bar, bar_null_back, bar_null_food, bar_food, foo, foo2, foobar, foobaz};
-    int num_strings = sizeof(strings) / sizeof(const struct aws_string *);
+    int num_strings = AWS_ARRAY_SIZE(strings);
 
     struct aws_array_list list;
     ASSERT_SUCCESS(

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -25,7 +25,7 @@ static struct aws_error_info s_errors[] = {
 
 static struct aws_error_info_list s_errors_list = {
     .error_list = s_errors,
-    .count = sizeof(s_errors) / sizeof(struct aws_error_info),
+    .count = AWS_ARRAY_SIZE(s_errors),
 };
 
 static void s_setup_errors_test_fn(struct aws_allocator *allocator, void *ctx) {

--- a/tests/rw_lock_test.c
+++ b/tests/rw_lock_test.c
@@ -137,7 +137,7 @@ static int s_test_rw_lock_many_readers(struct aws_allocator *allocator, void *ct
     struct aws_thread threads[8];
     AWS_ZERO_ARRAY(threads);
 
-    for (size_t i = 0; i < sizeof(threads) / sizeof(threads[0]); ++i) {
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(threads); ++i) {
 
         aws_thread_init(&threads[i], allocator);
         ASSERT_SUCCESS(
@@ -156,7 +156,7 @@ static int s_test_rw_lock_many_readers(struct aws_allocator *allocator, void *ct
         aws_rw_lock_wunlock(&lock);
     }
 
-    for (size_t i = 0; i < sizeof(threads) / sizeof(threads[0]); ++i) {
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(threads); ++i) {
 
         ASSERT_SUCCESS(aws_thread_join(&threads[i]), "Thread join failed with error code %d.", aws_last_error());
         aws_thread_clean_up(&threads[i]);


### PR DESCRIPTION
Also replaces the pattern of `sizeof(array) / sizeof(struct type_of_array)` with `AWS_ARRAY_SIZE`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
