### PR TITLE
printf support for aws_byte_cursor

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -52,27 +52,18 @@ struct aws_byte_cursor {
 };
 
 /**
- * Format macro for strings of a specified length.
- * Allows non null-terminated strings, such as those stored in aws_byte_cursor and aws_byte_buf,
- * to be used with the printf family of functions.
- *
- * The AWS_BYTE_CURSOR_PRI() macro is a helper for passing an aws_byte_cursor in the args.
- * Note that strings will be clipped if they contain '\0' or their length exceeds INT_MAX.
- *
- * Examples:
- * \code
- * printf("scheme is " PRInSTR, 4, "http://example.org"); // ouputs: "scheme is http"
- *
- * struct aws_byte_cursor c = aws_byte_cursor_from_c_str("https");
- *
- * printf("scheme is " PRInSTR, (int)c.len, c.ptr); // outputs: "scheme is https"
- * printf("scheme is " PRInSTR, AWS_BYTE_CURSOR_PRI(c)); // outputs: "scheme is https"
- * \endcode
+ * Helper macro for passing aws_byte_cursor to the printf family of functions.
+ * Intended for use with the PRInSTR format macro.
+ * Ex: printf(PRInSTR "\n", AWS_BYTE_CURSOR_PRI(my_cursor));
  */
-#define PRInSTR "%.*s"
 #define AWS_BYTE_CURSOR_PRI(C) ((int)(C).len < 0 ? 0 : (int)(C).len), (const char *)(C).ptr
+
+/**
+ * Helper macro for passing aws_byte_buf to the printf family of functions.
+ * Intended for use with the PRInSTR format macro.
+ * Ex: printf(PRInSTR "\n", AWS_BYTE_BUF_PRI(my_buf));
+ */
 #define AWS_BYTE_BUF_PRI(B) ((int)(B).len < 0 ? 0 : (int)(B).len), (const char *)(B).buffer
-#define AWS_STRING_PRI(S) ((int)(S).len < 0 ? 0 : (int)(S).len), (const char *)(S).bytes
 
 AWS_EXTERN_C_BEGIN
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -51,6 +51,29 @@ struct aws_byte_cursor {
     uint8_t *ptr;
 };
 
+/**
+ * Format macro for strings of a specified length.
+ * Allows non null-terminated strings, such as those stored in aws_byte_cursor and aws_byte_buf,
+ * to be used with the printf family of functions.
+ *
+ * The AWS_BYTE_CURSOR_PRI() macro is a helper for passing an aws_byte_cursor in the args.
+ * Note that strings will be clipped if they contain '\0' or their length exceeds INT_MAX.
+ *
+ * Examples:
+ * \code
+ * printf("scheme is " PRInSTR, 4, "http://example.org"); // ouputs: "scheme is http"
+ *
+ * struct aws_byte_cursor c = aws_byte_cursor_from_c_str("https");
+ *
+ * printf("scheme is " PRInSTR, (int)c.len, c.ptr); // outputs: "scheme is https"
+ * printf("scheme is " PRInSTR, AWS_BYTE_CURSOR_PRI(c)); // outputs: "scheme is https"
+ * \endcode
+ */
+#define PRInSTR "%.*s"
+#define AWS_BYTE_CURSOR_PRI(C) ((int)(C).len < 0 ? 0 : (int)(C).len), (const char *)(C).ptr
+#define AWS_BYTE_BUF_PRI(B) ((int)(B).len < 0 ? 0 : (int)(B).len), (const char *)(B).buffer
+#define AWS_STRING_PRI(S) ((int)(S).len < 0 ? 0 : (int)(S).len), (const char *)(S).bytes
+
 AWS_EXTERN_C_BEGIN
 
 AWS_COMMON_API

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -260,6 +260,13 @@ AWS_EXTERN_C_END
 
 #define AWS_CACHE_LINE 64
 
+/**
+ * Format macro for strings of a specified length.
+ * Allows non null-terminated strings to be used with the printf family of functions.
+ * Ex: printf("scheme is " PRInSTR, 4, "http://example.org"); // ouputs: "scheme is http"
+ */
+#define PRInSTR "%.*s"
+
 #if defined(_MSC_VER)
 #    include <malloc.h>
 #    define AWS_ALIGN(alignment) __declspec(align(alignment))

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -58,6 +58,13 @@ struct aws_string {
 #endif
 
 /**
+ * Helper macro for passing aws_string to the printf family of functions.
+ * Intended for use with the PRInSTR format macro.
+ * Ex: printf(PRInSTR "\n", AWS_STRING_PRI(my_string));
+ */
+#define AWS_STRING_PRI(S) ((int)(S)->len < 0 ? 0 : (int)(S)->len), (const char *)(S)->bytes
+
+/**
  * Equivalent to str->bytes. Here for legacy reaasons.
  */
 AWS_STATIC_IMPL const uint8_t *aws_string_bytes(const struct aws_string *str) {

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -58,13 +58,6 @@ struct aws_string {
 #endif
 
 /**
- * Helper macro for passing aws_string to the printf family of functions.
- * Intended for use with the PRInSTR format macro.
- * Ex: printf(PRInSTR "\n", AWS_STRING_PRI(my_string));
- */
-#define AWS_STRING_PRI(S) ((int)(S)->len < 0 ? 0 : (int)(S)->len), (const char *)(S)->bytes
-
-/**
  * Equivalent to str->bytes. Here for legacy reaasons.
  */
 AWS_STATIC_IMPL const uint8_t *aws_string_bytes(const struct aws_string *str) {

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -284,3 +284,38 @@ static int s_test_buffer_advance(struct aws_allocator *allocator, void *ctx) {
 
     return 0;
 }
+
+AWS_TEST_CASE(test_buffer_printf, s_test_buffer_printf)
+static int s_test_buffer_printf(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const char src[] = "abcdefg";
+
+    char dst[100] = {0};
+
+    /* check PRInSTR */
+    memset(dst, 0, sizeof(dst));
+    snprintf(dst, sizeof(dst), PRInSTR, 2, src);
+    ASSERT_UINT_EQUALS('a', dst[0]);
+    ASSERT_UINT_EQUALS('b', dst[1]);
+    ASSERT_UINT_EQUALS(0, dst[2]);
+
+    /* check AWS_BYTE_CURSOR_PRI() */
+    struct aws_byte_cursor cursor = aws_byte_cursor_from_array(src, 2);
+    memset(dst, 0, sizeof(dst));
+    snprintf(dst, sizeof(dst), PRInSTR, AWS_BYTE_CURSOR_PRI(cursor));
+    ASSERT_UINT_EQUALS('a', dst[0]);
+    ASSERT_UINT_EQUALS('b', dst[1]);
+    ASSERT_UINT_EQUALS(0, dst[2]);
+
+    /* check AWS_BYTE_BUF_PRI() */
+    struct aws_byte_buf buf = aws_byte_buf_from_array(src, 2);
+    memset(dst, 0, sizeof(dst));
+    snprintf(dst, sizeof(dst), PRInSTR, AWS_BYTE_BUF_PRI(buf));
+    ASSERT_UINT_EQUALS('a', dst[0]);
+    ASSERT_UINT_EQUALS('b', dst[1]);
+    ASSERT_UINT_EQUALS(0, dst[2]);
+
+    return AWS_OP_SUCCESS;
+}


### PR DESCRIPTION
Apparently, it has always been possible to print non null-terminated strings.
I had no idea until today.

Here are some helper macros to make it easier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
