### PR TITLE
aws_mem_acquire_many

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -172,6 +172,18 @@ void aws_wrapped_cf_allocator_destroy(CFAllocatorRef allocator);
 AWS_COMMON_API
 void *aws_mem_acquire(struct aws_allocator *allocator, size_t size);
 
+/**
+ * Allocates many chunks of bytes into a single block. Expects to be called with alternating void ** (dest), size_t
+ * (size). The first void ** will be set to the root of the allocation. Alignment is assumed to be sizeof(intmax_t).
+ *
+ * This is useful for allocating structs using the pimpl pattern, as you may allocate the public object and impl object
+ * in the same contiguous block of memory.
+ *
+ * Returns a pointer to the allocation.
+ */
+AWS_COMMON_API
+void *aws_mem_acquire_many(struct aws_allocator *allocator, size_t count, ...);
+
 /*
  * Releases ptr back to whatever allocated it.
  */

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -53,6 +53,11 @@ static void *s_mem_acquire_malloc(struct aws_allocator *allocator, size_t size) 
     test_allocator->allocated += size;
     struct memory_test_tracker *memory =
         (struct memory_test_tracker *)malloc(size + sizeof(struct memory_test_tracker));
+
+    if (!memory) {
+        return NULL;
+    }
+
     memory->size = size;
     memory->blob = (uint8_t *)memory + sizeof(struct memory_test_tracker);
     aws_mutex_unlock(&test_allocator->mutex);

--- a/source/common.c
+++ b/source/common.c
@@ -62,7 +62,7 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
     return mem;
 }
 
-#define AWS_ALIGN_ROUND_UP(value, alignment) (((value) + ((alignment)-1)) & -(alignment))
+#define AWS_ALIGN_ROUND_UP(value, alignment) (((value) + ((alignment)-1)) & ~((alignment)-1))
 
 void *aws_mem_acquire_many(struct aws_allocator *allocator, size_t count, ...) {
 

--- a/source/common.c
+++ b/source/common.c
@@ -15,6 +15,7 @@
 
 #include <aws/common/common.h>
 
+#include <stdarg.h>
 #include <stdlib.h>
 
 #ifdef __MACH__
@@ -60,6 +61,58 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
     }
     return mem;
 }
