### PR TITLE
Add support for building on consoles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ file(GLOB AWS_COMMON_SRC
 
 option(PERFORM_HEADER_CHECK "Performs compile-time checks that each header can be included independently. Requires a C++ compiler.")
 option(ENABLE_HW_OPTIMIZATION "Enables hardware specific optimizations in assembly. Not all compilers are supported." ON)
+option(AWS_NUM_CPU_CORES "Number of CPU cores of the target machine. Useful when cross-compiling." 0)
 
 if (WIN32)
     file(GLOB AWS_COMMON_OS_HEADERS
@@ -104,6 +105,10 @@ endif()
 
 aws_add_sanitizers(${CMAKE_PROJECT_NAME} BLACKLIST "sanitizer-blacklist.txt")
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC ${PLATFORM_LIBS})
+
+if (AWS_NUM_CPU_CORES)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -DAWS_NUM_CPU_CORES=${AWS_NUM_CPU_CORES})
+endif()
 
 # Our ABI is not yet stable
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES SOVERSION 0unstable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ else ()
         set(PLATFORM_LIBS pthread ${CORE_FOUNDATION_LIB})
     elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") # Android does not link to libpthread nor librt, so this is fine
             set(PLATFORM_LIBS pthread rt)
-        endif ()
-    endif ()
+    endif()
+endif()
 
 file(GLOB COMMON_HEADERS
         ${AWS_COMMON_HEADERS}
@@ -166,5 +166,7 @@ list(APPEND EXPORT_MODULES
 
 install(FILES ${EXPORT_MODULES} DESTINATION "lib/cmake/")
 
-include(CTest)
-add_subdirectory(tests)
+if (NOT CMAKE_CROSSCOMPILING)
+    include(CTest)
+    add_subdirectory(tests)
+endif()

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -90,6 +90,11 @@ function(aws_set_common_properties target)
             }"  NO_GNU_EXPR)
 
         endif(HAS_WGNU)
+
+        if (NOT NO_GNU_EXPR)
+            list(APPEND AWS_C_FLAGS -Wno-gnu-statement-expression)
+        endif()
+
     endif(NOT SET_PROPERTIES_NO_WGNU)
 
     set(old_flags "${CMAKE_REQUIRED_FLAGS}")
@@ -104,10 +109,6 @@ function(aws_set_common_properties target)
     }"  HAVE_SYSCONF)
 
     set(CMAKE_REQUIRED_FLAGS "${old_flags}")
-
-    if (NOT NO_GNU_EXPR)
-        list(APPEND AWS_C_FLAGS -Wno-gnu-statement-expression)
-    endif()
 
     if (HAVE_SYSCONF)
         list(APPEND AWS_C_DEFINES_PRIVATE -DHAVE_SYSCONF)

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -80,6 +80,8 @@ function(aws_set_common_properties target)
 
             # some platforms implement htonl family of functions via GNU statement expressions (https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html)
             # which generates -Wgnu-statement-expression warning.
+            set(old_flags "${CMAKE_REQUIRED_FLAGS}")
+            set(CMAKE_REQUIRED_FLAGS "-Wgnu -Werror")
             check_c_source_compiles("
             #include <netinet/in.h>
 
@@ -88,7 +90,7 @@ function(aws_set_common_properties target)
               x = htonl(x);
               return (int)x;
             }"  NO_GNU_EXPR)
-
+            set(CMAKE_REQUIRED_FLAGS "${old_flags}")
         endif(HAS_WGNU)
 
         if (NOT NO_GNU_EXPR)
@@ -97,18 +99,12 @@ function(aws_set_common_properties target)
 
     endif(NOT SET_PROPERTIES_NO_WGNU)
 
