### PR TITLE
MSVC configuration fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,9 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC ${PLATFORM_LIBS})
 
 # Our ABI is not yet stable
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES SOVERSION 0unstable)
-target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE "-fvisibility=hidden")
+if (NOT MSVC)
+    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE "-fvisibility=hidden")
+endif()
 
 target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,9 +113,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC ${PLATFORM_LIBS})
 
 # Our ABI is not yet stable
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES SOVERSION 0unstable)
-if (NOT MSVC)
-    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE "-fvisibility=hidden")
-endif()
 
 target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -24,7 +24,7 @@ function(aws_set_common_properties target)
     cmake_parse_arguments(SET_PROPERTIES "${options}" "" "" ${ARGN})
 
     if(MSVC)
-        list(APPEND AWS_C_FLAGS /W4 /WX)
+        list(APPEND AWS_C_FLAGS /W4 /WX /MP)
         # /volatile:iso relaxes some implicit memory barriers that MSVC normally applies for volatile accesses
         # Since we want to be compatible with user builds using /volatile:iso, use it for the tests.
         list(APPEND AWS_C_FLAGS /volatile:iso)


### PR DESCRIPTION
Removed -fvisibility=hidden from MSVC compile flags

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
