### PR TITLE
Added stack trace output to non windows builds.

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -476,7 +476,7 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
     SetUnhandledExceptionFilter(s_test_print_stack_trace);
 #else
     struct sigaction sa;
-    memset(&sa, 0, sizeof(sigaction));
+    memset(&sa, 0, sizeof(struct sigaction));
     sigemptyset(&sa.sa_mask);
 
     sa.sa_flags = SA_NODEFER;


### PR DESCRIPTION
output looks like this:

** Signal Thrown 11**
Stack Trace:
./aws-c-io-tests() [0x4487c3]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x11390) [0x7f68e64b4390]
./aws-c-io-tests(X509_STORE_set_flags+0) [0x547ac0]
./aws-c-io-tests(s2n_x509_trust_store_from_system_defaults+0xac) [0x4b0475]
./aws-c-io-tests() [0x49dae1]
./aws-c-io-tests(s2n_fetch_default_config+0x1b) [0x49db93]
./aws-c-io-tests(s2n_connection_new+0x9a) [0x48b763]
./aws-c-io-tests() [0x47f234]
./aws-c-io-tests() [0x47f673]
./aws-c-io-tests() [0x476161]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
