### PR TITLE
fix array_list integer overflows

### DIFF
--- a/.cbmc-batch/proof_helpers.h
+++ b/.cbmc-batch/proof_helpers.h
@@ -22,7 +22,7 @@ struct aws_array_list *get_arbitrary_array_list(size_t item_count, size_t item_s
         /* Use default allocator */
         struct aws_allocator *allocator = malloc(sizeof(*allocator));
         ASSUME_DEFAULT_ALLOCATOR(allocator);
-        aws_array_list_init_dynamic(list, allocator, item_count, item_size);
+        __CPROVER_assume(!aws_array_list_init_dynamic(list, allocator, item_count, item_size));
     } else { /* Static initialization */
         __CPROVER_assume(item_count > 0);
         __CPROVER_assume(item_size > 0);

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -26,6 +26,10 @@ int aws_array_list_init_dynamic(
     struct aws_allocator *alloc,
     size_t initial_item_allocation,
     size_t item_size) {
+    if (item_size == 0) {
+        return AWS_OP_ERR;
+    }
+
     list->alloc = alloc;
     size_t allocation_size;
     if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -28,7 +28,7 @@ int aws_array_list_init_dynamic(
     size_t item_size) {
     list->alloc = alloc;
     size_t allocation_size;
-    if(aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
+    if (aws_mul_size_checked(initial_item_allocation, item_size, &allocation_size)) {
         return AWS_OP_ERR;
     }
     list->data = NULL;
@@ -172,7 +172,9 @@ void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
 }
 
 AWS_STATIC_IMPL
-void aws_array_list_swap_contents(struct aws_array_list *AWS_RESTRICT list_a, struct aws_array_list *AWS_RESTRICT list_b) {
+void aws_array_list_swap_contents(
+    struct aws_array_list *AWS_RESTRICT list_a,
+    struct aws_array_list *AWS_RESTRICT list_b) {
     assert(list_a->alloc);
     assert(list_a->alloc == list_b->alloc);
     assert(list_a->item_size == list_b->item_size);
@@ -219,8 +221,24 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
 }
 
 AWS_STATIC_IMPL
+int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list, size_t index, size_t *necessary_size) {
+    size_t index_inc;
+    if (aws_add_size_checked(index, 1, &index_inc)) {
+        return AWS_OP_ERR;
+    }
+
+    if (aws_mul_size_checked(index_inc, list->item_size, necessary_size)) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}
+
+AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
-    size_t necessary_size = (index + 1) * list->item_size;
+    size_t necessary_size;
+    if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
+        return AWS_OP_ERR;
+    }
 
     if (list->current_size < necessary_size) {
         if (aws_array_list_ensure_capacity(list, index)) {

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -27,7 +27,7 @@ int aws_array_list_init_dynamic(
     size_t initial_item_allocation,
     size_t item_size) {
     if (item_size == 0) {
-        return AWS_OP_ERR;
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
     list->alloc = alloc;

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -46,6 +46,7 @@ int aws_array_list_init_dynamic(
 #endif
         list->current_size = allocation_size;
     }
+    assert(list->current_size == 0 || list->data);
 
     return AWS_OP_SUCCESS;
 }
@@ -245,6 +246,8 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
             return AWS_OP_ERR;
         }
     }
+
+    assert(list->data);
 
     memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 

--- a/tests/array_list_test.c
+++ b/tests/array_list_test.c
@@ -816,7 +816,9 @@ static int s_array_list_not_enough_space_test_failure_fn(struct aws_allocator *a
         aws_array_list_init_dynamic(&list_a, allocator, list_size, sizeof(int)),
         "List initialization failed with error %d",
         aws_last_error());
+    ASSERT_TRUE(list_a.data);
     aws_array_list_init_static(&list_b, static_list, 1, sizeof(int));
+    ASSERT_TRUE(list_b.data);
 
     int first = 1, second = 2;
 


### PR DESCRIPTION
*Description of changes:*
1. Prevent several possible integer overflows by using the ```checked()``` functions.
1. Add assertions to teach ```clang-tidy``` about invariants in the code
1. CBMC proofs found a potential error in ```aws_array_list_init_dynamic()```. Fix the error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
