### PR TITLE
CBMC verification runs: compute coverage and generate HTML reports

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_init_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_init_dynamic/cbmc-batch.yaml
@@ -2,5 +2,3 @@ jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_init_dynamic_verify"
 goto: proofs.goto
 expected: "SUCCESSFUL"
-coverage: false
-report: false

--- a/.cbmc-batch/jobs/aws_array_list_init_static/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_init_static/cbmc-batch.yaml
@@ -2,5 +2,3 @@ jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_init_static_verify"
 goto: proofs.goto
 expected: "SUCCESSFUL"
-coverage: false
-report: false

--- a/.cbmc-batch/jobs/aws_array_list_push_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/cbmc-batch.yaml
@@ -2,5 +2,3 @@ jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_push_back_verify;--unwindset;strlen.0:33,memcpy.0:33,__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
 goto: proofs.goto
 expected: "SUCCESSFUL"
-coverage: false
-report: false

--- a/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
@@ -2,5 +2,3 @@ jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_array_list_set_at_verify;--unwindset;strlen.0:33,memcpy.0:33,__builtin___memcpy_chk.0:33,aws_mem_release:1;--unwinding-assertions"
 goto: proofs.goto
 expected: "SUCCESSFUL"
-coverage: false
-report: false

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
@@ -2,5 +2,3 @@ jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_byte_buf_from_c_str_verify;--unwindset;strlen.0:33;--unwinding-assertions"
 goto: proofs.goto
 expected: "SUCCESSFUL"
-coverage: false
-report: false

--- a/.cbmc-batch/jobs/aws_byte_buf_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_init/cbmc-batch.yaml
@@ -2,5 +2,3 @@ jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_byte_buf_init_verify"
 goto: proofs.goto
 expected: "SUCCESSFUL"
-coverage: false
-report: false


### PR DESCRIPTION
Enables report generation for all verification tasks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
