### PR TITLE
Make the aws_string APIs return a non-const aws_string

### DIFF
--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -32,10 +32,14 @@
  * always included immediately after the data but not counted in the length, so
  * that the output of aws_string_bytes can be treated as a C-string in cases
  * where none of the the data bytes are null.
+ *
+ * Note that the fields of this structure are const; this ensures not only that
+ * they cannot be modified, but also that you can't assign the structure using
+ * the = operator accidentally.
  */
 struct aws_string {
-    struct aws_allocator *allocator;
-    size_t len;
+    struct aws_allocator *const allocator;
+    const size_t len;
 };
 
 static inline const uint8_t *aws_string_bytes(const struct aws_string *hdr) {
@@ -70,9 +74,9 @@ extern "C" {
  * Constructor functions which copy data from null-terminated C-string or array of unsigned or signed characters.
  */
 AWS_COMMON_API
-const struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, const char *c_str);
+struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, const char *c_str);
 AWS_COMMON_API
-const struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len);
+struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len);
 
 /**
  * Deallocate string. Takes a (void *) so it can be used as a destructor function for struct aws_hash_table.

--- a/source/string.c
+++ b/source/string.c
@@ -14,25 +14,17 @@
  */
 #include <aws/common/string.h>
 
-const struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, const char *c_str) {
-    size_t len = strlen(c_str);
-    struct aws_string *hdr = aws_mem_acquire(allocator, sizeof(struct aws_string) + len + 1);
-    if (!hdr) {
-        return NULL;
-    }
-    hdr->allocator = allocator;
-    hdr->len = len;
-    memcpy((void *)aws_string_bytes(hdr), c_str, len + 1);
-    return hdr;
+struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, const char *c_str) {
+    return aws_string_new_from_array(allocator, (const uint8_t *)c_str, strlen(c_str));
 }
 
-const struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len) {
+struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len) {
+    struct aws_string template = {.allocator = allocator, .len = len};
     struct aws_string *hdr = aws_mem_acquire(allocator, sizeof(struct aws_string) + len + 1);
     if (!hdr) {
         return NULL;
     }
-    hdr->allocator = allocator;
-    hdr->len = len;
+    memcpy(hdr, &template, sizeof(template));
     memcpy((void *)aws_string_bytes(hdr), bytes, len);
     uint8_t *extra_byte = (uint8_t *)aws_string_bytes(hdr) + len;
     *extra_byte = '\0';

--- a/source/string.c
+++ b/source/string.c
@@ -14,6 +14,12 @@
  */
 #include <aws/common/string.h>
 
+#ifdef _MSC_VER
+/* disables warning non const declared initializers for Microsoft compilers */
+#    pragma warning(disable : 4204)
+#    pragma warning(disable : 4706)
+#endif
+
 struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, const char *c_str) {
     return aws_string_new_from_array(allocator, (const uint8_t *)c_str, strlen(c_str));
 }


### PR DESCRIPTION
This improves ergonomics, in particular allowing the newly created string to be
passed to aws_string_destroy without casting. To restore (and further improve)
safety, we instead make the fields of the aws_string structure const. This has
the beneficial side effect of preventing the aws_string pointer from being
assigned to (except at local variable initialization time).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
