### PR TITLE
fix incorrect cast in aws_mul_size_checked()

### DIFF
--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -91,10 +91,10 @@ AWS_STATIC_IMPL size_t aws_mul_size_saturating(size_t a, size_t b) {
 }
 
 AWS_STATIC_IMPL int aws_mul_size_checked(size_t a, size_t b, size_t *r) {
-    if ((uint64_t)SIZE_MAX == ~(uint32_t)0) {
-        return (int)aws_mul_u32_checked((uint32_t)a, (uint32_t)b, (uint32_t *)r);
+    if (sizeof(size_t) == sizeof(uint32_t)) {
+        return aws_mul_u32_checked(a, b, (uint32_t *)r);
     }
-    return (int)aws_mul_u64_checked((uint32_t)a, (uint32_t)b, (uint64_t *)r);
+    return aws_mul_u64_checked(a, b, (uint64_t *)r);
 }
 
 #if _MSC_VER

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -78,16 +78,13 @@ AWS_COMMON_API int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
 #endif                              /* _MSC_VER */
 
 AWS_STATIC_IMPL size_t aws_mul_size_saturating(size_t a, size_t b) {
-    /* static assert: SIZE_MAX == (~(uint32_t)0) || (~(uint64_t)0)*/
-    char assert_sizet_is_32_or_64_bit
-        [(((uint64_t)SIZE_MAX == ~(uint32_t)0) || ((uint64_t)SIZE_MAX == ~(uint64_t)0)) ? 1 : -1] = {0};
-    /* suppress unused variable warning */
-    (void)assert_sizet_is_32_or_64_bit;
-
-    if ((uint64_t)SIZE_MAX == ~(uint32_t)0) {
-        return (size_t)aws_mul_u32_saturating((uint32_t)a, (uint32_t)b);
-    }
+#if SIZE_MAX == UINT32_MAX
+    return (size_t)aws_mul_u32_saturating(a, b);
+#elif SIZE_MAX == UINT64_MAX
     return (size_t)aws_mul_u64_saturating(a, b);
+#else
+#    error "Target not supported"
+#endif
 }
 
 AWS_STATIC_IMPL int aws_mul_size_checked(size_t a, size_t b, size_t *r) {

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -91,10 +91,13 @@ AWS_STATIC_IMPL size_t aws_mul_size_saturating(size_t a, size_t b) {
 }
 
 AWS_STATIC_IMPL int aws_mul_size_checked(size_t a, size_t b, size_t *r) {
-    if (sizeof(size_t) == sizeof(uint32_t)) {
-        return aws_mul_u32_checked(a, b, (uint32_t *)r);
-    }
+#if SIZE_MAX == UINT32_MAX
+    return aws_mul_u32_checked(a, b, (uint32_t *)r);
+#elif SIZE_MAX == UINT64_MAX
     return aws_mul_u64_checked(a, b, (uint64_t *)r);
+#else
+#   error "Target not supported"
+#endif
 }
 
 #if _MSC_VER

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -96,7 +96,7 @@ AWS_STATIC_IMPL int aws_mul_size_checked(size_t a, size_t b, size_t *r) {
 #elif SIZE_MAX == UINT64_MAX
     return aws_mul_u64_checked(a, b, (uint64_t *)r);
 #else
-#   error "Target not supported"
+#    error "Target not supported"
 #endif
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,6 +156,8 @@ add_test_case(test_u64_saturating)
 add_test_case(test_u32_saturating)
 add_test_case(test_u64_checked)
 add_test_case(test_u32_checked)
+add_test_case(test_size_saturating)
+add_test_case(test_size_checked)
 
 add_test_case(nospec_index_test)
 add_test_case(test_byte_cursor_advance)

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -91,6 +91,7 @@ static int s_test_u32_saturating_fn(struct aws_allocator *allocator, void *ctx) 
 }
 
 AWS_TEST_CASE(test_size_saturating, s_test_size_saturating_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_size_saturating_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
@@ -223,6 +224,7 @@ static int s_test_u32_checked_fn(struct aws_allocator *allocator, void *ctx) {
 }
 
 AWS_TEST_CASE(test_size_checked, s_test_size_checked_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_size_checked_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -96,44 +96,44 @@ static int s_test_size_saturating_fn(struct aws_allocator *allocator, void *ctx)
     (void)allocator;
     (void)ctx;
 
-    if (sizeof(size_t) == sizeof(uint32_t)) {
-        CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
-        CHECK_SAT(aws_mul_size_saturating, 0, 1, 0);
-        CHECK_SAT(aws_mul_size_saturating, 0, ~0U, 0);
-        CHECK_SAT(aws_mul_size_saturating, 4, 5, 20);
-        CHECK_SAT(aws_mul_size_saturating, 1234, 4321, 5332114);
+#if SIZE_MAX == UINT32_MAX
+    CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
+    CHECK_SAT(aws_mul_size_saturating, 0, 1, 0);
+    CHECK_SAT(aws_mul_size_saturating, 0, ~0U, 0);
+    CHECK_SAT(aws_mul_size_saturating, 4, 5, 20);
+    CHECK_SAT(aws_mul_size_saturating, 1234, 4321, 5332114);
 
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFF, 1, 0xFFFF);
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFF, 0xFFFF, 0xfffe0001);
-        CHECK_SAT(aws_mul_size_saturating, 0x10000, 0xFFFF, 0xFFFF0000U);
-        CHECK_SAT(aws_mul_size_saturating, 0x10001, 0xFFFF, 0xFFFFFFFFU);
-        CHECK_SAT(aws_mul_size_saturating, 0x10001, 0xFFFE, 0xFFFEFFFEU);
-        CHECK_SAT(aws_mul_size_saturating, 0x10002, 0xFFFE, 0xFFFFFFFCU);
-        CHECK_SAT(aws_mul_size_saturating, 0x10003, 0xFFFE, 0xFFFFFFFFU);
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFE, 0xFFFE, 0xFFFC0004U);
-        CHECK_SAT(aws_mul_size_saturating, 0x1FFFF, 0x1FFFF, 0xFFFFFFFFU);
-        CHECK_SAT(aws_mul_size_saturating, ~0U, ~0U, ~0U);
-    } else if (sizeof(size_t) == sizeof(uint64_t)) {
-        CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
-        CHECK_SAT(aws_mul_size_saturating, 0, 1, 0);
-        CHECK_SAT(aws_mul_size_saturating, 0, ~0LLU, 0);
-        CHECK_SAT(aws_mul_size_saturating, 4, 5, 20);
-        CHECK_SAT(aws_mul_size_saturating, 1234, 4321, 5332114);
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFF, 1, 0xFFFF);
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFF, 0xFFFF, 0xfffe0001);
+    CHECK_SAT(aws_mul_size_saturating, 0x10000, 0xFFFF, 0xFFFF0000U);
+    CHECK_SAT(aws_mul_size_saturating, 0x10001, 0xFFFF, 0xFFFFFFFFU);
+    CHECK_SAT(aws_mul_size_saturating, 0x10001, 0xFFFE, 0xFFFEFFFEU);
+    CHECK_SAT(aws_mul_size_saturating, 0x10002, 0xFFFE, 0xFFFFFFFCU);
+    CHECK_SAT(aws_mul_size_saturating, 0x10003, 0xFFFE, 0xFFFFFFFFU);
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFE, 0xFFFE, 0xFFFC0004U);
+    CHECK_SAT(aws_mul_size_saturating, 0x1FFFF, 0x1FFFF, 0xFFFFFFFFU);
+    CHECK_SAT(aws_mul_size_saturating, ~0U, ~0U, ~0U);
+#elif SIZE_MAX == UINT64_MAX
+    CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
+    CHECK_SAT(aws_mul_size_saturating, 0, 1, 0);
+    CHECK_SAT(aws_mul_size_saturating, 0, ~0LLU, 0);
+    CHECK_SAT(aws_mul_size_saturating, 4, 5, 20);
+    CHECK_SAT(aws_mul_size_saturating, 1234, 4321, 5332114);
 
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 0xFFFFFFFF, 0xfffffffe00000001LLU);
-        CHECK_SAT(aws_mul_size_saturating, 0x100000000, 0xFFFFFFFF, 0xFFFFFFFF00000000LLU);
-        CHECK_SAT(aws_mul_size_saturating, 0x100000001, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
-        CHECK_SAT(aws_mul_size_saturating, 0x100000001, 0xFFFFFFFE, 0xFFFFFFFEFFFFFFFELLU);
-        CHECK_SAT(aws_mul_size_saturating, 0x100000002, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFCLLU);
-        CHECK_SAT(aws_mul_size_saturating, 0x100000003, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFFLLU);
-        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFC00000004LLU);
-        CHECK_SAT(aws_mul_size_saturating, 0x1FFFFFFFF, 0x1FFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
-        CHECK_SAT(aws_mul_size_saturating, ~0LLU, ~0LLU, ~0LLU);
-    } else {
-        FAIL("Unexpected size for size_t");
-    }
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 0xFFFFFFFF, 0xfffffffe00000001LLU);
+    CHECK_SAT(aws_mul_size_saturating, 0x100000000, 0xFFFFFFFF, 0xFFFFFFFF00000000LLU);
+    CHECK_SAT(aws_mul_size_saturating, 0x100000001, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_SAT(aws_mul_size_saturating, 0x100000001, 0xFFFFFFFE, 0xFFFFFFFEFFFFFFFELLU);
+    CHECK_SAT(aws_mul_size_saturating, 0x100000002, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFCLLU);
+    CHECK_SAT(aws_mul_size_saturating, 0x100000003, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFC00000004LLU);
+    CHECK_SAT(aws_mul_size_saturating, 0x1FFFFFFFF, 0x1FFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_SAT(aws_mul_size_saturating, ~0LLU, ~0LLU, ~0LLU);
+#else
+    FAIL("Unexpected size for size_t: %zu", sizeof(size_t));
+#endif
 
     return 0;
 }
@@ -229,43 +229,43 @@ static int s_test_size_checked_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
 
-    if (sizeof(size_t) == sizeof(uint32_t)) {
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 1, 0);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, ~0u, 0);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 4, 5, 20);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 1234, 4321, 5332114);
+#if SIZE_MAX == UINT32_MAX
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 1, 0);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, ~0u, 0);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 4, 5, 20);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 1234, 4321, 5332114);
 
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFF, 1, 0xFFFFFFFF);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFF, 1, 0xFFFF);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFF, 0xFFFF, 0xfffe0001u);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10000, 0xFFFF, 0xFFFF0000u);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10001, 0xFFFF, 0xFFFFFFFFu);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10001, 0xFFFE, 0xFFFEFFFEu);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10002, 0xFFFE, 0xFFFFFFFCu);
-        CHECK_OVF(aws_mul_size_checked, size_t, 0x10003, 0xFFFE);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFE, 0xFFFE, 0xFFFC0004u);
-        CHECK_OVF(aws_mul_size_checked, size_t, 0x1FFFF, 0x1FFFF);
-        CHECK_OVF(aws_mul_size_checked, size_t, ~0u, ~0u);
-    } else if (sizeof(size_t) == sizeof(uint64_t)) {
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 1, 0);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, ~0LLU, 0);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 4, 5, 20);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 1234, 4321, 5332114);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFF, 1, 0xFFFF);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFF, 0xFFFF, 0xfffe0001u);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10000, 0xFFFF, 0xFFFF0000u);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10001, 0xFFFF, 0xFFFFFFFFu);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10001, 0xFFFE, 0xFFFEFFFEu);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10002, 0xFFFE, 0xFFFFFFFCu);
+    CHECK_OVF(aws_mul_size_checked, size_t, 0x10003, 0xFFFE);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFE, 0xFFFE, 0xFFFC0004u);
+    CHECK_OVF(aws_mul_size_checked, size_t, 0x1FFFF, 0x1FFFF);
+    CHECK_OVF(aws_mul_size_checked, size_t, ~0u, ~0u);
+#elif SIZE_MAX == UINT64_MAX
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 1, 0);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, ~0LLU, 0);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 4, 5, 20);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 1234, 4321, 5332114);
 
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFFLLU, 1LLU, 0xFFFFFFFFLLU);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFFLLU, 0xFFFFFFFFLLU, 0xfffffffe00000001LLU);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000000LLU, 0xFFFFFFFFLLU, 0xFFFFFFFF00000000LLU);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000001LLU, 0xFFFFFFFFLLU, 0xFFFFFFFFFFFFFFFFLLU);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000001LLU, 0xFFFFFFFELLU, 0xFFFFFFFEFFFFFFFELLU);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000002LLU, 0xFFFFFFFELLU, 0xFFFFFFFFFFFFFFFCLLU);
-        CHECK_OVF(aws_mul_size_checked, size_t, 0x100000003LLU, 0xFFFFFFFELLU);
-        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFELLU, 0xFFFFFFFELLU, 0xFFFFFFFC00000004LLU);
-        CHECK_OVF(aws_mul_size_checked, size_t, 0x1FFFFFFFFLLU, 0x1FFFFFFFFLLU);
-        CHECK_OVF(aws_mul_size_checked, size_t, ~0LLU, ~0LLU);
-    } else {
-        FAIL("Unexpected size for size_t");
-    }
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFFLLU, 1LLU, 0xFFFFFFFFLLU);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFFLLU, 0xFFFFFFFFLLU, 0xfffffffe00000001LLU);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000000LLU, 0xFFFFFFFFLLU, 0xFFFFFFFF00000000LLU);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000001LLU, 0xFFFFFFFFLLU, 0xFFFFFFFFFFFFFFFFLLU);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000001LLU, 0xFFFFFFFELLU, 0xFFFFFFFEFFFFFFFELLU);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000002LLU, 0xFFFFFFFELLU, 0xFFFFFFFFFFFFFFFCLLU);
+    CHECK_OVF(aws_mul_size_checked, size_t, 0x100000003LLU, 0xFFFFFFFELLU);
+    CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFELLU, 0xFFFFFFFELLU, 0xFFFFFFFC00000004LLU);
+    CHECK_OVF(aws_mul_size_checked, size_t, 0x1FFFFFFFFLLU, 0x1FFFFFFFFLLU);
+    CHECK_OVF(aws_mul_size_checked, size_t, ~0LLU, ~0LLU);
+#else
+    FAIL("Unexpected size for size_t: %zu", sizeof(size_t));
+#endif
     return 0;
 }

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -90,6 +90,53 @@ static int s_test_u32_saturating_fn(struct aws_allocator *allocator, void *ctx) 
     return 0;
 }
 
