### PR TITLE
Cursor/Buffer/String Conversions/Equality

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -150,6 +150,22 @@ int aws_byte_buf_append(struct aws_byte_buf *to, struct aws_byte_cursor *from);
 AWS_COMMON_API
 int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...);
 
+/**
+ * Compares two aws_byte_cursor structures
+ * Returns true if a has the same length as b and their buffers have the same bytes
+ * (or both buffers are null). When both a and b are null the function returns true
+ */
+AWS_COMMON_API
+bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b);
+
+/**
+ * Compares an aws_byte_cursor against an aws_byte_buf
+ * Returns true if a has the same length as b and their buffers have the same bytes
+ * (or both buffers are null). When both a and b are null the function returns true
+ */
+AWS_COMMON_API
+bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *a, const struct aws_byte_buf *b);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -137,4 +137,12 @@ static inline bool aws_byte_cursor_write_from_whole_string(
     return aws_byte_cursor_write(cur, aws_string_bytes(src), src->len);
 }
 
+/**
+ * Creates an aws_byte_cursor from an existing string.
+ */
+static inline struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src) {
+
+    return aws_byte_cursor_from_array(aws_string_bytes(src), src->len);
+}
+
 #endif /* AWS_COMMON_STRING_H */

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -167,6 +167,40 @@ int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...) {
     return AWS_OP_SUCCESS;
 }
 
+bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
+
+    if (!a || !b) {
+        return (a == b);
+    }
+
+    if (a->len != b->len) {
+        return false;
+    }
+
+    if (!a->ptr || !b->ptr) {
+        return (a->ptr == b->ptr);
+    }
+
+    return !memcmp(a->ptr, b->ptr, a->len);
+}
+
+bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *a, const struct aws_byte_buf *b) {
+
+    if (!a || !b) {
+        return ((void *)a == (void *)b);
+    }
+
+    if (a->len != b->len) {
+        return false;
+    }
+
+    if (!a->ptr || !b->buffer) {
+        return (a->ptr == b->buffer);
+    }
+
+    return !memcmp(a->ptr, b->buffer, a->len);
+}
+
 int aws_byte_buf_append(struct aws_byte_buf *to, struct aws_byte_cursor *from) {
     assert(from->ptr);
     assert(to->buffer);


### PR DESCRIPTION
Adds the following:
* `aws_byte_cursor_eq`
* `aws_byte_cursor_eq_byte_buf`
* `aws_byte_cursor_from_string`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
