### PR TITLE
Update harnesses for math.fallback.inl

### DIFF
--- a/.cbmc-batch/jobs/aws_add_size_checked/Makefile
+++ b/.cbmc-batch/jobs/aws_add_size_checked/Makefile
@@ -17,9 +17,9 @@
 
 CBMCFLAGS +=
 
-DEPENDENCIES = $(HELPERDIR)/source/make_common_data_structures.c \
-		   $(HELPERDIR)/stubs/error.c \
-	       $(SRCDIR)/source/common.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
 
 ENTRY = aws_add_size_checked_harness
 ###########

--- a/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
@@ -2,7 +2,7 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 /**
- * Coverage: 1.00 (29 lines out of 29 statically-reachable lines in 5 functions reached)
+ * Coverage: 1.00 (31 lines out of 31 statically-reachable lines in 5 functions reached)
  * Runtime: 0m2.025s
  *
  * Assumptions:
@@ -19,6 +19,8 @@ void aws_add_size_checked_harness() {
         uint64_t r = nondet_uint64_t();
         if (!aws_add_u64_checked(a, b, &r)) {
             assert(r == a + b);
+        } else {
+            assert((b > 0) && (a > (UINT64_MAX - b)));
         }
     } else {
         uint32_t a = nondet_uint32_t();
@@ -26,6 +28,8 @@ void aws_add_size_checked_harness() {
         uint32_t r = nondet_uint32_t();
         if (!aws_add_u32_checked(a, b, &r)) {
             assert(r == a + b);
+        } else {
+            assert((b > 0) && (a > (UINT32_MAX - b)));
         }
     }
 }

--- a/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
@@ -10,7 +10,7 @@
  *       aws_add_u64_checked functions return AWS_OP_SUCCESS.
  */
 void aws_add_size_checked_harness() {
-    if (nondet_int()) {
+    if (nondet_bool()) {
         uint64_t a = nondet_uint64_t();
         uint64_t b = nondet_uint64_t();
         uint64_t r = nondet_uint64_t();

--- a/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
@@ -6,8 +6,11 @@
  * Runtime: 0m2.025s
  *
  * Assumptions:
- *     - For any given inputs, r will never overflow, if aws_add_u32_checked or
- *       aws_add_u64_checked functions return AWS_OP_SUCCESS.
+ *     - given 2 non-deterministics unsigned integers
+ *
+ * Assertions:
+ *     - r does not overflow, if aws_add_u32_checked or
+ *       aws_add_u64_checked functions return AWS_OP_SUCCESS
  */
 void aws_add_size_checked_harness() {
     if (nondet_bool()) {

--- a/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
@@ -17,13 +17,15 @@ void aws_add_size_checked_harness() {
         uint64_t a = nondet_uint64_t();
         uint64_t b = nondet_uint64_t();
         uint64_t r = nondet_uint64_t();
-        if (!aws_add_u64_checked(a, b, &r))
+        if (!aws_add_u64_checked(a, b, &r)) {
             assert(r == a + b);
+        }
     } else {
         uint32_t a = nondet_uint32_t();
         uint32_t b = nondet_uint32_t();
         uint32_t r = nondet_uint32_t();
-        if (!aws_add_u32_checked(a, b, &r))
+        if (!aws_add_u32_checked(a, b, &r)) {
             assert(r == a + b);
+        }
     }
 }

--- a/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
@@ -2,48 +2,25 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 /**
- * Adds a + b and returns the result in *r. If the result
- * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCCESS.
- */
-AWS_STATIC_IMPL int __aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    uint64_t x = a + b;
-    *r = x;
-    if (x < a) {
-        return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
-    }
-    return AWS_OP_SUCCESS;
-}
-
-/**
- * Adds a + b and returns the result in *r. If the result
- * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCCESS.
- */
-AWS_STATIC_IMPL int __aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
-    uint32_t x = a + b;
-    *r = x;
-    if (x < a) {
-        return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
-    }
-    return AWS_OP_SUCCESS;
-}
-
-/**
+ * Coverage: 1.00 (29 lines out of 29 statically-reachable lines in 5 functions reached)
  * Runtime: 0m2.025s
+ *
+ * Assumptions:
+ *     - For any given inputs, r will never overflow, if aws_add_u32_checked or
+ *       aws_add_u64_checked functions return AWS_OP_SUCCESS.
  */
 void aws_add_size_checked_harness() {
-    size_t r = nondet_size_t();
-    size_t __r = nondet_size_t();
-    __CPROVER_assume(r == __r);
-
     if (nondet_int()) {
         uint64_t a = nondet_uint64_t();
         uint64_t b = nondet_uint64_t();
-        if (aws_add_u64_checked(a, b, &r) == AWS_OP_SUCCESS && __aws_add_u64_checked(a, b, &__r) == AWS_OP_SUCCESS)
-            assert(r == __r);
+        uint64_t r = nondet_uint64_t();
+        if (!aws_add_u64_checked(a, b, &r))
+            assert(r == a + b);
     } else {
         uint32_t a = nondet_uint32_t();
         uint32_t b = nondet_uint32_t();
-        if (aws_add_u32_checked(a, b, &r) == AWS_OP_SUCCESS && __aws_add_u32_checked(a, b, &__r) == AWS_OP_SUCCESS)
-            assert(r == __r);
+        uint32_t r = nondet_uint32_t();
+        if (!aws_add_u32_checked(a, b, &r))
+            assert(r == a + b);
     }
 }

--- a/.cbmc-batch/jobs/aws_add_size_saturating/Makefile
+++ b/.cbmc-batch/jobs/aws_add_size_saturating/Makefile
@@ -17,9 +17,9 @@
 
 CBMCFLAGS +=
 
-DEPENDENCIES =  $(HELPERDIR)/source/make_common_data_structures.c \
-		   $(HELPERDIR)/stubs/error.c \
-	       $(SRCDIR)/source/common.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
 
 ENTRY = aws_add_size_saturating_harness
 ###########

--- a/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
@@ -2,38 +2,29 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 /**
- * Adds a + b.  If the result overflows returns 2^64 - 1.
- */
-AWS_STATIC_IMPL uint64_t __aws_add_u64_saturating(uint64_t a, uint64_t b) {
-    uint64_t x = a + b;
-    if (x < a) {
-        return UINT64_MAX;
-    }
-    return x;
-}
-
-/**
- * Adds a + b. If the result overflows returns 2^32 - 1.
- */
-AWS_STATIC_IMPL uint32_t __aws_add_u32_saturating(uint32_t a, uint32_t b) {
-    uint32_t x = a + b;
-    if (x < a) {
-        return UINT32_MAX;
-    }
-    return x;
-}
-
-/**
- * Runtime: 0m2.608s
+ * Coverage: 1.00 (24 lines out of 24 statically-reachable lines in 3 functions reached)
+ * Runtime: 0m2.698s
+ *
+ * Assumptions:
+ *     - If a + b overflows, aws_add_u32_saturating and aws_add_u64_saturating
+ *       functions must always return the corresponding saturated value.
  */
 void aws_add_size_saturating_harness() {
     if (nondet_int()) {
         uint64_t a = nondet_uint64_t();
         uint64_t b = nondet_uint64_t();
-        assert(aws_add_u64_saturating(a, b) == __aws_add_u64_saturating(a, b));
+        uint64_t r = aws_add_u64_saturating(a, b);
+        if ((b > 0) && (a > (UINT64_MAX - b)))
+            assert(r == UINT64_MAX);
+        else
+            assert(r == a + b);
     } else {
         uint32_t a = nondet_uint32_t();
         uint32_t b = nondet_uint32_t();
-        assert(aws_add_u32_saturating(a, b) == __aws_add_u32_saturating(a, b));
+        uint32_t r = aws_add_u32_saturating(a, b);
+        if ((b > 0) && (a > (UINT32_MAX - b)))
+            assert(r == UINT32_MAX);
+        else
+            assert(r == a + b);
     }
 }

--- a/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
@@ -10,7 +10,7 @@
  *       functions must always return the corresponding saturated value.
  */
 void aws_add_size_saturating_harness() {
-    if (nondet_int()) {
+    if (nondet_bool()) {
         uint64_t a = nondet_uint64_t();
         uint64_t b = nondet_uint64_t();
         uint64_t r = aws_add_u64_saturating(a, b);

--- a/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
@@ -6,8 +6,11 @@
  * Runtime: 0m2.698s
  *
  * Assumptions:
- *     - If a + b overflows, aws_add_u32_saturating and aws_add_u64_saturating
- *       functions must always return the corresponding saturated value.
+ *     - given 2 non-deterministics unsigned integers
+ *
+ * Assertions:
+ *     - if a + b overflows, aws_add_u32_saturating and aws_add_u64_saturating
+ *       functions must always return the corresponding saturated value
  */
 void aws_add_size_saturating_harness() {
     if (nondet_bool()) {

--- a/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_saturating/aws_add_size_saturating_harness.c
@@ -17,17 +17,19 @@ void aws_add_size_saturating_harness() {
         uint64_t a = nondet_uint64_t();
         uint64_t b = nondet_uint64_t();
         uint64_t r = aws_add_u64_saturating(a, b);
-        if ((b > 0) && (a > (UINT64_MAX - b)))
+        if ((b > 0) && (a > (UINT64_MAX - b))) {
             assert(r == UINT64_MAX);
-        else
+        } else {
             assert(r == a + b);
+        }
     } else {
         uint32_t a = nondet_uint32_t();
         uint32_t b = nondet_uint32_t();
         uint32_t r = aws_add_u32_saturating(a, b);
-        if ((b > 0) && (a > (UINT32_MAX - b)))
+        if ((b > 0) && (a > (UINT32_MAX - b))) {
             assert(r == UINT32_MAX);
-        else
+        } else {
             assert(r == a + b);
+        }
     }
 }

--- a/.cbmc-batch/jobs/aws_mul_size_checked/Makefile
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/Makefile
@@ -17,9 +17,9 @@
 
 CBMCFLAGS +=
 
-DEPENDENCIES =  $(HELPERDIR)/source/make_common_data_structures.c \
-		   $(HELPERDIR)/stubs/error.c \
-  	       $(SRCDIR)/source/common.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
 
 ENTRY = aws_mul_size_checked_harness
 ###########

--- a/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -21,8 +21,9 @@ void aws_mul_size_checked_harness() {
         uint64_t a = (nondet_int()) ? 0 : UINT64_MAX;
         uint64_t b = nondet_uint64_t();
         uint64_t r = nondet_uint64_t();
-        if (!aws_mul_u64_checked(a, b, &r))
+        if (!aws_mul_u64_checked(a, b, &r)) {
             assert(r == a * b);
+        }
     } else {
         /*
          * In this particular case, full range of nondet inputs leads
@@ -31,7 +32,8 @@ void aws_mul_size_checked_harness() {
         uint32_t a = (nondet_bool()) ? 0 : UINT32_MAX;
         uint32_t b = nondet_uint32_t();
         uint32_t r = nondet_uint32_t();
-        if (!aws_mul_u32_checked(a, b, &r))
+        if (!aws_mul_u32_checked(a, b, &r)) {
             assert(r == a * b);
+        }
     }
 }

--- a/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -10,7 +10,7 @@
  *       or aws_mul_u64_checked functions return AWS_OP_SUCCESS.
  */
 void aws_mul_size_checked_harness() {
-    if (nondet_int()) {
+    if (nondet_bool()) {
         /*
          * In this particular case, full range of nondet inputs leads
          * to excessively long runtimes, so use 0 or UINT64_MAX instead.
@@ -25,7 +25,7 @@ void aws_mul_size_checked_harness() {
          * In this particular case, full range of nondet inputs leads
          * to excessively long runtimes, so use 0 or UINT32_MAX instead.
          */
-        uint32_t a = (nondet_int()) ? 0 : UINT32_MAX;
+        uint32_t a = (nondet_bool()) ? 0 : UINT32_MAX;
         uint32_t b = nondet_uint32_t();
         uint32_t r = nondet_uint32_t();
         if (!aws_mul_u32_checked(a, b, &r))

--- a/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -2,7 +2,7 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 /**
- * Coverage: 1.00 (29 lines out of 29 statically-reachable lines in 5 functions reached)
+ * Coverage: 1.00 (31 lines out of 31 statically-reachable lines in 5 functions reached)
  * Runtime: 0m3.302s
  *
  * Assumptions:
@@ -23,6 +23,8 @@ void aws_mul_size_checked_harness() {
         uint64_t r = nondet_uint64_t();
         if (!aws_mul_u64_checked(a, b, &r)) {
             assert(r == a * b);
+        } else {
+            assert((b > 0) && (a > (UINT64_MAX - b)));
         }
     } else {
         /*
@@ -34,6 +36,8 @@ void aws_mul_size_checked_harness() {
         uint32_t r = nondet_uint32_t();
         if (!aws_mul_u32_checked(a, b, &r)) {
             assert(r == a * b);
+        } else {
+            assert((b > 0) && (a > (UINT32_MAX - b)));
         }
     }
 }

--- a/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -2,56 +2,33 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 /**
- * Multiplies a * b and returns the result in *r. If the result
- * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCCESS.
- */
-AWS_STATIC_IMPL int __aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    uint64_t x = a * b;
-    *r = x;
-    if (a != 0 && (a > UINT32_MAX || b > UINT32_MAX) && x / a != b) {
-        return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
-    }
-    return AWS_OP_SUCCESS;
-}
-
-/**
- * Multiplies a * b and returns the result in *r. If the result
- * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCCESS.
- */
-AWS_STATIC_IMPL int __aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
-    uint32_t x = a * b;
-    *r = x;
-    if (a != 0 && (a > UINT16_MAX || b > UINT16_MAX) && x / a != b) {
-        return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
-    }
-    return AWS_OP_SUCCESS;
-}
-
-/**
- * Runtime: 0m3.872s
+ * Coverage: 1.00 (29 lines out of 29 statically-reachable lines in 5 functions reached)
+ * Runtime: 0m3.302s
+ *
+ * Assumptions:
+ *     - For any given inputs, r will never overflow, if aws_mul_u32_checked
+ *       or aws_mul_u64_checked functions return AWS_OP_SUCCESS.
  */
 void aws_mul_size_checked_harness() {
-    size_t r = nondet_size_t();
-    size_t __r = nondet_size_t();
-    __CPROVER_assume(r == __r);
-
     if (nondet_int()) {
         /*
          * In this particular case, full range of nondet inputs leads
-         * to excessively long runtimes, so use UINT64_MAX instead.
+         * to excessively long runtimes, so use 0 or UINT64_MAX instead.
          */
-        uint64_t a = UINT64_MAX;
+        uint64_t a = (nondet_int()) ? 0 : UINT64_MAX;
         uint64_t b = nondet_uint64_t();
-        if (aws_mul_u64_checked(a, b, &r) == AWS_OP_SUCCESS && __aws_mul_u64_checked(a, b, &__r) == AWS_OP_SUCCESS)
-            assert(r == __r);
+        uint64_t r = nondet_uint64_t();
+        if (!aws_mul_u64_checked(a, b, &r))
+            assert(r == a * b);
     } else {
         /*
          * In this particular case, full range of nondet inputs leads
-         * to excessively long runtimes, so use UINT32_MAX instead.
+         * to excessively long runtimes, so use 0 or UINT32_MAX instead.
          */
-        uint32_t a = UINT32_MAX;
+        uint32_t a = (nondet_int()) ? 0 : UINT32_MAX;
         uint32_t b = nondet_uint32_t();
-        if (aws_mul_u32_checked(a, b, &r) == AWS_OP_SUCCESS && __aws_mul_u32_checked(a, b, &__r) == AWS_OP_SUCCESS)
-            assert(r == __r);
+        uint32_t r = nondet_uint32_t();
+        if (!aws_mul_u32_checked(a, b, &r))
+            assert(r == a * b);
     }
 }

--- a/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -6,8 +6,11 @@
  * Runtime: 0m3.302s
  *
  * Assumptions:
- *     - For any given inputs, r will never overflow, if aws_mul_u32_checked
- *       or aws_mul_u64_checked functions return AWS_OP_SUCCESS.
+ *     - given 2 non-deterministics unsigned integers
+ *
+ * Assertions:
+ *     - r does not overflow, if aws_mul_u32_checked or
+ *       aws_mul_u64_checked functions return AWS_OP_SUCCESS
  */
 void aws_mul_size_checked_harness() {
     if (nondet_bool()) {

--- a/.cbmc-batch/jobs/aws_mul_size_saturating/Makefile
+++ b/.cbmc-batch/jobs/aws_mul_size_saturating/Makefile
@@ -17,9 +17,9 @@
 
 CBMCFLAGS +=
 
-DEPENDENCIES =  $(HELPERDIR)/source/make_common_data_structures.c \
-		   $(HELPERDIR)/stubs/error.c \
-	       $(SRCDIR)/source/common.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
 
 ENTRY = aws_mul_size_saturating_harness
 ###########

--- a/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
@@ -6,8 +6,11 @@
  * Runtime: 0m2.962s
  *
  * Assumptions:
- *     - If a * b overflows, aws_mul_u32_saturating and aws_mul_u64_saturating
- *       functions must always return the corresponding saturated value.
+ *     - given 2 non-deterministics unsigned integers
+ *
+ * Assertions:
+ *     - if a * b overflows, aws_mul_u32_saturating and aws_mul_u64_saturating
+ *       functions must always return the corresponding saturated value
  */
 void aws_mul_size_saturating_harness() {
     if (nondet_bool()) {

--- a/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
@@ -21,10 +21,11 @@ void aws_mul_size_saturating_harness() {
         uint64_t a = (nondet_int()) ? 0 : UINT64_MAX;
         uint64_t b = nondet_uint64_t();
         uint64_t r = aws_mul_u64_saturating(a, b);
-        if (a > 0 && b > 0 && a > (UINT64_MAX / b))
+        if (a > 0 && b > 0 && a > (UINT64_MAX / b)) {
             assert(r == UINT64_MAX);
-        else
+        } else {
             assert(r == a * b);
+        }
     } else {
         /*
          * In this particular case, full range of nondet inputs leads
@@ -33,9 +34,10 @@ void aws_mul_size_saturating_harness() {
         uint32_t a = (nondet_bool()) ? 0 : UINT32_MAX;
         uint32_t b = nondet_uint32_t();
         uint32_t r = aws_mul_u32_saturating(a, b);
-        if (a > 0 && b > 0 && a > (UINT32_MAX / b))
+        if (a > 0 && b > 0 && a > (UINT32_MAX / b)) {
             assert(r == UINT32_MAX);
-        else
+        } else {
             assert(r == a * b);
+        }
     }
 }

--- a/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
@@ -10,7 +10,7 @@
  *       functions must always return the corresponding saturated value.
  */
 void aws_mul_size_saturating_harness() {
-    if (nondet_int()) {
+    if (nondet_bool()) {
         /*
          * In this particular case, full range of nondet inputs leads
          * to excessively long runtimes, so use 0 or UINT64_MAX instead.
@@ -27,7 +27,7 @@ void aws_mul_size_saturating_harness() {
          * In this particular case, full range of nondet inputs leads
          * to excessively long runtimes, so use 0 or UINT32_MAX instead.
          */
-        uint32_t a = (nondet_int()) ? 0 : UINT32_MAX;
+        uint32_t a = (nondet_bool()) ? 0 : UINT32_MAX;
         uint32_t b = nondet_uint32_t();
         uint32_t r = aws_mul_u32_saturating(a, b);
         if (a > 0 && b > 0 && a > (UINT32_MAX / b))

--- a/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_saturating/aws_mul_size_saturating_harness.c
@@ -2,46 +2,37 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 /**
- * Multiplies a * b. If the result overflows, returns 2^64 - 1.
- */
-AWS_STATIC_IMPL uint64_t __aws_mul_u64_saturating(uint64_t a, uint64_t b) {
-    uint64_t x = a * b;
-    if (a != 0 && (a > UINT32_MAX || b > UINT32_MAX) && x / a != b) {
-        return UINT64_MAX;
-    }
-    return x;
-}
-
-/**
- * Multiplies a * b. If the result overflows, returns 2^32 - 1.
- */
-AWS_STATIC_IMPL uint32_t __aws_mul_u32_saturating(uint32_t a, uint32_t b) {
-    uint32_t x = a * b;
-    if (a != 0 && (a > UINT16_MAX || b > UINT16_MAX) && x / a != b) {
-        return UINT32_MAX;
-    }
-    return x;
-}
-
-/**
- * Runtime: 0m3.393s
+ * Coverage: 1.00 (24 lines out of 24 statically-reachable lines in 3 functions reached)
+ * Runtime: 0m2.962s
+ *
+ * Assumptions:
+ *     - If a * b overflows, aws_mul_u32_saturating and aws_mul_u64_saturating
+ *       functions must always return the corresponding saturated value.
  */
 void aws_mul_size_saturating_harness() {
     if (nondet_int()) {
         /*
          * In this particular case, full range of nondet inputs leads
-         * to excessively long runtimes, so use UINT64_MAX instead.
+         * to excessively long runtimes, so use 0 or UINT64_MAX instead.
          */
-        uint64_t a = UINT64_MAX;
+        uint64_t a = (nondet_int()) ? 0 : UINT64_MAX;
         uint64_t b = nondet_uint64_t();
-        assert(aws_mul_u64_saturating(a, b) == __aws_mul_u64_saturating(a, b));
+        uint64_t r = aws_mul_u64_saturating(a, b);
+        if (a > 0 && b > 0 && a > (UINT64_MAX / b))
+            assert(r == UINT64_MAX);
+        else
+            assert(r == a * b);
     } else {
         /*
          * In this particular case, full range of nondet inputs leads
-         * to excessively long runtimes, so use UINT32_MAX instead.
+         * to excessively long runtimes, so use 0 or UINT32_MAX instead.
          */
-        uint32_t a = UINT32_MAX;
+        uint32_t a = (nondet_int()) ? 0 : UINT32_MAX;
         uint32_t b = nondet_uint32_t();
-        assert(aws_mul_u32_saturating(a, b) == __aws_mul_u32_saturating(a, b));
+        uint32_t r = aws_mul_u32_saturating(a, b);
+        if (a > 0 && b > 0 && a > (UINT32_MAX / b))
+            assert(r == UINT32_MAX);
+        else
+            assert(r == a * b);
     }
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Remove old implementation from harnesses to avoid proof failures when `unsigned-overflow-check` flag is used. The new harnesses only check the current implementation of the `math.fallback.inl` functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.