### PR TITLE
#ifndef unnecessary (and different) timegm on macOS

### DIFF
--- a/source/posix/time.c
+++ b/source/posix/time.c
@@ -69,8 +69,10 @@ time_t aws_timegm(struct tm *const t) {
 
 #else
 
+#    ifndef __APPLE__
 /* glibc.... you disappoint me.. */
 extern time_t timegm(struct tm *);
+#    endif
 
 time_t aws_timegm(struct tm *const t) {
     return timegm(t);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
