### PR TITLE
FreeBSD build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ aws_prepare_symbol_visibility_args(${CMAKE_PROJECT_NAME} "AWS_COMMON")
 
 #apple source already includes the definitions we want, and setting this posix source
 #version causes it to revert to an older version. So don't turn it on there, we don't need it.
-if (UNIX AND NOT APPLE)
+if (UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} MATCHES FreeBSD)
     #this only gets applied to aws-c-common (not its consumers).
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500)
 endif()


### PR DESCRIPTION
FreeBSD should not have _XOPEN_SOURCE and _POSIX_C_SOURCE, as it deletes the declarations of the byteorder functions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
