### PR TITLE
Fix typo in next_split function

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -101,7 +101,7 @@ bool aws_byte_buf_eq(const struct aws_byte_buf *a, const struct aws_byte_buf *b)
  * long enough to use the results.
  */
 AWS_COMMON_API
-bool aws_byte_cursor_next_split(const struct aws_byte_buf *input_str, char split_on, struct aws_byte_cursor *substr);
+bool aws_byte_buf_next_split(const struct aws_byte_buf *input_str, char split_on, struct aws_byte_cursor *substr);
 
 /**
  * No copies, no buffer allocations. Fills in output with a list of


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
