### PR TITLE
Use default value of cbmc.tar.gz when running verification

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_init_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_init_dynamic/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_init_dynamic_verify"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_array_list_init_static/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_init_static/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_init_static_verify"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_array_list_push_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_push_back_verify;--unwindset;strlen.0:33,memcpy.0:33,__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_set_at_verify;--unwindset;strlen.0:33,memcpy.0:33,__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_byte_buf_append/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_byte_buf_append_verify;--unwinding-assertions;--unwindset;memcpy.0:33,__builtin___memcpy_chk.0:33"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_byte_buf_from_c_str_verify;--unwindset;strlen.0:33;--unwinding-assertions"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_byte_buf_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_init/cbmc-batch.yaml
@@ -1,4 +1,3 @@
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_byte_buf_init_verify"
 goto: proofs.goto


### PR DESCRIPTION
The default used by CBMC Batch is just fine, no need to use a different name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
