### PR TITLE
Move the hash_table impl structs to their own .h file

### DIFF
--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -1,0 +1,42 @@
+#ifndef AWS_COMMON_PRIVATE_HASH_TABLE_IMPL_H
+#define AWS_COMMON_PRIVATE_HASH_TABLE_IMPL_H
+
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+
+struct hash_table_entry {
+    struct aws_hash_element element;
+    uint64_t hash_code; /* hash code (0 signals empty) */
+};
+
+struct hash_table_state {
+    aws_hash_fn *hash_fn;
+    aws_hash_callback_eq_fn *equals_fn;
+    aws_hash_callback_destroy_fn *destroy_key_fn;
+    aws_hash_callback_destroy_fn *destroy_value_fn;
+    struct aws_allocator *alloc;
+
+    size_t size, entry_count;
+    size_t max_load;
+    /* We AND a hash value with mask to get the slot index */
+    size_t mask;
+    double max_load_factor;
+    /* actually variable length */
+    struct hash_table_entry slots[1];
+};
+
+#endif /* AWS_COMMON_PRIVATE_HASH_TABLE_IMPL_H */

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -19,9 +19,9 @@
  */
 
 #include <aws/common/hash_table.h>
-
 #include <aws/common/math.h>
 #include <aws/common/string.h>
+#include <aws/common/private/hash_table_impl.h>
 
 #include <limits.h>
 #include <stdio.h>
@@ -40,27 +40,6 @@ static void s_suppress_unused_lookup3_func_warnings(void) {
     (void)hashlittle;
     (void)hashbig;
 }
-
-struct hash_table_entry {
-    struct aws_hash_element element;
-    uint64_t hash_code; /* hash code (0 signals empty) */
-};
-
-struct hash_table_state {
-    aws_hash_fn *hash_fn;
-    aws_hash_callback_eq_fn *equals_fn;
-    aws_hash_callback_destroy_fn *destroy_key_fn;
-    aws_hash_callback_destroy_fn *destroy_value_fn;
-    struct aws_allocator *alloc;
-
-    size_t size, entry_count;
-    size_t max_load;
-    /* We AND a hash value with mask to get the slot index */
-    size_t mask;
-    double max_load_factor;
-    /* actually variable length */
-    struct hash_table_entry slots[1];
-};
 
 static uint64_t s_hash_for(struct hash_table_state *state, const void *key) {
     s_suppress_unused_lookup3_func_warnings();

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -20,8 +20,8 @@
 
 #include <aws/common/hash_table.h>
 #include <aws/common/math.h>
-#include <aws/common/string.h>
 #include <aws/common/private/hash_table_impl.h>
+#include <aws/common/string.h>
 
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
*Description of changes:*
Put the hash_table implementation structures in a private header file so they can be used for the CBMC proofs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
