### PR TITLE
Updates to make the test harness usable from CPP. Dirty secret, decla…

### DIFF
--- a/cmake/AwsTestHarness.cmake
+++ b/cmake/AwsTestHarness.cmake
@@ -42,3 +42,21 @@ function(generate_test_driver driver_exe_name)
     # Clear test cases in case another driver needsto be generated
     unset(TEST_CASES PARENT_SCOPE)
 endfunction()
+
+function(generate_cpp_test_driver driver_exe_name)
+    create_test_sourcelist(test_srclist test_runner.cpp ${TEST_CASES})
+
+    add_executable(${driver_exe_name} ${CMAKE_CURRENT_BINARY_DIR}/test_runner.cpp ${TESTS})
+    target_link_libraries(${driver_exe_name} PRIVATE ${CMAKE_PROJECT_NAME})
+
+    set_target_properties(${driver_exe_name} PROPERTIES LINKER_LANGUAGE CXX)
+    target_compile_definitions(${driver_exe_name} PRIVATE AWS_UNSTABLE_TESTING_API=1)
+    target_include_directories(${driver_exe_name} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+    foreach(name IN LISTS TEST_CASES)
+        add_test(${name} ${driver_exe_name} "${name}")
+    endforeach()
+
+    # Clear test cases in case another driver needsto be generated
+    unset(TEST_CASES PARENT_SCOPE)
+endfunction()

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -347,6 +347,8 @@ struct aws_test_harness {
 
 #define AWS_TEST_ALLOCATOR_INIT(name)                                                                                  \
     static struct memory_test_allocator name##_alloc_impl = {                                                          \
+        .mem_acquire = NULL,                                                                                           \
+        .mem_release = NULL,                                                                                           \
         .allocated = 0,                                                                                                \
         .freed = 0,                                                                                                    \
         .mutex = AWS_MUTEX_INIT,                                                                                       \
@@ -365,8 +367,8 @@ struct aws_test_harness {
         .on_before = NULL,                                                                                             \
         .run = (fn),                                                                                                   \
         .on_after = NULL,                                                                                              \
-        .ctx = NULL,                                                                                                   \
         .allocator = &name##_allocator,                                                                                \
+        .ctx = NULL,                                                                                                   \
         .test_name = #name,                                                                                            \
         .suppress_memcheck = (s),                                                                                      \
     };                                                                                                                 \


### PR DESCRIPTION
…red initializers will work as long as the members are initialized in order, added cpp test driver generation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
