### PR TITLE
Fix Windows usage of dll import/export

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -72,7 +72,7 @@ function(aws_set_common_properties target)
         string(REGEX REPLACE "^AWS-C-" "AWS-" EXPORT_DEFINE ${EXPORT_DEFINE})
         string(REPLACE "-" "_" EXPORT_DEFINE ${EXPORT_DEFINE})
 
-        list(APPEND AWS_C_DEFINES -DUSE_IMPORT_EXPORT)
+        list(APPEND AWS_C_DEFINES -DAWS_COMMON_USE_IMPORT_EXPORT)
         list(APPEND AWS_C_DEFINES -D${EXPORT_DEFINE}_EXPORTS)
     endif()
 

--- a/include/aws/common/exports.h
+++ b/include/aws/common/exports.h
@@ -14,8 +14,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-#if defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
-#    ifdef USE_IMPORT_EXPORT
+#if defined(AWS_COMMON_USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
+#    ifdef AWS_COMMON_USE_IMPORT_EXPORT
 #        ifdef AWS_COMMON_EXPORTS
 #            define AWS_COMMON_API __declspec(dllexport)
 #        else


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
USE_IMPORT_EXPORT variable name clashes with the aws-cpp-sdk and this might trigger errors when aws-cpp-sdk is shared and aws-c-common is static :
```
(Link target) ->
  t_cpputils.obj : warning LNK4217: locally defined symbol aws_last_error imported in function "int __cdecl Aws::Crypto
sdk::Testing::t_assert_edks_equals(struct aws_array_list const *,struct aws_array_list const *)" (?t_assert_edks_equals
@Testing@Cryptosdk@Aws@@YAHPEBUaws_array_list@@0@Z) [C:\Users\Administrator\workplace\build\aws-encryption-sdk-cpp\t_cp
putils.vcxproj]
```
This code just changes the name of the variables to avoid building errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
