### PR TITLE
Fix spurious uninitialized variable warning

### DIFF
--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -26,7 +26,7 @@ static void s_sift_down(struct aws_priority_queue *queue) {
     size_t root = 0;
     size_t left = LEFT_OF(root);
     size_t len = aws_array_list_length(&queue->container);
-    void *right_item, *left_item, *root_item;
+    void *right_item = NULL, *left_item = NULL, *root_item = NULL;
 
     while (left < len) {
         aws_array_list_get_at_ptr(&queue->container, &left_item, left);


### PR DESCRIPTION
GCC 7.3.0 believes that the right/left/root variables may be uninitialized
after the array_list inlining changes. These can't actually be uninitialized as
we explicitly check array length first, but just to make it happy, initialize
these variables to NULL explicitly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
