### PR TITLE
Fix accidental bash path breakage

### DIFF
--- a/format-check.sh
+++ b/format-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -z $CLANG_FORMAT ]] ; then
     CLANG_FORMAT=clang-format


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Fix the shell invocation in format-check.sh; Jonathan Henson says that this was an
accident, and hard-cording the path as /bin/bash is not portable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
