### PR TITLE
Reduce rw_lock threads from 8 to 2

### DIFF
--- a/tests/rw_lock_test.c
+++ b/tests/rw_lock_test.c
@@ -134,7 +134,7 @@ static int s_test_rw_lock_many_readers(struct aws_allocator *allocator, void *ct
     struct aws_rw_lock lock;
     aws_rw_lock_init(&lock);
 
-    struct aws_thread threads[8];
+    struct aws_thread threads[2];
     AWS_ZERO_ARRAY(threads);
 
     for (size_t i = 0; i < AWS_ARRAY_SIZE(threads); ++i) {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