+AWS_TEST_CASE(test_size_saturating, s_test_size_saturating_fn)
+static int s_test_size_saturating_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    if (sizeof(size_t) == sizeof(uint32_t)) {
+        CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
+        CHECK_SAT(aws_mul_size_saturating, 0, 1, 0);
+        CHECK_SAT(aws_mul_size_saturating, 0, ~0U, 0);
+        CHECK_SAT(aws_mul_size_saturating, 4, 5, 20);
+        CHECK_SAT(aws_mul_size_saturating, 1234, 4321, 5332114);
+
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFF, 1, 0xFFFF);
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFF, 0xFFFF, 0xfffe0001);
+        CHECK_SAT(aws_mul_size_saturating, 0x10000, 0xFFFF, 0xFFFF0000U);
+        CHECK_SAT(aws_mul_size_saturating, 0x10001, 0xFFFF, 0xFFFFFFFFU);
+        CHECK_SAT(aws_mul_size_saturating, 0x10001, 0xFFFE, 0xFFFEFFFEU);
+        CHECK_SAT(aws_mul_size_saturating, 0x10002, 0xFFFE, 0xFFFFFFFCU);
+        CHECK_SAT(aws_mul_size_saturating, 0x10003, 0xFFFE, 0xFFFFFFFFU);
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFE, 0xFFFE, 0xFFFC0004U);
+        CHECK_SAT(aws_mul_size_saturating, 0x1FFFF, 0x1FFFF, 0xFFFFFFFFU);
+        CHECK_SAT(aws_mul_size_saturating, ~0U, ~0U, ~0U);
+    } else if (sizeof(size_t) == sizeof(uint64_t)) {
+        CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
+        CHECK_SAT(aws_mul_size_saturating, 0, 1, 0);
+        CHECK_SAT(aws_mul_size_saturating, 0, ~0LLU, 0);
+        CHECK_SAT(aws_mul_size_saturating, 4, 5, 20);
+        CHECK_SAT(aws_mul_size_saturating, 1234, 4321, 5332114);
+
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFF, 0xFFFFFFFF, 0xfffffffe00000001LLU);
+        CHECK_SAT(aws_mul_size_saturating, 0x100000000, 0xFFFFFFFF, 0xFFFFFFFF00000000LLU);
+        CHECK_SAT(aws_mul_size_saturating, 0x100000001, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
+        CHECK_SAT(aws_mul_size_saturating, 0x100000001, 0xFFFFFFFE, 0xFFFFFFFEFFFFFFFELLU);
+        CHECK_SAT(aws_mul_size_saturating, 0x100000002, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFCLLU);
+        CHECK_SAT(aws_mul_size_saturating, 0x100000003, 0xFFFFFFFE, 0xFFFFFFFFFFFFFFFFLLU);
+        CHECK_SAT(aws_mul_size_saturating, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFC00000004LLU);
+        CHECK_SAT(aws_mul_size_saturating, 0x1FFFFFFFF, 0x1FFFFFFFF, 0xFFFFFFFFFFFFFFFFLLU);
+        CHECK_SAT(aws_mul_size_saturating, ~0LLU, ~0LLU, ~0LLU);
+    } else {
+        FAIL("Unexpected size for size_t");
+    }
+
+    return 0;
+}
+
 #define CHECK_OVF_0(fn, type, a, b)                                                                                    \
     do {                                                                                                               \
         type result_val;                                                                                               \
@@ -172,5 +219,51 @@ static int s_test_u32_checked_fn(struct aws_allocator *allocator, void *ctx) {
     CHECK_OVF(aws_mul_u32_checked, uint32_t, 0x1FFFF, 0x1FFFF);
     CHECK_OVF(aws_mul_u32_checked, uint32_t, ~0u, ~0u);
 
+    return 0;
+}
+
+AWS_TEST_CASE(test_size_checked, s_test_size_checked_fn)
+static int s_test_size_checked_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    if (sizeof(size_t) == sizeof(uint32_t)) {
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 1, 0);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, ~0u, 0);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 4, 5, 20);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 1234, 4321, 5332114);
+
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFF, 1, 0xFFFFFFFF);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFF, 1, 0xFFFF);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFF, 0xFFFF, 0xfffe0001u);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10000, 0xFFFF, 0xFFFF0000u);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10001, 0xFFFF, 0xFFFFFFFFu);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10001, 0xFFFE, 0xFFFEFFFEu);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x10002, 0xFFFE, 0xFFFFFFFCu);
+        CHECK_OVF(aws_mul_size_checked, size_t, 0x10003, 0xFFFE);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFE, 0xFFFE, 0xFFFC0004u);
+        CHECK_OVF(aws_mul_size_checked, size_t, 0x1FFFF, 0x1FFFF);
+        CHECK_OVF(aws_mul_size_checked, size_t, ~0u, ~0u);
+    } else if (sizeof(size_t) == sizeof(uint64_t)) {
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 1, 0);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, ~0LLU, 0);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 4, 5, 20);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 1234, 4321, 5332114);
+
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFFLLU, 1LLU, 0xFFFFFFFFLLU);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFFLLU, 0xFFFFFFFFLLU, 0xfffffffe00000001LLU);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000000LLU, 0xFFFFFFFFLLU, 0xFFFFFFFF00000000LLU);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000001LLU, 0xFFFFFFFFLLU, 0xFFFFFFFFFFFFFFFFLLU);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000001LLU, 0xFFFFFFFELLU, 0xFFFFFFFEFFFFFFFELLU);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0x100000002LLU, 0xFFFFFFFELLU, 0xFFFFFFFFFFFFFFFCLLU);
+        CHECK_OVF(aws_mul_size_checked, size_t, 0x100000003LLU, 0xFFFFFFFELLU);
+        CHECK_NO_OVF(aws_mul_size_checked, size_t, 0xFFFFFFFELLU, 0xFFFFFFFELLU, 0xFFFFFFFC00000004LLU);
+        CHECK_OVF(aws_mul_size_checked, size_t, 0x1FFFFFFFFLLU, 0x1FFFFFFFFLLU);
+        CHECK_OVF(aws_mul_size_checked, size_t, ~0LLU, ~0LLU);
+    } else {
+        FAIL("Unexpected size for size_t");
+    }
     return 0;
 }


### PR DESCRIPTION
*Description of changes:*
```aws_mul_size_checked()``` incorrectly downcasts in the case of 64 bit numbers.  This PR fixes it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
