### PR TITLE
Warn about implicit conversions that result in precision loss

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -44,6 +44,11 @@ function(aws_set_common_properties target)
 
         # Avoid exporting symbols we don't intend to export
         list(APPEND AWS_C_FLAGS -fvisibility=hidden)
+
+        # Warn about implicit conversions that would result in precision loss (MSVC warns about those anyway with /W4)
+        # Without -Wno-sign-conversion, this becomes too noisy.
+        list(APPEND AWS_C_FLAGS -Wconversion -Wno-sign-conversion)
+
     endif()
 
     check_include_file(stdint.h HAS_STDINT)

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -184,7 +184,7 @@ int aws_hex_decode(const struct aws_byte_buf *AWS_RESTRICT to_decode, struct aws
             return aws_raise_error(AWS_ERROR_INVALID_HEX_STR);
         }
 
-        uint8_t value = high_value << 4;
+        uint8_t value = (uint8_t)(high_value << 4);
         value |= low_value;
         output->buffer[written++] = value;
     }

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -56,7 +56,7 @@ struct hash_table_state {
     size_t size, entry_count;
     size_t max_load;
     /* We AND a hash value with mask to get the slot index */
-    uint64_t mask;
+    size_t mask;
     double max_load_factor;
     /* actually variable length */
     struct hash_table_entry slots[1];
@@ -212,7 +212,7 @@ static int s_update_template_size(struct hash_table_state *template, size_t expe
     }
 
     template->size = size;
-    template->max_load = (size_t)(template->max_load_factor * template->size);
+    template->max_load = (size_t)(template->max_load_factor * (double)template->size);
     if (template->max_load >= size) {
         template->max_load = size - 1;
     }

--- a/source/posix/condition_variable.c
+++ b/source/posix/condition_variable.c
@@ -87,7 +87,8 @@ int aws_condition_variable_wait_for(
 
     struct timespec ts;
     uint64_t remainder = 0;
-    ts.tv_sec = (time_t)aws_timestamp_convert((uint64_t)time_to_wait, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, &remainder);
+    ts.tv_sec =
+        (time_t)aws_timestamp_convert((uint64_t)time_to_wait, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, &remainder);
     ts.tv_nsec = (long)remainder;
 
     int err_code = pthread_cond_timedwait(&condition_variable->condition_handle, &mutex->mutex_handle, &ts);

--- a/source/posix/condition_variable.c
+++ b/source/posix/condition_variable.c
@@ -87,8 +87,8 @@ int aws_condition_variable_wait_for(
 
     struct timespec ts;
     uint64_t remainder = 0;
-    ts.tv_sec = aws_timestamp_convert((uint64_t)time_to_wait, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, &remainder);
-    ts.tv_nsec = remainder;
+    ts.tv_sec = (time_t)aws_timestamp_convert((uint64_t)time_to_wait, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, &remainder);
+    ts.tv_nsec = (long)remainder;
 
     int err_code = pthread_cond_timedwait(&condition_variable->condition_handle, &mutex->mutex_handle, &ts);
 

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -131,7 +131,7 @@ cleanup:
 }
 
 uint64_t aws_thread_get_id(struct aws_thread *thread) {
-    return (uint64_t)thread->thread_id;
+    return (uintptr_t)thread->thread_id;
 }
 
 enum aws_thread_detach_state aws_thread_get_detach_state(struct aws_thread *thread) {
@@ -161,16 +161,16 @@ int aws_thread_join(struct aws_thread *thread) {
 }
 
 uint64_t aws_thread_current_thread_id(void) {
-    return (uint64_t)pthread_self();
+    return (uintptr_t)pthread_self();
 }
 
 void aws_thread_current_sleep(uint64_t nanos) {
     uint64_t nano = 0;
-    uint64_t seconds = aws_timestamp_convert(nanos, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, &nano);
+    time_t seconds = (time_t)aws_timestamp_convert(nanos, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, &nano);
 
     struct timespec tm = {
         .tv_sec = seconds,
-        .tv_nsec = nano,
+        .tv_nsec = (long)nano,
     };
     struct timespec output;
 

--- a/tests/secure_zero_test.c
+++ b/tests/secure_zero_test.c
@@ -34,7 +34,7 @@ static int s_test_secure_zero_fn(struct aws_allocator *allocator, void *ctx) {
         volatile char *ptr = buf;
         ptr += i;
 
-        *ptr = 0xDD;
+        *ptr = (unsigned char)0xDD;
     }
 
     aws_secure_zero(buf, sizeof(buf) / 2);


### PR DESCRIPTION
*Description of changes:*

MSVC warns about those anyway with /W4. Having them pop up in POSIX
environments saves us finding out about the warning from CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
