### PR TITLE
optimization: don't allocate a new string on static strings

### DIFF
--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -92,13 +92,17 @@ AWS_COMMON_API
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len);
 
 /**
- * Allocate a new string with the same contents as the old.
+ * Allocate a new string with the same contents as the old. This uses an optimization
+ * that does not duplicate memory of strings created with AWS_STATIC_STRING_FROM_LITERAL.
+ * This is safe because aws_string_destroy is a no-op on such strings, and therefore
+ * there is no risk of a double free.
  */
 AWS_COMMON_API
 struct aws_string *aws_string_new_from_string(struct aws_allocator *allocator, const struct aws_string *str);
 
 /**
  * Deallocate string. Takes a (void *) so it can be used as a destructor function for struct aws_hash_table.
+ * This is a no-op on strings created with AWS_STATIC_STRING_FROM_LITERAL.
  */
 AWS_COMMON_API
 void aws_string_destroy(void *str);

--- a/source/string.c
+++ b/source/string.c
@@ -34,7 +34,10 @@ struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, co
 }
 
 struct aws_string *aws_string_new_from_string(struct aws_allocator *allocator, const struct aws_string *str) {
-    return aws_string_new_from_array(allocator, str->bytes, str->len);
+    if (str->allocator) return aws_string_new_from_array(allocator, str->bytes, str->len);
+
+    /* Optimization: if this is a static string, don't allocate a new one */
+    return (struct aws_string *)str;
 }
 
 void aws_string_destroy(void *str) {

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -87,7 +87,6 @@ static int s_string_tests_fn(struct aws_allocator *allocator, void *ctx) {
 
     /* Test: all allocated memory is deallocated properly. */
     aws_string_destroy((void *)test_string_2);
-    aws_string_destroy((void *)dup_string_1);
     aws_string_destroy((void *)dup_string_2);
 
     return 0;


### PR DESCRIPTION
Detects if a string being duplicated is static and if so just continues to use the static string as the duplicate. Works because aws_string_destroy is a no-op on static strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
