### PR TITLE
case-insensitive string functions

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -241,6 +241,15 @@ AWS_COMMON_API
 bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b);
 
 /**
+ * Perform a case-insensitive string comparison of two aws_byte_cursors.
+ * Returns true if a and b are equivalent.
+ * The "C" locale is used for comparing upper and lowercase letters.
+ * Data is assumed to be ASCII text, UTF-8 will work fine too.
+ */
+AWS_COMMON_API
+bool aws_byte_cursor_eq_case_insensitive(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b);
+
+/**
  * Compares an aws_byte_cursor against an aws_byte_buf
  * Returns true if a has the same length as b and their buffers have the same bytes
  * (or both buffers are null). When both a and b are null the function returns true

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -250,6 +250,13 @@ AWS_COMMON_API
 bool aws_byte_cursor_eq_case_insensitive(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b);
 
 /**
+ * Case-insensitive hash function for aws_byte_cursors stored in an aws_hash_table.
+ * For case-sensitive hashing, use aws_hash_byte_cursor_ptr().
+ */
+AWS_COMMON_API
+uint64_t aws_hash_byte_cursor_ptr_case_insensitive(const void *item);
+
+/**
  * Compares an aws_byte_cursor against an aws_byte_buf
  * Returns true if a has the same length as b and their buffers have the same bytes
  * (or both buffers are null). When both a and b are null the function returns true

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -260,6 +260,24 @@ bool aws_byte_cursor_eq_case_insensitive(const struct aws_byte_cursor *a, const 
     return true;
 }
 
+uint64_t aws_hash_byte_cursor_ptr_case_insensitive(const void *item) {
+    /* FNV-1a: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function */
+    const uint64_t fnv_offset_basis = 0xcbf29ce484222325ULL;
+    const uint64_t fnv_prime = 0x100000001b3ULL;
+
+    const struct aws_byte_cursor *cursor = item;
+    const uint8_t *i = cursor->ptr;
+    const uint8_t *end = cursor->ptr + cursor->len;
+
+    uint64_t hash = fnv_offset_basis;
+    while (i != end) {
+        const uint8_t lower = s_tolower_table[*i++];
+        hash ^= lower;
+        hash *= fnv_prime;
+    }
+    return hash;
+}
+
 bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *a, const struct aws_byte_buf *b) {
 
     if (!a || !b) {

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -227,6 +227,39 @@ bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_c
     return !memcmp(a->ptr, b->ptr, a->len);
 }
 
+/* Every possible uint8_t value, lowercased */
+static const uint8_t s_tolower_table[256] = {
+    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,
+    22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,
+    44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  'a',
+    'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
+    'x', 'y', 'z', 91,  92,  93,  94,  95,  96,  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 123, 124, 125, 126, 127, 128, 129, 130, 131,
+    132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
+    154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+    176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
+    198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+    220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
+    242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
+
+bool aws_byte_cursor_eq_case_insensitive(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
+    if (!a || !b) {
+        return a == b;
+    }
+
+    if (a->len != b->len) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a->len; ++i) {
+        if (s_tolower_table[a->ptr[i]] != s_tolower_table[b->ptr[i]]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *a, const struct aws_byte_buf *b) {
 
     if (!a || !b) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,6 +206,8 @@ add_test_case(test_buffer_eq_null_internal_byte_buffer)
 add_test_case(test_buffer_init_copy)
 add_test_case(test_buffer_init_copy_null_buffer)
 add_test_case(test_buffer_advance)
+add_test_case(test_buffer_printf)
+add_test_case(test_cursor_eq_case_insensitive)
 
 add_test_case(byte_swap_test)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -208,6 +208,7 @@ add_test_case(test_buffer_init_copy_null_buffer)
 add_test_case(test_buffer_advance)
 add_test_case(test_buffer_printf)
 add_test_case(test_cursor_eq_case_insensitive)
+add_test_case(test_cursor_hash_case_insensitive)
 
 add_test_case(byte_swap_test)
 

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -386,3 +386,32 @@ static int s_test_cursor_eq_case_insensitive(struct aws_allocator *allocator, vo
 
     return 0;
 }
+
+AWS_TEST_CASE(test_cursor_hash_case_insensitive, s_test_cursor_hash_case_insensitive)
+static int s_test_cursor_hash_case_insensitive(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    (void)allocator;
+
+    {
+        /* Check against known FNV-1A values */
+        struct aws_byte_cursor a = aws_byte_cursor_from_c_str("abc");
+        ASSERT_UINT_EQUALS(0xe71fa2190541574bULL, aws_hash_byte_cursor_ptr_case_insensitive(&a));
+
+        struct aws_byte_cursor b = aws_byte_cursor_from_c_str("ABC");
+        ASSERT_UINT_EQUALS(0xe71fa2190541574bULL, aws_hash_byte_cursor_ptr_case_insensitive(&b));
+    }
+
+    {
+        struct aws_byte_cursor a = aws_byte_cursor_from_c_str("aBc123");
+        struct aws_byte_cursor b = aws_byte_cursor_from_c_str("Abc123");
+        ASSERT_TRUE(aws_hash_byte_cursor_ptr_case_insensitive(&a) == aws_hash_byte_cursor_ptr_case_insensitive(&b));
+    }
+
+    {
+        struct aws_byte_cursor a = aws_byte_cursor_from_c_str("abc");
+        struct aws_byte_cursor b = aws_byte_cursor_from_c_str("xyz");
+        ASSERT_FALSE(aws_hash_byte_cursor_ptr_case_insensitive(&a) == aws_hash_byte_cursor_ptr_case_insensitive(&b));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Needed by aws-c-http.

Fun Fact: Did some local benchmarking. Looking up values in a static array is a 1.4X speedup vs checking if a letter is between 'A':'Z' and lowercasing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
