### PR TITLE
Enable -Wstrict-prototypes

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -29,7 +29,7 @@ function(aws_set_common_properties target)
         # Since we want to be compatible with user builds using /volatile:iso, use it for the tests.
         list(APPEND AWS_C_FLAGS /volatile:iso)
     else()
-        list(APPEND AWS_C_FLAGS -Wall -Werror)
+        list(APPEND AWS_C_FLAGS -Wall -Werror -Wstrict-prototypes)
 
         if(NOT SET_PROPERTIES_NO_WEXTRA)
             list(APPEND AWS_C_FLAGS -Wextra)

--- a/include/aws/common/atomics_gnu_old.inl
+++ b/include/aws/common/atomics_gnu_old.inl
@@ -43,7 +43,7 @@ struct aws_atomic_var {
         .u = {.ptrval = (void *)(x) }                                                                                  \
     }
 
-static inline void aws_atomic_private_compiler_barrier() {
+static inline void aws_atomic_private_compiler_barrier(void) {
     __asm__ __volatile__("" : : : "memory");
 }
 

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -28,7 +28,7 @@
  * out at compile time and code which calls "if (aws_is_big_endian())" will do
  * the right thing without branching.
  */
-AWS_STATIC_IMPL int aws_is_big_endian() {
+AWS_STATIC_IMPL int aws_is_big_endian(void) {
     const uint16_t z = 0x100;
     return *(const uint8_t *)&z;
 }

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -1,5 +1,5 @@
 #ifndef AWS_COMMON_COMMON_H
-#    define AWS_COMMON_COMMON_H
+#define AWS_COMMON_COMMON_H
 
 /*
  * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -16,104 +16,104 @@
  * permissions and limitations under the License.
  */
 
-#    include <aws/common/exports.h>
+#include <aws/common/exports.h>
 
-#    include <stddef.h>
-#    include <string.h>
+#include <stddef.h>
+#include <string.h>
 
-#    ifndef AWS_STATIC_IMPL
+#ifndef AWS_STATIC_IMPL
 /*
  * In order to allow us to export our inlinable methods in a DLL/.so, we have a designated .c
  * file where this AWS_STATIC_IMPL macro will be redefined to be non-static.
  */
-#        define AWS_STATIC_IMPL static inline
-#    endif
+#    define AWS_STATIC_IMPL static inline
+#endif
 
-#    define AWS_STATIC_ASSERT0(cond, msg) typedef char static_assertion_##msg[(!!(cond)) * 2 - 1]
-#    define AWS_STATIC_ASSERT1(cond, line) AWS_STATIC_ASSERT0(cond, static_assertion_at_line_##line)
-#    define AWS_STATIC_ASSERT(cond) AWS_STATIC_ASSERT1(cond, __LINE__)
+#define AWS_STATIC_ASSERT0(cond, msg) typedef char static_assertion_##msg[(!!(cond)) * 2 - 1]
+#define AWS_STATIC_ASSERT1(cond, line) AWS_STATIC_ASSERT0(cond, static_assertion_at_line_##line)
+#define AWS_STATIC_ASSERT(cond) AWS_STATIC_ASSERT1(cond, __LINE__)
 
-#    if defined(_MSC_VER)
-#        include <Windows.h> /* for SecureZeroMemory */
-#    endif
+#if defined(_MSC_VER)
+#    include <Windows.h> /* for SecureZeroMemory */
+#endif
 
-#    ifndef NO_STDBOOL
-#        include <stdbool.h>
-#    else
-#        ifndef __cplusplus
-#            define bool _Bool
-#            define true 1
-#            define false 0
-#        elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#ifndef NO_STDBOOL
+#    include <stdbool.h>
+#else
+#    ifndef __cplusplus
+#        define bool _Bool
+#        define true 1
+#        define false 0
+#    elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
 
-#            define _Bool bool
-#            if __cplusplus < 201103L
+#        define _Bool bool
+#        if __cplusplus < 201103L
 /* For C++98, define bool, false, true as a GNU extension. */
-#                define bool bool
-#                define false false
-#                define true true
-#            endif
+#            define bool bool
+#            define false false
+#            define true true
 #        endif
 #    endif
+#endif
 
-#    ifndef NO_STDINT
-#        include <stdint.h>
-#    else
-#        if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(__ia64__) ||                   \
+#ifndef NO_STDINT
+#    include <stdint.h>
+#else
+#    if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(__ia64__) ||                   \
             defined(__powerpc64__)
-#            define PTR_SIZE 8
-#        else
-#            define PTR_SIZE 4
-#        endif
+#        define PTR_SIZE 8
+#    else
+#        define PTR_SIZE 4
+#    endif
 
 typedef signed char int8_t;
 typedef short int int16_t;
 typedef int int32_t;
-#        if (PTR_SIZE == 8)
+#    if (PTR_SIZE == 8)
 typedef long int int64_t;
-#        else
+#    else
 typedef long long int int64_t;
-#        endif
+#    endif
 
 typedef unsigned char uint8_t;
 typedef unsigned short int uint16_t;
 
 typedef unsigned int uint32_t;
 
-#        if (PTR_SIZE == 8)
+#    if (PTR_SIZE == 8)
 typedef unsigned long int uint64_t;
-#        else
+#    else
 typedef unsigned long long int uint64_t;
-#        endif
+#    endif
 
-#        if (PTR_SIZE == 8)
+#    if (PTR_SIZE == 8)
 typedef long int intptr_t;
 typedef unsigned long int uintptr_t;
-#        else
+#    else
 typedef int intptr_t;
 typedef unsigned int uintptr_t;
-#        endif
+#    endif
 
-#        if (PTR_SIZE == 8)
-#            define __INT64_C(c) c##L
-#            define __UINT64_C(c) c##UL
-#        else
-#            define __INT64_C(c) c##LL
-#            define __UINT64_C(c) c##ULL
-#        endif
+#    if (PTR_SIZE == 8)
+#        define __INT64_C(c) c##L
+#        define __UINT64_C(c) c##UL
+#    else
+#        define __INT64_C(c) c##LL
+#        define __UINT64_C(c) c##ULL
+#    endif
 
-#        define INT8_MIN (-128)
-#        define INT16_MIN (-32767 - 1)
-#        define INT32_MIN (-2147483647 - 1)
-#        define INT64_MIN (-__INT64_C(9223372036854775807) - 1)
-#        define INT8_MAX (127)
-#        define INT16_MAX (32767)
-#        define INT32_MAX (2147483647)
-#        define INT64_MAX (__INT64_C(9223372036854775807))
-#        define UINT8_MAX (255)
-#        define UINT16_MAX (65535)
-#        define UINT32_MAX (4294967295U)
-#        define UINT64_MAX (__UINT64_C(18446744073709551615))
+#    define INT8_MIN (-128)
+#    define INT16_MIN (-32767 - 1)
+#    define INT32_MIN (-2147483647 - 1)
+#    define INT64_MIN (-__INT64_C(9223372036854775807) - 1)
+#    define INT8_MAX (127)
+#    define INT16_MAX (32767)
+#    define INT32_MAX (2147483647)
+#    define INT64_MAX (__INT64_C(9223372036854775807))
+#    define UINT8_MAX (255)
+#    define UINT16_MAX (65535)
+#    define UINT32_MAX (4294967295U)
+#    define UINT64_MAX (__UINT64_C(18446744073709551615))
 
 AWS_STATIC_ASSERT(sizeof(uint64_t) == 8);
 AWS_STATIC_ASSERT(sizeof(uint32_t) == 4);
@@ -126,15 +126,15 @@ AWS_STATIC_ASSERT(sizeof(int8_t) == 1);
 AWS_STATIC_ASSERT(sizeof(uintptr_t) == sizeof(void *));
 AWS_STATIC_ASSERT(sizeof(intptr_t) == sizeof(void *));
 AWS_STATIC_ASSERT(sizeof(char) == 1);
-#    endif
+#endif
 
-#    include <aws/common/error.h>
+#include <aws/common/error.h>
 
-#    if defined(_MSC_VER)
-#        define AWS_THREAD_LOCAL __declspec(thread)
-#    else
-#        define AWS_THREAD_LOCAL __thread
-#    endif
+#if defined(_MSC_VER)
+#    define AWS_THREAD_LOCAL __declspec(thread)
+#else
+#    define AWS_THREAD_LOCAL __thread
+#endif
 
 /* Allocator structure. An instance of this will be passed around for anything needing memory allocation */
 struct aws_allocator {
@@ -146,19 +146,19 @@ struct aws_allocator {
 };
 
 /* Avoid pulling in CoreFoundation headers in a header file. */
-#    ifdef __MACH__
+#ifdef __MACH__
 struct __CFAllocator;
 typedef const struct __CFAllocator *CFAllocatorRef;
-#    endif
+#endif
 
-#    ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-#    endif
+#endif
 
 AWS_COMMON_API
-struct aws_allocator *aws_default_allocator();
+struct aws_allocator *aws_default_allocator(void);
 
-#    ifdef __MACH__
+#ifdef __MACH__
 /**
  * Wraps a CFAllocator around aws_allocator. For Mac only. Use this anytime you need a CFAllocatorRef for interacting
  * with Apple Frameworks. Unfortunately, it allocates memory so we can't make it static file scope, be sure to call
@@ -172,7 +172,7 @@ CFAllocatorRef aws_wrapped_cf_allocator_new(struct aws_allocator *allocator);
  */
 AWS_COMMON_API
 void aws_wrapped_cf_allocator_destroy(CFAllocatorRef allocator);
-#    endif
+#endif
 
 /*
  * Returns at least `size` of memory ready for usage or returns NULL on failure.
@@ -222,48 +222,48 @@ int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize,
 AWS_COMMON_API
 void aws_load_error_strings(void);
 
-#    ifdef __cplusplus
+#ifdef __cplusplus
 }
-#    endif
+#endif
 
-#    define AWS_CACHE_LINE 64
+#define AWS_CACHE_LINE 64
 
-#    if defined(_MSC_VER)
-#        define AWS_ALIGN(alignment) __declspec(align(alignment))
-#        define AWS_LIKELY(x) x
-#        define AWS_UNLIKELY(x) x
-#        define AWS_FORCE_INLINE __forceinline
-#    else
-#        if defined(__GNUC__) || defined(__clang__)
-#            define AWS_ALIGN(alignment) __attribute__((aligned(alignment)))
-#            define AWS_TYPE_OF(a) __typeof__(a)
-#            define AWS_LIKELY(x) __builtin_expect(!!(x), 1)
-#            define AWS_UNLIKELY(x) __builtin_expect(!!(x), 0)
-#            define AWS_FORCE_INLINE __attribute__((always_inline))
-#        endif
+#if defined(_MSC_VER)
+#    define AWS_ALIGN(alignment) __declspec(align(alignment))
+#    define AWS_LIKELY(x) x
+#    define AWS_UNLIKELY(x) x
+#    define AWS_FORCE_INLINE __forceinline
+#else
+#    if defined(__GNUC__) || defined(__clang__)
+#        define AWS_ALIGN(alignment) __attribute__((aligned(alignment)))
+#        define AWS_TYPE_OF(a) __typeof__(a)
+#        define AWS_LIKELY(x) __builtin_expect(!!(x), 1)
+#        define AWS_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#        define AWS_FORCE_INLINE __attribute__((always_inline))
 #    endif
+#endif
 
 /* If this is C++, restrict isn't supported. If this is not at least C99 on gcc and clang, it isn't supported.
  * If visual C++ building in C mode, the restrict definition is __restrict.
  * This just figures all of that out based on who's including this header file. */
-#    if defined(__cplusplus)
-#        define AWS_RESTRICT
+#if defined(__cplusplus)
+#    define AWS_RESTRICT
+#else
+#    if defined(_MSC_VER)
+#        define AWS_RESTRICT __restrict
 #    else
-#        if defined(_MSC_VER)
-#            define AWS_RESTRICT __restrict
+#        if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#            define AWS_RESTRICT restrict
 #        else
-#            if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#                define AWS_RESTRICT restrict
-#            else
-#                define AWS_RESTRICT
-#            endif
+#            define AWS_RESTRICT
 #        endif
 #    endif
+#endif
 
-#    define AWS_CACHE_ALIGN AWS_ALIGN(AWS_CACHE_LINE)
+#define AWS_CACHE_ALIGN AWS_ALIGN(AWS_CACHE_LINE)
 
-#    define AWS_OP_SUCCESS (0)
-#    define AWS_OP_ERR (-1)
+#define AWS_OP_SUCCESS (0)
+#define AWS_OP_ERR (-1)
 
 enum aws_common_error {
     AWS_ERROR_SUCCESS = 0,
@@ -306,16 +306,16 @@ enum aws_common_error {
  * the compiler will not optimize away this zeroing operation.
  */
 AWS_STATIC_IMPL void aws_secure_zero(void *pBuf, size_t bufsize) {
-#    if defined(_MSC_VER)
+#if defined(_MSC_VER)
     SecureZeroMemory(pBuf, bufsize);
-#    else
+#else
     /* We cannot use memset_s, even on a C11 compiler, because that would require
      * that __STDC_WANT_LIB_EXT1__ be defined before the _first_ inclusion of string.h.
      *
      * We'll try to work around this by using inline asm on GCC-like compilers,
      * and by exposing the buffer pointer in a volatile local pointer elsewhere.
      */
-#        if defined(__GNUC__) || defined(__clang__)
+#    if defined(__GNUC__) || defined(__clang__)
     memset(pBuf, 0, bufsize);
     /* This inline asm serves to convince the compiler that the buffer is (somehow) still
      * used after the zero, and therefore that the optimizer can't eliminate the memset.
@@ -332,26 +332,26 @@ AWS_STATIC_IMPL void aws_secure_zero(void *pBuf, size_t bufsize) {
                           * seems to optimize a zero of a stack buffer without it.
                           */
                          : "memory");
-#        else  // not GCC/clang
+#    else  // not GCC/clang
     /* We don't have access to inline asm, since we're on a non-GCC platform. Move the pointer
      * through a volatile pointer in an attempt to confuse the optimizer.
      */
     volatile void *pVolBuf = pBuf;
     memset(pVolBuf, 0, bufsize);
-#        endif // #else not GCC/clang
-#    endif     // #else not windows
+#    endif // #else not GCC/clang
+#endif     // #else not windows
 }
 
-#    define AWS_ZERO_STRUCT(object)                                                                                    \
+#define AWS_ZERO_STRUCT(object)                                                                                    \
         do {                                                                                                           \
             memset(&(object), 0, sizeof(object));                                                                      \
         } while (0)
-#    define AWS_ZERO_ARRAY(array)                                                                                      \
+#define AWS_ZERO_ARRAY(array)                                                                                      \
         do {                                                                                                           \
             memset((void *)array, 0, sizeof(array));                                                                   \
         } while (0)
-#    define AWS_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+#define AWS_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
-#    define AWS_ENABLE_HW_OPTIMIZATION 1
+#define AWS_ENABLE_HW_OPTIMIZATION 1
 
 #endif /* AWS_COMMON_COMMON_H */

--- a/include/aws/common/system_info.h
+++ b/include/aws/common/system_info.h
@@ -24,7 +24,7 @@ extern "C" {
 
 /* Returns the number of online processors available for usage. */
 AWS_COMMON_API
-size_t aws_system_info_processor_count();
+size_t aws_system_info_processor_count(void);
 
 #ifdef __cplusplus
 }

--- a/include/aws/common/thread.h
+++ b/include/aws/common/thread.h
@@ -22,7 +22,11 @@
 #    include <pthread.h>
 #endif
 
-enum aws_thread_detach_state { AWS_THREAD_NOT_CREATED = 1, AWS_THREAD_JOINABLE, AWS_THREAD_JOIN_COMPLETED };
+enum aws_thread_detach_state {
+    AWS_THREAD_NOT_CREATED = 1,
+    AWS_THREAD_JOINABLE,
+    AWS_THREAD_JOIN_COMPLETED,
+};
 
 struct aws_thread_options {
     size_t stack_size;
@@ -99,7 +103,7 @@ void aws_thread_clean_up(struct aws_thread *thread);
  * returns the thread id of the calling thread.
  */
 AWS_COMMON_API
-uint64_t aws_thread_current_thread_id();
+uint64_t aws_thread_current_thread_id(void);
 
 /**
  * Sleeps the current thread by nanos.

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -434,7 +434,7 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
 #        define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #    endif
 
-static inline int enable_vt_mode() {
+static inline int enable_vt_mode(void) {
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     if (hOut == INVALID_HANDLE_VALUE) {
         return AWS_OP_ERR;
@@ -454,7 +454,7 @@ static inline int enable_vt_mode() {
 
 #else
 
-static inline int enable_vt_mode() {
+static inline int enable_vt_mode(void) {
     return AWS_OP_ERR;
 }
 

--- a/source/arch/cpuid.c
+++ b/source/arch/cpuid.c
@@ -36,7 +36,7 @@
 static int cpuid_state = 2;
 
 #ifdef HAVE_MSVC_CPUIDEX
-static bool msvc_check_avx2() {
+static bool msvc_check_avx2(void) {
     int cpuInfo[4];
 
     /* Check maximum supported function */
@@ -58,7 +58,7 @@ static bool msvc_check_avx2() {
 }
 #endif
 
-bool aws_common_private_has_avx2() {
+bool aws_common_private_has_avx2(void) {
     if (AWS_LIKELY(cpuid_state == 0))
         return true;
     if (AWS_LIKELY(cpuid_state == 1))

--- a/source/common.c
+++ b/source/common.c
@@ -50,7 +50,7 @@ static struct aws_allocator default_allocator = {
     .mem_realloc = s_default_realloc,
 };
 
-struct aws_allocator *aws_default_allocator() {
+struct aws_allocator *aws_default_allocator(void) {
     return &default_allocator;
 }
 

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -22,7 +22,7 @@
 #ifdef USE_SIMD_ENCODING
 size_t aws_common_private_base64_decode_sse41(const unsigned char *in, unsigned char *out, size_t len);
 size_t aws_common_private_base64_encode_sse41(const unsigned char *in, unsigned char *out, size_t len);
-bool aws_common_private_has_avx2();
+bool aws_common_private_has_avx2(void);
 #else
 /*
  * When AVX2 compilation is unavailable, we use these stubs to fall back to the pure-C decoder.

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -47,7 +47,7 @@ static inline size_t aws_common_private_base64_encode_sse41(
     (void)len;
     return (size_t)-1; /* unreachable */
 }
-static inline bool aws_common_private_has_avx2() {
+static inline bool aws_common_private_has_avx2(void) {
     return false;
 }
 #endif

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -31,7 +31,7 @@
  * macro. */
 #include <aws/common/private/lookup3.c>
 
-static void s_suppress_unused_lookup3_func_warnings() {
+static void s_suppress_unused_lookup3_func_warnings(void) {
     /* We avoid making changes to lookup3 if we can avoid it, but since it has functions
      * we're not using, reference them somewhere to suppress the unused function warning.
      */

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -160,7 +160,7 @@ int aws_thread_join(struct aws_thread *thread) {
     return AWS_OP_SUCCESS;
 }
 
-uint64_t aws_thread_current_thread_id() {
+uint64_t aws_thread_current_thread_id(void) {
     return (uint64_t)pthread_self();
 }
 

--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -99,7 +99,7 @@ void aws_thread_clean_up(struct aws_thread *thread) {
     thread->thread_handle = 0;
 }
 
-uint64_t aws_thread_current_thread_id() {
+uint64_t aws_thread_current_thread_id(void) {
     return (uint64_t)GetCurrentThreadId();
 }
 

--- a/tests/assert_test.c
+++ b/tests/assert_test.c
@@ -51,7 +51,7 @@ int begin_test(int *index, const char *testname, const char *file, int line, int
 
 static int side_effect_ctr = 0;
 
-int side_effect() {
+int side_effect(void) {
     if (side_effect_ctr++) {
         fprintf(
             stderr,
@@ -162,7 +162,7 @@ int test_asserts(int *index) {
     return NO_MORE_TESTS;
 }
 
-void reset() {
+void reset(void) {
     g_cur_testname = "UNKNOWN";
     g_cur_file = "UNKNOWN";
     g_bail_out = 0;

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -314,7 +314,7 @@ static int run_races(
     return 0;
 }
 
-static void notify_race_completed() {
+static void notify_race_completed(void) {
     if (aws_mutex_lock(&done_mutex)) {
         abort();
     }

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -443,7 +443,7 @@ static void s_destroy_value_fn(void *value) {
     ++s_value_removal_counter;
 }
 
-static void s_reset_destroy_ck() {
+static void s_reset_destroy_ck(void) {
     s_key_removal_counter = 0;
     s_value_removal_counter = 0;
     s_last_removed_key = NULL;
@@ -773,7 +773,7 @@ static int s_qsort_churn_entry(const void *a, const void *b) {
     return 0;
 }
 
-static long s_timestamp() {
+static long s_timestamp(void) {
     uint64_t time = 0;
     aws_sys_clock_get_ticks(&time);
     return (long)(time / 1000);


### PR DESCRIPTION
This warning is on when building Python extensions, so I'd like to turn it on globally to prevent build noise.

Also, I highly suggest disabling whitespace diffs on common.h.

**NOTE** This may break downstream code, however it may be disabled by calling `target_compile_options(${target} PRIVATE -Wno-strict-prototypes)` after `aws_set_common_properties`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
