### PR TITLE
[CI] Fix clang-tidy & errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,8 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '\./*'
+HeaderFilterRegex: '.*(?<!lookup3.c)$'
 FormatStyle: 'file'
-# Use empty line filter to skip linting code we don't own
-LineFilter:
-  - name:            lookup3.c
-    lines:           []
 CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '1'

--- a/include/aws/common/array_list.h
+++ b/include/aws/common/array_list.h
@@ -182,4 +182,4 @@ void aws_array_list_sort(struct aws_array_list *list, aws_array_list_comparator_
 }
 #endif
 
-#endif /*AWS_COMMON_ARRAY_LIST_H */
+#endif /* AWS_COMMON_ARRAY_LIST_H */

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -280,14 +280,14 @@ void aws_hash_table_clear(struct aws_hash_table *map);
  * Convenience hash function for NULL-terminated C-strings
  */
 AWS_COMMON_API
-uint64_t aws_hash_c_string(const void *a);
+uint64_t aws_hash_c_string(const void *item);
 
 /**
  * Convenience hash function for struct aws_strings.
  * Hash is same as used on the string bytes by aws_hash_c_string.
  */
 AWS_COMMON_API
-uint64_t aws_hash_string(const void *a);
+uint64_t aws_hash_string(const void *item);
 
 /**
  * Convenience hash function which hashes the pointer value directly,
@@ -295,7 +295,7 @@ uint64_t aws_hash_string(const void *a);
  * is desired, or where a uintptr_t is encoded into a const void *.
  */
 AWS_COMMON_API
-uint64_t aws_hash_ptr(const void *a);
+uint64_t aws_hash_ptr(const void *item);
 
 /**
  * Convenience eq function for NULL-terminated C-strings
@@ -314,34 +314,6 @@ bool aws_string_eq(const void *a, const void *b);
  */
 AWS_COMMON_API
 bool aws_ptr_eq(const void *a, const void *b);
-
-/**
- * Removes every element from the hash map. destroy_fn will be called for
- * each element.
- */
-AWS_COMMON_API
-void aws_hash_table_clear(struct aws_hash_table *map);
-
-/**
- * Convenience hash function for NULL-terminated C-strings
- */
-AWS_COMMON_API
-uint64_t aws_hash_c_string(const void *item);
-
-/**
- * Convenience hash function for struct aws_strings.
- * Hash is same as used on the string bytes by aws_hash_c_string.
- */
-AWS_COMMON_API
-uint64_t aws_hash_string(const void *item);
-
-/**
- * Convenience hash function which hashes the pointer value directly,
- * without dereferencing.  This can be used in cases where pointer identity
- * is desired, or where a uintptr_t is encoded into a const void *.
- */
-AWS_COMMON_API
-uint64_t aws_hash_ptr(const void *item);
 
 #ifdef __cplusplus
 }

--- a/include/aws/common/task_scheduler.h
+++ b/include/aws/common/task_scheduler.h
@@ -84,13 +84,16 @@ int aws_task_scheduler_next_task(struct aws_task_scheduler *scheduler, struct aw
  * Schedules a task to run immediately. task is copied
  */
 AWS_COMMON_API
-int aws_task_scheduler_schedule_now(struct aws_task_scheduler *queue, struct aws_task *task);
+int aws_task_scheduler_schedule_now(struct aws_task_scheduler *scheduler, struct aws_task *task);
 
 /**
  * Schedules a task to run at time_to_run units after the current time. task is copied
  */
 AWS_COMMON_API
-int aws_task_scheduler_schedule_future(struct aws_task_scheduler *queue, struct aws_task *task, uint64_t time_to_run);
+int aws_task_scheduler_schedule_future(
+    struct aws_task_scheduler *scheduler,
+    struct aws_task *task,
+    uint64_t time_to_run);
 
 /**
  * Sequentially execute all tasks that are ready until either the queue is empty or no ready tasks are available.
@@ -106,7 +109,7 @@ int aws_task_scheduler_schedule_future(struct aws_task_scheduler *queue, struct 
  * no tasks are scheduled. AWS_OP_ERR is only returned if an actual error condition occurs (OOM, Clock failure etc...).
  */
 AWS_COMMON_API
-int aws_task_scheduler_run_all(struct aws_task_scheduler *queue, uint64_t *next_task_time);
+int aws_task_scheduler_run_all(struct aws_task_scheduler *scheduler, uint64_t *next_task_time);
 
 #ifdef __cplusplus
 }

--- a/source/common.c
+++ b/source/common.c
@@ -28,14 +28,17 @@
 #endif
 
 static void *s_default_malloc(struct aws_allocator *allocator, size_t size) {
+    (void)allocator;
     return malloc(size);
 }
 
 static void s_default_free(struct aws_allocator *allocator, void *ptr) {
+    (void)allocator;
     free(ptr);
 }
 
 static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
+    (void)allocator;
     (void)oldsize;
     return realloc(ptr, newsize);
 }

--- a/source/string.c
+++ b/source/string.c
@@ -50,8 +50,9 @@ void aws_string_destroy_secure(void *str) {
     struct aws_string *self = str;
     if (self) {
         aws_secure_zero((void *)aws_string_bytes(self), self->len);
-        if (self->allocator)
+        if (self->allocator) {
             aws_mem_release(self->allocator, self);
+        }
     }
 }
 


### PR DESCRIPTION
Support for the `LineFilter` option seems funky, so just implement it via header-filter instead.
This exposes errors that were previously ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
