### PR TITLE
Add a CMake option to disable some of the math compiler intrinsic calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,6 @@ endif()
 
 if (ENABLE_HW_OPTIMIZATION)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -DAWS_ENABLE_HW_OPTIMIZATION)
-    message(STATUS "Hardware optimizations are enabled.")
 endif()
 
 # Preserve subdirectories when installing headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ file(GLOB AWS_COMMON_SRC
         )
 
 option(PERFORM_HEADER_CHECK "Performs compile-time checks that each header can be included independently. Requires a C++ compiler.")
+option(ENABLE_HW_OPTIMIZATION "Enables hardware specific optimizations in assembly. Not all compilers are supported." ON)
 
 if (WIN32)
     file(GLOB AWS_COMMON_OS_HEADERS
@@ -126,10 +127,15 @@ if (HAVE_MAY_I_USE OR HAVE_BUILTIN_CPU_SUPPORTS OR HAVE_MSVC_CPUIDEX)
 endif()
 
 if (HAVE_AVX2_INTRINSICS AND HAVE_SIMD_CPUID)
-	target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -DUSE_SIMD_ENCODING)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -DUSE_SIMD_ENCODING)
     target_sources(${CMAKE_PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/source/arch/cpuid.c")
     simd_add_source_avx2(${CMAKE_PROJECT_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/source/arch/encoding_avx2.c")
     message(STATUS "Building SIMD base64 decoder")
+endif()
+
+if (ENABLE_HW_OPTIMIZATION)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -DAWS_ENABLE_HW_OPTIMIZATION)
+    message(STATUS "Hardware optimizations are enabled.")
 endif()
 
 # Preserve subdirectories when installing headers

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -362,6 +362,4 @@ AWS_STATIC_IMPL void aws_secure_zero(void *pBuf, size_t bufsize) {
         } while (0)
 #define AWS_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
-#define AWS_ENABLE_HW_OPTIMIZATION 1
-
 #endif /* AWS_COMMON_COMMON_H */


### PR DESCRIPTION
This is needed when building on platforms that we do not have code to
support it yet. For example, Android.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
