### PR TITLE
Convert aws_base64_compute_decoded_len to byte_buf

### DIFF
--- a/include/aws/common/encoding.h
+++ b/include/aws/common/encoding.h
@@ -73,7 +73,7 @@ int aws_base64_encode(const struct aws_byte_buf *AWS_RESTRICT to_encode, struct 
  * returns -1 on failure, and 0 on success. decoded_len will be set on success.
  */
 AWS_COMMON_API
-int aws_base64_compute_decoded_len(const char *input, size_t len, size_t *decoded_len);
+int aws_base64_compute_decoded_len(const struct aws_byte_buf *AWS_RESTRICT to_decode, size_t *decoded_len);
 
 /*
  * Base 64 decodes the contents of to_decode and stores the result in output.

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -217,9 +217,12 @@ int aws_base64_compute_encoded_len(size_t to_encode_len, size_t *encoded_len) {
     return AWS_OP_SUCCESS;
 }
 
-int aws_base64_compute_decoded_len(const char *input, size_t len, size_t *decoded_len) {
-    assert(input);
+int aws_base64_compute_decoded_len(const struct aws_byte_buf *AWS_RESTRICT to_decode, size_t *decoded_len) {
+    assert(to_decode);
     assert(decoded_len);
+
+    const size_t len = to_decode->len;
+    const char *input = (const char *)to_decode->buffer;
 
     if (len == 0) {
         *decoded_len = 0;
@@ -320,7 +323,7 @@ static inline int s_base64_get_decoded_value(unsigned char to_decode, uint8_t *v
 int aws_base64_decode(const struct aws_byte_buf *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
     size_t decoded_length = 0;
 
-    if (AWS_UNLIKELY(aws_base64_compute_decoded_len((char *)to_decode->buffer, to_decode->len, &decoded_length))) {
+    if (AWS_UNLIKELY(aws_base64_compute_decoded_len(to_decode, &decoded_length))) {
         return AWS_OP_ERR;
     }
 

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -323,8 +323,9 @@ static int s_run_base64_encoding_test_case(
 
     /* Part 2: decoding */
 
+    struct aws_byte_buf expected_cur = aws_byte_buf_from_array((const uint8_t *)expected, expected_size - 1);
     ASSERT_SUCCESS(
-        aws_base64_compute_decoded_len(expected, expected_size - 1, &output_size),
+        aws_base64_compute_decoded_len(&expected_cur, &output_size),
         "Compute base64 decoded length failed with %d",
         aws_last_error());
     ASSERT_INT_EQUALS(test_str_size, output_size, "Output size on string should be %d", test_str_size);

--- a/tests/fuzz/base64_encoding_transitive.c
+++ b/tests/fuzz/base64_encoding_transitive.c
@@ -36,7 +36,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     assert(result == AWS_OP_SUCCESS);
     --encode_output.len; /* Remove null terminator */
 
-    result = aws_base64_compute_decoded_len((const char *)encode_output.buffer, encode_output.len, &output_size);
+    result = aws_base64_compute_decoded_len(&encode_output, &output_size);
     assert(result == AWS_OP_SUCCESS);
     assert(output_size == size);
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