+
+#define AWS_ALIGN_ROUND_UP(value, alignment) (((value) + ((alignment)-1)) & -(alignment))
+
+void *aws_mem_acquire_many(struct aws_allocator *allocator, size_t count, ...) {
+
+    enum { S_ALIGNMENT = sizeof(intmax_t) };
+
+    va_list args_size;
+    va_start(args_size, count);
+    va_list args_allocs;
+    va_copy(args_allocs, args_size);
+
+    size_t total_size = 0;
+    for (size_t i = 0; i < count; ++i) {
+
+        /* Ignore the pointer argument for now */
+        va_arg(args_size, void **);
+
+        size_t alloc_size = va_arg(args_size, size_t);
+        total_size += AWS_ALIGN_ROUND_UP(alloc_size, S_ALIGNMENT);
+    }
+    va_end(args_size);
+
+    void *allocation = NULL;
+
+    if (total_size > 0) {
+
+        allocation = aws_mem_acquire(allocator, total_size);
+        if (!allocation) {
+            goto cleanup;
+        }
+
+        uint8_t *current_ptr = allocation;
+
+        for (size_t i = 0; i < count; ++i) {
+
+            void **out_ptr = va_arg(args_allocs, void **);
+
+            size_t alloc_size = va_arg(args_allocs, size_t);
+            alloc_size = AWS_ALIGN_ROUND_UP(alloc_size, S_ALIGNMENT);
+
+            *out_ptr = current_ptr;
+            current_ptr += alloc_size;
+        }
+    }
+
+cleanup:
+    va_end(args_allocs);
+    return allocation;
+}
+
+#undef AWS_ALIGN_ROUND_UP
 
 void aws_mem_release(struct aws_allocator *allocator, void *ptr) {
     allocator->mem_release(allocator, ptr);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,7 @@ add_test(test_realloc_fallback_oom ${TEST_BINARY_NAME} test_realloc_fallback_oom
 add_test(test_realloc_passthrough ${TEST_BINARY_NAME} test_realloc_passthrough)
 add_test(test_realloc_passthrough_oom ${TEST_BINARY_NAME} test_realloc_passthrough_oom)
 add_test(test_cf_allocator_wrapper ${TEST_BINARY_NAME} test_cf_allocator_wrapper)
+add_test(test_acquire_many ${TEST_BINARY_NAME} test_acquire_many)
 
 add_test(test_lru_cache_overflow_static_members ${TEST_BINARY_NAME} test_lru_cache_overflow_static_members)
 add_test(test_lru_cache_lru_ness_static_members ${TEST_BINARY_NAME} test_lru_cache_lru_ness_static_members)

--- a/tests/main.c
+++ b/tests/main.c
@@ -189,6 +189,7 @@ int main(int argc, char *argv[]) {
         &test_realloc_passthrough_oom,
         &test_realloc_passthrough,
         &test_cf_allocator_wrapper,
+        &test_acquire_many,
         &test_lru_cache_overflow_static_members,
         &test_lru_cache_lru_ness_static_members,
         &test_lru_cache_entries_cleanup,

--- a/tests/realloc_test.c
+++ b/tests/realloc_test.c
@@ -239,14 +239,14 @@ static int s_test_acquire_many_fn(struct aws_allocator *allocator, void *ctx) {
 
     void *a = NULL;
     void *b = NULL;
-    void *buffer = aws_mem_acquire_many(allocator, 2, &a, 32, &b, 32);
+    void *buffer = aws_mem_acquire_many(allocator, 2, &a, (size_t)64, &b, (size_t)64);
 
     ASSERT_NOT_NULL(buffer);
     ASSERT_NOT_NULL(a);
     ASSERT_NOT_NULL(b);
 
     ASSERT_UINT_EQUALS((uintptr_t)a, (uintptr_t)buffer);
-    ASSERT_UINT_EQUALS((uintptr_t)b, (uintptr_t)buffer + 32);
+    ASSERT_UINT_EQUALS((uintptr_t)b, (uintptr_t)buffer + 64);
     ASSERT_UINT_EQUALS((uintptr_t)a % sizeof(intmax_t), 0);
     ASSERT_UINT_EQUALS((uintptr_t)b % sizeof(intmax_t), 0);
 
@@ -254,7 +254,7 @@ static int s_test_acquire_many_fn(struct aws_allocator *allocator, void *ctx) {
     a = NULL;
     b = NULL;
 
-    buffer = aws_mem_acquire_many(allocator, 2, &a, 1, &b, 1);
+    buffer = aws_mem_acquire_many(allocator, 2, &a, (size_t)1, &b, (size_t)1);
 
     ASSERT_NOT_NULL(buffer);
     ASSERT_NOT_NULL(a);

--- a/tests/realloc_test.c
+++ b/tests/realloc_test.c
@@ -231,3 +231,41 @@ static int s_test_cf_allocator_wrapper_fn(struct aws_allocator *allocator, void 
 
     return 0;
 }
+
+AWS_TEST_CASE(test_acquire_many, s_test_acquire_many_fn)
+static int s_test_acquire_many_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    void *a = NULL;
+    void *b = NULL;
+    void *buffer = aws_mem_acquire_many(allocator, 2, &a, 32, &b, 32);
+
+    ASSERT_NOT_NULL(buffer);
+    ASSERT_NOT_NULL(a);
+    ASSERT_NOT_NULL(b);
+
+    ASSERT_UINT_EQUALS((uintptr_t)a, (uintptr_t)buffer);
+    ASSERT_UINT_EQUALS((uintptr_t)b, (uintptr_t)buffer + 32);
+    ASSERT_UINT_EQUALS((uintptr_t)a % sizeof(intmax_t), 0);
+    ASSERT_UINT_EQUALS((uintptr_t)b % sizeof(intmax_t), 0);
+
+    aws_mem_release(allocator, buffer);
+    a = NULL;
+    b = NULL;
+
+    buffer = aws_mem_acquire_many(allocator, 2, &a, 1, &b, 1);
+
+    ASSERT_NOT_NULL(buffer);
+    ASSERT_NOT_NULL(a);
+    ASSERT_NOT_NULL(b);
+
+    ASSERT_UINT_EQUALS((uintptr_t)a, (uintptr_t)buffer);
+    ASSERT_UINT_EQUALS((uintptr_t)b, (uintptr_t)buffer + sizeof(intmax_t));
+    ASSERT_UINT_EQUALS((uintptr_t)a % sizeof(intmax_t), 0);
+    ASSERT_UINT_EQUALS((uintptr_t)b % sizeof(intmax_t), 0);
+
+    aws_mem_release(allocator, buffer);
+
+    return 0;
+}


### PR DESCRIPTION
Adds `aws_mem_acquire_many`, a useful function for allocating lots of stuff contiguously. This is very good for cache locality. Extremely useful for pimpl pattern, i.e.:
```c
    struct aws_mqtt_client *client = NULL;
    struct aws_mqtt_client_impl *client_impl = NULL;
    aws_mem_acquire_many(allocator, 2,
        &client, sizeof(struct aws_mqtt_client),
        &client_impl, sizeof(struct aws_mqtt_client_impl));

    AWS_ZERO_STRUCT(*client);
    AWS_ZERO_STRUCT(*client_impl);

    client->impl = client_impl;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
