### PR TITLE
Remove compare function from common files

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -93,8 +93,3 @@ struct aws_string *make_arbitrary_aws_string_nondet_len(struct aws_allocator *al
  * Makes a valid string, with as much nondet as possible, len < max
  */
 struct aws_string *make_arbitrary_aws_string_nondet_len_with_max(struct aws_allocator *allocator, size_t max);
-
-/**
- * Standard implementation of compare function for qsort
- */
-int compare(const void *a, const void *b, size_t item_size);

--- a/.cbmc-batch/jobs/aws_array_list_sort/aws_array_list_sort_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_sort/aws_array_list_sort_harness.c
@@ -21,6 +21,16 @@
 #define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
 
 /**
+ * Standard implementation of compare function for qsort
+ */
+int compare(const void *a, const void *b, size_t item_size) {
+    int res;
+    __CPROVER_precondition(__CPROVER_r_ok(a, item_size), "first element readable in compare function");
+    __CPROVER_precondition(__CPROVER_r_ok(b, item_size), "second element readable in compare function");
+    return res;
+}
+
+/**
  * Runtime: 0m3.399s
  */
 void aws_array_list_sort_harness() {

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -121,9 +121,3 @@ struct aws_string *make_arbitrary_aws_string_nondet_len_with_max(struct aws_allo
     __CPROVER_assume(len < max);
     return make_arbitrary_aws_string(allocator, len);
 }
-
-int compare(const void *a, const void *b, size_t item_size) {
-    __CPROVER_precondition(__CPROVER_r_ok(a, item_size), "first element readable in compare function");
-    __CPROVER_precondition(__CPROVER_r_ok(b, item_size), "second element readable in compare function");
-    return nondet_int();
-}


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Remove compare function from `make_common_data_structures` files to the harness `aws_array_list_sort_harness`. I don't see any advantage to include this particular implementation in any common file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
