### PR TITLE
Replace all assert statements with AWS_FATAL_ASSERT in aws_array_list

### DIFF
--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -50,7 +50,7 @@ int aws_array_list_init_dynamic(
 #endif
         list->current_size = allocation_size;
     }
-    assert(list->current_size == 0 || list->data);
+    AWS_FATAL_ASSERT(list->current_size == 0 || list->data);
 
     return AWS_OP_SUCCESS;
 }
@@ -61,9 +61,9 @@ void aws_array_list_init_static(
     void *raw_array,
     size_t item_count,
     size_t item_size) {
-    assert(raw_array);
-    assert(item_count);
-    assert(item_size);
+    AWS_FATAL_ASSERT(raw_array);
+    AWS_FATAL_ASSERT(item_count);
+    AWS_FATAL_ASSERT(item_size);
 
     list->alloc = NULL;
 
@@ -154,7 +154,7 @@ AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
     if (aws_array_list_length(list) > 0) {
 
-        assert(list->data);
+        AWS_FATAL_ASSERT(list->data);
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -180,10 +180,10 @@ AWS_STATIC_IMPL
 void aws_array_list_swap_contents(
     struct aws_array_list *AWS_RESTRICT list_a,
     struct aws_array_list *AWS_RESTRICT list_b) {
-    assert(list_a->alloc);
-    assert(list_a->alloc == list_b->alloc);
-    assert(list_a->item_size == list_b->item_size);
-    assert(list_a != list_b);
+    AWS_FATAL_ASSERT(list_a->alloc);
+    AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
+    AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
+    AWS_FATAL_ASSERT(list_a != list_b);
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
@@ -192,7 +192,7 @@ void aws_array_list_swap_contents(
 
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
-    assert(list->item_size);
+    AWS_FATAL_ASSERT(list->item_size);
     return list->current_size / list->item_size;
 }
 
@@ -202,7 +202,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * This assert teaches clang-tidy and friends that list->data cannot be null in a non-empty
      * list.
      */
-    assert(!list->length || list->data);
+    AWS_FATAL_ASSERT(!list->length || list->data);
 
     return list->length;
 }
@@ -251,7 +251,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
         }
     }
 
-    assert(list->data);
+    AWS_FATAL_ASSERT(list->data);
 
     memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -47,8 +47,8 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 }
 
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
-    assert(from->item_size == to->item_size);
-    assert(from->data);
+    AWS_FATAL_ASSERT(from->item_size == to->item_size);
+    AWS_FATAL_ASSERT(from->data);
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -142,8 +142,8 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
 static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT item2, size_t item_size) {
     enum { SLICE = 128 };
 
-    assert(item1);
-    assert(item2);
+    AWS_FATAL_ASSERT(item1);
+    AWS_FATAL_ASSERT(item2);
 
     /* copy SLICE sized bytes at a time */
     size_t slice_count = item_size / SLICE;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Update array_list implementation to use `AWS_FATAL_ASSERT` instead of the usual `assert`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
