### PR TITLE
Test colors for windows

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -424,6 +424,42 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
     FAIL("%s [ \033[31mFAILED\033[0m ]", harness->test_name);
 }
 
+/* Enables terminal escape sequences for text coloring on Windows. */
+/* https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences */
+#ifdef _WIN32
+
+#   include <Windows.h>
+
+#   ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#   define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#   endif
+
+    static int enable_vt_mode() {
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hOut == INVALID_HANDLE_VALUE) {
+            return AWS_OP_ERR;
+        }
+
+        DWORD dwMode = 0;
+        if (!GetConsoleMode(hOut, &dwMode)) {
+            return AWS_OP_ERR;
+        }
+
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        if (!SetConsoleMode(hOut, dwMode)) {
+            return AWS_OP_ERR;
+        }
+        return AWS_OP_SUCCESS;
+    }
+
+#else
+
+    int enable_vt_mode() {
+        return AWS_OP_ERR;
+    }
+
+#endif
+
 #define AWS_RUN_TEST_CASES(...)                                                                                        \
     struct aws_test_harness *tests[] = {__VA_ARGS__};                                                                  \
     int ret_val = 0;                                                                                                   \
@@ -432,6 +468,8 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
     if (argc >= 2) {                                                                                                   \
         test_name = argv[1];                                                                                           \
     }                                                                                                                  \
+                                                                                                                       \
+    enable_vt_mode();                                                                                                  \
                                                                                                                        \
     size_t test_count = AWS_ARRAY_SIZE(tests);                                                                         \
     if (test_name) {                                                                                                   \

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -434,7 +434,7 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
 #   define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #   endif
 
-    static int enable_vt_mode() {
+    static inline int enable_vt_mode() {
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
         if (hOut == INVALID_HANDLE_VALUE) {
             return AWS_OP_ERR;
@@ -454,7 +454,7 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
 
 #else
 
-    int enable_vt_mode() {
+    static inline int enable_vt_mode() {
         return AWS_OP_ERR;
     }
 

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -428,35 +428,35 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
 /* https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences */
 #ifdef _WIN32
 
-#   include <Windows.h>
+#    include <Windows.h>
 
-#   ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-#   define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
-#   endif
+#    ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#        define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#    endif
 
-    static inline int enable_vt_mode() {
-        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (hOut == INVALID_HANDLE_VALUE) {
-            return AWS_OP_ERR;
-        }
-
-        DWORD dwMode = 0;
-        if (!GetConsoleMode(hOut, &dwMode)) {
-            return AWS_OP_ERR;
-        }
-
-        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-        if (!SetConsoleMode(hOut, dwMode)) {
-            return AWS_OP_ERR;
-        }
-        return AWS_OP_SUCCESS;
+static inline int enable_vt_mode() {
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) {
+        return AWS_OP_ERR;
     }
+
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(hOut, &dwMode)) {
+        return AWS_OP_ERR;
+    }
+
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (!SetConsoleMode(hOut, dwMode)) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}
 
 #else
 
-    static inline int enable_vt_mode() {
-        return AWS_OP_ERR;
-    }
+static inline int enable_vt_mode() {
+    return AWS_OP_ERR;
+}
 
 #endif
 


### PR DESCRIPTION
Enabling vt mode for cmd.exe to enable color text escape sequences as per:
https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

![image](https://user-images.githubusercontent.com/1919825/44759826-0efb7180-aaf1-11e8-9fc2-1466c19496ea.png)
