### PR TITLE
Replace assert with AWS_FATAL_ASSERT in aws_array_list_swap function

### DIFF
--- a/include/aws/common/array_list.h
+++ b/include/aws/common/array_list.h
@@ -185,7 +185,7 @@ AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index);
 
 /**
- * Swap elements at the specified indices.
+ * Swap elements at the specified indices, which must be within the bounds of the array.
  */
 AWS_COMMON_API
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b);

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -163,8 +163,8 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 }
 
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
-    assert(a < list->length);
-    assert(b < list->length);
+    AWS_FATAL_ASSERT(a < list->length);
+    AWS_FATAL_ASSERT(b < list->length);
     if (a == b) {
         return;
     }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This approach does not require to change the signature to the function. However, if we change the signature of the function, we could instead raise an `AWS_ERROR_INVALID_INDEX`, if the indices `a` and `b` past the bounds of the array. So which approach would be a better fit here?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
