### PR TITLE
Disable integer sanitizer

### DIFF
--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -47,7 +47,7 @@ endfunction()
 
 # This function enables sanitizers on the given target
 # Options:
-#  SANITIZERS: The list of sanitizers to enable. Defaults to address;undefined;integer
+#  SANITIZERS: The list of sanitizers to enable. Defaults to address;undefined
 #  BLACKLIST: The blacklist file to use (passed to -fsanitizer-blacklist=)
 function(aws_add_sanitizers target)
     set(oneValueArgs BLACKLIST)
@@ -58,7 +58,7 @@ function(aws_add_sanitizers target)
         check_c_compiler_flag(-fsanitize= HAS_SANITIZERS)
         if(HAS_SANITIZERS)
             if(NOT SANITIZER_SANITIZERS)
-                set(SANITIZER_SANITIZERS "address;undefined;integer")
+                set(SANITIZER_SANITIZERS "address;undefined")
             endif()
 
             foreach(sanitizer IN LISTS SANITIZER_SANITIZERS)


### PR DESCRIPTION
Unsigned integer overflow is far too common of an occurrence to blacklist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