-    set(old_flags "${CMAKE_REQUIRED_FLAGS}")
-    set(CMAKE_REQUIRED_FLAGS "-Wgnu -Werror")
-
-
     # some platforms (especially when cross-compiling) do not have the sysconf API in their toolchain files.
     check_c_source_compiles("
     #include <unistd.h>
     int main() {
       sysconf(_SC_NPROCESSORS_ONLN);
     }"  HAVE_SYSCONF)
-
-    set(CMAKE_REQUIRED_FLAGS "${old_flags}")
 
     if (HAVE_SYSCONF)
         list(APPEND AWS_C_DEFINES_PRIVATE -DHAVE_SYSCONF)

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -86,18 +86,17 @@ function(aws_set_common_properties target)
             #include <netinet/in.h>
 
             int main() {
-              uint32_t x = 0;
-              x = htonl(x);
-              return (int)x;
+            uint32_t x = 0;
+            x = htonl(x);
+            return (int)x;
             }"  NO_GNU_EXPR)
             set(CMAKE_REQUIRED_FLAGS "${old_flags}")
-        endif(HAS_WGNU)
 
-        if (DEFINED NO_GNU_EXPR AND NOT NO_GNU_EXPR)
-            list(APPEND AWS_C_FLAGS -Wno-gnu-statement-expression)
+            if (NOT NO_GNU_EXPR)
+                list(APPEND AWS_C_FLAGS -Wno-gnu-statement-expression)
+            endif()
         endif()
-
-    endif(NOT SET_PROPERTIES_NO_WGNU)
+    endif()
 
     # some platforms (especially when cross-compiling) do not have the sysconf API in their toolchain files.
     check_c_source_compiles("

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -93,7 +93,7 @@ function(aws_set_common_properties target)
             set(CMAKE_REQUIRED_FLAGS "${old_flags}")
         endif(HAS_WGNU)
 
-        if (NOT NO_GNU_EXPR)
+        if (DEFINED NO_GNU_EXPR AND NOT NO_GNU_EXPR)
             list(APPEND AWS_C_FLAGS -Wno-gnu-statement-expression)
         endif()
 

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -5,7 +5,7 @@
 
 #include <stdlib.h>
 
-#if defined(_M_X64) || defined(_M_IX86) || defined(_M_ARM)
+#if (AWS_ENABLE_HW_OPTIMIZATION && defined(_M_X64) || defined(_M_IX86) || defined(_M_ARM))
 #    include <immintrin.h>
 #    include <intrin.h>
 #endif

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -31,7 +31,12 @@ size_t aws_system_info_processor_count(void) {
 #else
 
 size_t aws_system_info_processor_count(void) {
+#if defined(AWS_NUM_CPU_CORES)
+    assert(AWS_NUM_CPU_CORES > 0)
+    return AWS_NUM_CPU_CORES;
+#else
     return 1;
+#endif
 }
 
 #endif

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -18,6 +18,7 @@
 #include <assert.h>
 #include <unistd.h>
 
+#if defined(HAVE_SYSCONF)
 size_t aws_system_info_processor_count(void) {
     long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
     if (AWS_LIKELY(nprocs >= 0)) {
@@ -27,3 +28,10 @@ size_t aws_system_info_processor_count(void) {
     assert(0);
     return 0;
 }
+#else
+
+size_t aws_system_info_processor_count(void) {
+    return 1;
+}
+
+#endif

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -29,14 +29,12 @@ size_t aws_system_info_processor_count(void) {
     return 0;
 }
 #else
-
 size_t aws_system_info_processor_count(void) {
-#if defined(AWS_NUM_CPU_CORES)
-    assert(AWS_NUM_CPU_CORES > 0)
+#    if defined(AWS_NUM_CPU_CORES)
+    assert(AWS_NUM_CPU_CORES > 0);
     return AWS_NUM_CPU_CORES;
-#else
+#    else
     return 1;
-#endif
+#    endif
 }
-
 #endif


### PR DESCRIPTION
When cross-compiling to some platforms, the 'sysconf' API is not
available.
Also, we shouldn't attempt to build the tests since we can't run them
when cross-compiling.
Finally, some platforms use the GNU statement-expressions to implemnent
network-host byte order translations. Those extensions will generate a
warning when using the flag -Wgnu, this patch mitigates that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
