### PR TITLE
Prevent possible integer overflow in aws_string

### DIFF
--- a/source/string.c
+++ b/source/string.c
@@ -19,7 +19,11 @@ struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, co
 }
 
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len) {
-    struct aws_string *str = aws_mem_acquire(allocator, sizeof(struct aws_string) + len + 1);
+    size_t malloc_size;
+    if (aws_add_size_checked(sizeof(struct aws_string) + 1, len, &malloc_size)) {
+        return NULL;
+    }
+    struct aws_string *str = aws_mem_acquire(allocator, malloc_size);
     if (!str) {
         return NULL;
     }


### PR DESCRIPTION
*Description of changes:*
There is an unlikely but possible integer overflow in the aws_string initializer.  Use the new checked functions to return an error if this occurs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
