### PR TITLE
Default Allocator Leak Checker

### DIFF
--- a/include/aws/common/mutex.h
+++ b/include/aws/common/mutex.h
@@ -16,7 +16,7 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/common.h>
+#include <aws/common/exports.h>
 #ifndef _WIN32
 #    include <pthread.h>
 #endif

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -53,13 +53,13 @@ struct memory_test_tracker {
     void *blob;
 };
 
-static inline void *s_mem_acquire_malloc(struct aws_allocator *allocator, size_t size) {
+static inline void *s_mem_acquire_malloc(struct aws_allocator *allocator, size_t size, const char *file, int line) {
     struct memory_test_allocator *test_allocator = (struct memory_test_allocator *)allocator->impl;
 
     aws_mutex_lock(&test_allocator->mutex);
     test_allocator->allocated += size;
     struct memory_test_tracker *memory =
-        (struct memory_test_tracker *)malloc(size + sizeof(struct memory_test_tracker));
+        (struct memory_test_tracker *)aws_default_malloc(allocator, size + sizeof(struct memory_test_tracker), file, line);
 
     if (!memory) {
         return NULL;
@@ -79,7 +79,7 @@ static inline void s_mem_release_free(struct aws_allocator *allocator, void *ptr
     aws_mutex_lock(&test_allocator->mutex);
     test_allocator->freed += memory->size;
     aws_mutex_unlock(&test_allocator->mutex);
-    free(memory);
+    aws_default_free(allocator, memory);
 }
 
 /** Prints a message to stdout using printf format that appends the function, file and line number.

--- a/source/common.c
+++ b/source/common.c
@@ -19,7 +19,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-#ifdef AWS_ALLOCATOR_LEAKCHECK
+#ifdef AWS_DEFAULT_ALLOCATOR_LEAKCHECK
 #   include <stdio.h>
 #endif
 

--- a/tests/realloc_test.c
+++ b/tests/realloc_test.c
@@ -23,8 +23,10 @@
 
 static size_t s_alloc_counter, s_alloc_total_size, s_call_ct_malloc, s_call_ct_free, s_call_ct_realloc;
 
-static void *s_test_alloc_acquire(struct aws_allocator *allocator, size_t size) {
+static void *s_test_alloc_acquire(struct aws_allocator *allocator, size_t size, const char *file, int line) {
     (void)allocator;
+    (void)file;
+    (void)line;
 
     s_alloc_counter++;
     s_call_ct_malloc++;
@@ -52,8 +54,10 @@ static void s_test_alloc_release(struct aws_allocator *allocator, void *ptr) {
 
 static size_t s_original_size, s_reported_oldsize;
 
-static void *s_test_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
+static void *s_test_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize, const char *file, int line) {
     (void)allocator;
+    (void)file;
+    (void)line;
 
     uint8_t *buf = ptr;
     buf -= 16;
@@ -78,17 +82,21 @@ static void *s_test_realloc(struct aws_allocator *allocator, void *ptr, size_t o
     return buf + 16;
 }
 
-static void *s_test_malloc_failing(struct aws_allocator *allocator, size_t size) {
+static void *s_test_malloc_failing(struct aws_allocator *allocator, size_t size, const char *file, int line) {
     (void)allocator;
     (void)size;
+    (void)file;
+    (void)line;
     return NULL;
 }
 
-static void *s_test_realloc_failing(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
+static void *s_test_realloc_failing(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize, const char *file, int line) {
     (void)allocator;
     (void)ptr;
     (void)oldsize;
     (void)newsize;
+    (void)file;
+    (void)line;
     return NULL;
 }
 

--- a/tests/task_scheduler_test.c
+++ b/tests/task_scheduler_test.c
@@ -305,12 +305,12 @@ struct oom_allocator_impl {
     size_t num_allocations_rejected;
 };
 
-static void *s_oom_allocator_acquire(struct aws_allocator *allocator, size_t size) {
+static void *s_oom_allocator_acquire(struct aws_allocator *allocator, size_t size, const char *file, int line) {
     struct oom_allocator_impl *impl = allocator->impl;
     void *mem = NULL;
 
     if (impl->num_allocations < impl->num_allocations_limit) {
-        mem = aws_mem_acquire(impl->alloc, size);
+        mem = aws_mem_acquire_implementation(impl->alloc, size, file, line);
         if (mem) {
             impl->num_allocations++;
         }


### PR DESCRIPTION
Implemented a quick and dirty leak checker for the default allocator in aws-c-common. Useful for grabbing file/line pairs, even Apple machines (where valgrind/sanitizers can't perform leak checking).

Just throwing this out here in case anyone else thinks it might be good to add to common. Otherwise it can just live in this branch, and I'll personally refer to it as needed.

Everything is compiled away by default, except for two extra parameters passed to `aws_mem_acquire` and `aws_mem_realloc` (one for `const char *file` and one for `int line`). To enable the leak checking `AWS_DEFAULT_ALLOCATOR_LEAKCHECK` can be defined.

There's a function called `aws_mem_print_leaks_from_default_allocator`, which prints to `stderr` like so:

```
LEAKED 280 bytes from file "/Users/randgaul/Desktop/work/aws-c-common/source/common.c" at line 269 from address 0x6120000004e8.
LEAKED 280 bytes from file "/Users/randgaul/Desktop/work/aws-c-common/source/common.c" at line 269 from address 0x612000000368.
LEAKED 120 bytes from file "/Users/randgaul/Desktop/work/aws-c-common/source/common.c" at line 269 from address 0x60e000000228.
LEAKED 1096 bytes from file "/Users/randgaul/Desktop/work/aws-c-common/source/common.c" at line 269 from address 0x6190000023a8.
LEAKED 664 bytes from file "/Users/randgaul/Desktop/work/aws-c-common/source/common.c" at line 269 from address 0x6170000000a8.
WARNING: Memory leaks detected (see above).
```

And if no leaks are there, prints somethiing like: `SUCCESS: No memory leaks detected.`

I considered implementing leak checking in a way such that even user-provided allocators could use the leak printing function -- but this turned out to not really be worth mangling the allocator API. Instead, just providing this function for the default allocator was good enough for my own uses.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
