### PR TITLE
aws_error_name()

### DIFF
--- a/include/aws/common/error.h
+++ b/include/aws/common/error.h
@@ -56,6 +56,12 @@ AWS_COMMON_API
 const char *aws_error_str(int err);
 
 /*
+ * Returns the enum name corresponding to `err`.
+ */
+AWS_COMMON_API
+const char *aws_error_name(int err);
+
+/*
  * Returns the error lib name corresponding to `err`.
  */
 AWS_COMMON_API

--- a/source/error.c
+++ b/source/error.c
@@ -76,6 +76,16 @@ const char *aws_error_str(int err) {
     return "Unknown Error Code";
 }
 
+const char *aws_error_name(int err) {
+    const struct aws_error_info *error_info = get_error_by_code(err);
+
+    if (error_info) {
+        return error_info->literal_name;
+    }
+
+    return "Unknown Error Code";
+}
+
 const char *aws_error_lib_name(int err) {
     const struct aws_error_info *error_info = get_error_by_code(err);
 


### PR DESCRIPTION
`aws_error_name(0)` returns "AWS_ERROR_SUCCESS"

I wanted this for logging.

Previously, you could only get the enum name via `aws_error_debug_str()` as part of a much longer string that looked like:
"aws-c-common: AWS_ERROR_SUCCESS, Success."


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
