### PR TITLE
Fix lookup3 valgrind warnings

### DIFF
--- a/include/aws/common/private/lookup3.c
+++ b/include/aws/common/private/lookup3.c
@@ -3,9 +3,12 @@
  * # All functions have been made static.
  * # The self test harness has been turned off.
  * # stdint.h include removed for C89 compatibility.
+ * # VALGRIND has been enabled to suppress valgrind warnings
  *
  * The original code was retrieved from http://burtleburtle.net/bob/c/lookup3.c
  */
+
+#define VALGRIND
 
 /*
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This switches lookup3 to use a marginally slower way of accessing the last 12
bytes of a string, in exchange for removing the valgrind
access-beyond-end-of-buffer warnings that arise from its normal methods.

While this is a slight pessimization, leaving this optimization in makes it
difficult for consuming applications and libraries to perform valgrind testing;
valgrind appears to attribute the uninitialized accesses to later code, making
it very difficult to accurately suppress these warnings. Considering cases
where the aws-c-common library builder may not be the same person as the
library user, it's better to have this in the valgrind-safe mode by default; we
can later make it togglable if the performance gains are needed in
ultra-high-performance systems.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
