### PR TITLE
Include CMakeParseArguments module

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -13,6 +13,7 @@
 
 include(CheckCCompilerFlag)
 include(CheckIncludeFile)
+include(CMakeParseArguments) # needed for CMake v3.4 and lower
 
 # This function will set all common flags on a target
 # Options:


### PR DESCRIPTION
The function cmake_parse_arguments() is defined natively in the newer
CMake versions and does not require an explicit include(). However,
CMake v3.4 and lower require explicitly including the module to use that
function.

The minimum required CMake version in aws-c-common is currently set to
v3.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
