### PR TITLE
Specialize hashlittle2, add aws_hash_iter_delete suppression

### DIFF
--- a/codebuild/common-posix.sh
+++ b/codebuild/common-posix.sh
@@ -7,6 +7,6 @@ cd build
 
 cmake -DPERFORM_HEADER_CHECK=ON -DENABLE_SANITIZERS=ON $@ ../
 make
-make test
+ctest . --output-on-failure
 
 cd ..

--- a/sanitizer-blacklist.txt
+++ b/sanitizer-blacklist.txt
@@ -3,5 +3,7 @@
 fun:hashlittle2
 
 [unsigned-integer-overflow]
-# aws_hash_iter_delete underflows a signed integer when deleting the 0th element, but checks for this behavior in aws_hash_iter_done
+# aws_hash_iter_delete underflows a unsigned integer when deleting the 0th element, but checks for this behavior in aws_hash_iter_done
 fun:aws_hash_iter_delete
+# aws_hash_iter_next adds 1 to this underflowed integer, overflowing it back to 0
+fun:aws_hash_iter_next

--- a/sanitizer-blacklist.txt
+++ b/sanitizer-blacklist.txt
@@ -1,2 +1,7 @@
-# Disable hashlittle2, which purposefully reads past string ends
+[address|unsigned-integer-overflow]
+# hashlittle2 purposefully reads past string ends (but shifts unnecessary data out before doing anything with it)
 fun:hashlittle2
+
+[unsigned-integer-overflow]
+# aws_hash_iter_delete underflows a signed integer when deleting the 0th element, but checks for this behavior in aws_hash_iter_done
+fun:aws_hash_iter_delete


### PR DESCRIPTION
* Only suppress errors uint overflow and global buffer overflow from `hashlittle2` (there's comments in the function about why it does these things)
* Suppress signed int overflow in `aws_hash_iter_delete`, there's also a comment about how it does this on purpose.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
