### PR TITLE
[FIF] Add AWS_EXTERN_C_BEGIN & AWS_EXTERN_C_END macros

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*,-readability-magic-numbers'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*(?<!lookup3.c)$'
 FormatStyle: 'file'

--- a/include/aws/common/array_list.h
+++ b/include/aws/common/array_list.h
@@ -35,9 +35,7 @@ struct aws_array_list {
  */
 typedef int(aws_array_list_comparator_fn)(const void *a, const void *b);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes an array list with an array of size initial_item_allocation * item_size. In this mode, the array size
@@ -178,8 +176,6 @@ void aws_array_list_swap(struct aws_array_list *list, size_t a, size_t b);
 AWS_COMMON_API
 void aws_array_list_sort(struct aws_array_list *list, aws_array_list_comparator_fn *compare_fn);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_ARRAY_LIST_H */

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -47,9 +47,7 @@ struct aws_byte_cursor {
     uint8_t *ptr;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 AWS_COMMON_API
 int aws_byte_buf_init(struct aws_allocator *allocator, struct aws_byte_buf *buf, size_t capacity);
@@ -168,9 +166,7 @@ bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_c
 AWS_COMMON_API
 bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *a, const struct aws_byte_buf *b);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 /**
  * For creating a byte buffer from a null-terminated string literal.

--- a/include/aws/common/clock.h
+++ b/include/aws/common/clock.h
@@ -54,9 +54,7 @@ AWS_STATIC_IMPL uint64_t aws_timestamp_convert(
     }
 }
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 /**
  * Get ticks in nanoseconds (usually 100 nanosecond precision) on the high resolution clock (most-likely TSC). This
  * clock has no bearing on the actual system time. On success, timestamp will be set.
@@ -72,8 +70,6 @@ int aws_high_res_clock_get_ticks(uint64_t *timestamp);
 AWS_COMMON_API
 int aws_sys_clock_get_ticks(uint64_t *timestamp);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_CLOCK_H */

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -128,6 +128,14 @@ AWS_STATIC_ASSERT(sizeof(intptr_t) == sizeof(void *));
 AWS_STATIC_ASSERT(sizeof(char) == 1);
 #endif
 
+#ifdef __cplusplus
+#    define AWS_EXTERN_C_BEGIN extern "C" {
+#    define AWS_EXTERN_C_END }
+#else
+#    define AWS_EXTERN_C_BEGIN
+#    define AWS_EXTERN_C_END
+#endif
+
 #include <aws/common/error.h>
 
 #if defined(_MSC_VER)
@@ -151,9 +159,7 @@ struct __CFAllocator;
 typedef const struct __CFAllocator *CFAllocatorRef;
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 AWS_COMMON_API
 struct aws_allocator *aws_default_allocator(void);
@@ -222,9 +228,7 @@ int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize,
 AWS_COMMON_API
 void aws_load_error_strings(void);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #define AWS_CACHE_LINE 64
 

--- a/include/aws/common/condition_variable.h
+++ b/include/aws/common/condition_variable.h
@@ -48,9 +48,7 @@ struct aws_condition_variable {
         { .condition_handle = PTHREAD_COND_INITIALIZER }
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes a condition variable.
@@ -115,8 +113,5 @@ int aws_condition_variable_wait_for_pred(
     aws_condition_predicate_fn *pred,
     void *pred_ctx);
 
-#ifdef __cplusplus
-}
-#endif
-
+AWS_EXTERN_C_END
 #endif /* AWS_COMMON_CONDITION_VARIABLE_H */

--- a/include/aws/common/encoding.h
+++ b/include/aws/common/encoding.h
@@ -22,9 +22,7 @@
 
 #include <memory.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /*
  * computes the length necessary to store the result of aws_hex_encode().
@@ -83,9 +81,7 @@ int aws_base64_compute_decoded_len(const char *input, size_t len, size_t *decode
 AWS_COMMON_API
 int aws_base64_decode(const struct aws_byte_buf *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 /* Add a 64 bit unsigned integer to the buffer, ensuring network - byte order
  * Assumes the buffer size is at least 8 bytes.

--- a/include/aws/common/error.h
+++ b/include/aws/common/error.h
@@ -40,9 +40,7 @@ struct aws_error_info_list {
 
 typedef void(aws_error_handler_fn)(int err, void *ctx);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /*
  * Returns the latest error code on the current thread, or 0 if none have
@@ -112,8 +110,6 @@ aws_error_handler_fn *aws_set_thread_local_error_handler_fn(aws_error_handler_fn
 AWS_COMMON_API
 void aws_register_error_info(const struct aws_error_info_list *error_info);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_ERROR_H */

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -109,9 +109,7 @@ typedef bool(aws_equals_fn)(const void *a, const void *b);
  */
 typedef void(aws_hash_element_destroy_fn)(void *key_or_value);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes a hash map with initial capacity for 'size' elements
@@ -329,8 +327,6 @@ bool aws_string_eq(const void *a, const void *b);
 AWS_COMMON_API
 bool aws_ptr_eq(const void *a, const void *b);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_HASH_TABLE_H */

--- a/include/aws/common/lru_cache.h
+++ b/include/aws/common/lru_cache.h
@@ -31,9 +31,7 @@ struct aws_lru_cache {
     size_t max_items;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes the cache. Sets up the underlying hash table and linked list.
@@ -107,8 +105,6 @@ void *aws_lru_cache_get_mru_element(const struct aws_lru_cache *cache);
 AWS_COMMON_API
 size_t aws_lru_cache_get_element_count(const struct aws_lru_cache *cache);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_LRU_CACHE_H */

--- a/include/aws/common/mutex.h
+++ b/include/aws/common/mutex.h
@@ -37,9 +37,7 @@ struct aws_mutex {
         { .mutex_handle = PTHREAD_MUTEX_INITIALIZER }
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes a new platform instance of mutex.
@@ -75,8 +73,6 @@ int aws_mutex_try_lock(struct aws_mutex *mutex);
 AWS_COMMON_API
 int aws_mutex_unlock(struct aws_mutex *mutex);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_MUTEX_H */

--- a/include/aws/common/posix/common.inl
+++ b/include/aws/common/posix/common.inl
@@ -20,9 +20,7 @@
 
 #include <errno.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 static inline int aws_private_convert_and_raise_error_code(int error_code) {
     switch (error_code) {
@@ -43,8 +41,6 @@ static inline int aws_private_convert_and_raise_error_code(int error_code) {
     }
 }
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_POSIX_COMMON_INL */

--- a/include/aws/common/posix/rw_lock.inl
+++ b/include/aws/common/posix/rw_lock.inl
@@ -20,9 +20,7 @@
 
 #include <aws/common/posix/common.inl>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 AWS_STATIC_IMPL int aws_rw_lock_init(struct aws_rw_lock *lock) {
 
@@ -64,8 +62,6 @@ AWS_STATIC_IMPL int aws_rw_lock_wunlock(struct aws_rw_lock *lock) {
     return aws_private_convert_and_raise_error_code(pthread_rwlock_unlock(&lock->lock_handle));
 }
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_POSIX_RW_LOCK_INL */

--- a/include/aws/common/priority_queue.h
+++ b/include/aws/common/priority_queue.h
@@ -39,9 +39,7 @@ struct aws_priority_queue {
     struct aws_array_list container;
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes a priority queue struct for use. This mode will grow memory automatically (exponential model)
@@ -112,8 +110,6 @@ size_t aws_priority_queue_size(const struct aws_priority_queue *queue);
 AWS_COMMON_API
 size_t aws_priority_queue_capacity(const struct aws_priority_queue *queue);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_PRIORITY_QUEUE_H */

--- a/include/aws/common/rw_lock.h
+++ b/include/aws/common/rw_lock.h
@@ -39,9 +39,7 @@ struct aws_rw_lock {
         { .lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes a new platform instance of mutex.
@@ -75,9 +73,7 @@ AWS_STATIC_IMPL int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
 AWS_STATIC_IMPL int aws_rw_lock_runlock(struct aws_rw_lock *lock);
 AWS_STATIC_IMPL int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #ifdef _WIN32
 #    include <aws/common/windows/rw_lock.inl>

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -66,9 +66,7 @@ AWS_STATIC_IMPL bool aws_string_eq_byte_buf(const struct aws_string *str, const 
     return (!memcmp(aws_string_bytes(str), buf->buffer, buf->len));
 }
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Constructor functions which copy data from null-terminated C-string or array of unsigned or signed characters.
@@ -112,9 +110,7 @@ int aws_string_compare(const struct aws_string *a, const struct aws_string *b);
 AWS_COMMON_API
 int aws_array_list_comparator_string(const void *a, const void *b);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 /**
  * Defines a (static const struct aws_string *) with name specified in first

--- a/include/aws/common/system_info.h
+++ b/include/aws/common/system_info.h
@@ -18,16 +18,12 @@
 
 #include <aws/common/common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /* Returns the number of online processors available for usage. */
 AWS_COMMON_API
 size_t aws_system_info_processor_count(void);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_SYSTEM_INFO_H */

--- a/include/aws/common/task_scheduler.h
+++ b/include/aws/common/task_scheduler.h
@@ -56,9 +56,7 @@ struct aws_task_scheduler {
     struct aws_linked_list asap_list;      /* Tasks scheduled to run as soon as possible */
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes a task scheduler instance.
@@ -107,8 +105,6 @@ void aws_task_scheduler_schedule_future(
 AWS_COMMON_API
 void aws_task_scheduler_run_all(struct aws_task_scheduler *scheduler, uint64_t current_time);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_TASK_SCHEDULER_H */

--- a/include/aws/common/thread.h
+++ b/include/aws/common/thread.h
@@ -43,9 +43,7 @@ struct aws_thread {
 #endif
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * Returns an instance of system default thread options.
@@ -111,8 +109,6 @@ uint64_t aws_thread_current_thread_id(void);
 AWS_COMMON_API
 void aws_thread_current_sleep(uint64_t nanos);
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_THREAD_H */

--- a/include/aws/common/windows/rw_lock.inl
+++ b/include/aws/common/windows/rw_lock.inl
@@ -16,9 +16,7 @@
  * permissions and limitations under the License.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 AWS_STATIC_IMPL int aws_rw_lock_init(struct aws_rw_lock *lock) {
 
@@ -75,8 +73,6 @@ AWS_STATIC_IMPL int aws_rw_lock_wunlock(struct aws_rw_lock *lock) {
     return AWS_OP_SUCCESS;
 }
 
-#ifdef __cplusplus
-}
-#endif
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_WINDOWS_RW_LOCK_INL */

--- a/source/arch/cpuid.c
+++ b/source/arch/cpuid.c
@@ -59,10 +59,12 @@ static bool msvc_check_avx2(void) {
 #endif
 
 bool aws_common_private_has_avx2(void) {
-    if (AWS_LIKELY(cpuid_state == 0))
+    if (AWS_LIKELY(cpuid_state == 0)) {
         return true;
-    if (AWS_LIKELY(cpuid_state == 1))
+    }
+    if (AWS_LIKELY(cpuid_state == 1)) {
         return false;
+    }
 
     /* Provide a hook for testing fallbacks and benchmarking */
     const char *env_avx2_enabled = getenv("AWS_COMMON_AVX2");


### PR DESCRIPTION
Makes typos less common, reduces ugly preproc directives.

No functional changes, this should not break any code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
