### PR TITLE
Rewrite aws_array_list_back harness with new proof style

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -21,6 +21,7 @@
 #include <aws/common/string.h>
 #include <proof_helpers/nondet.h>
 #include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
 
 #include <stdlib.h>
 
@@ -61,6 +62,16 @@ bool is_bounded_byte_cursor(struct aws_byte_cursor *cursor, size_t max_size);
  * Ensures aws_byte_cursor has a proper allocated buffer member
  */
 void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *cursor);
+
+/*
+ * Checks whether aws_array_list is bounded by max_initial_item_allocation and max_item_size
+ */
+bool aws_array_list_is_bounded(struct aws_array_list *list, size_t max_initial_item_allocation, size_t max_item_size);
+
+/**
+ * Ensures the data member of an aws_array_list structure is correctly allocated
+ */
+void ensure_array_list_has_allocated_data_member(struct aws_array_list *list);
 
 /**
  * Makes an array list, with as much nondet as possible, defined initial_item_allocation and defined item_size

--- a/.cbmc-batch/include/proof_helpers/proof_allocators.h
+++ b/.cbmc-batch/include/proof_helpers/proof_allocators.h
@@ -14,7 +14,10 @@
  */
 
 #pragma once
+
 #include <aws/common/common.h>
+#include <proof_helpers/nondet.h>
+#include <stdlib.h>
 
 /*
  * CBMC has an internal representation in which each object has an index and a (signed) offset

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -15,9 +15,33 @@
 
 #pragma once
 
+#include <aws/common/array_list.h>
+#include <proof_helpers/nondet.h>
 #include <stddef.h>
 #include <stdint.h>
+
+struct store_byte_from_buffer {
+    size_t index;
+    uint8_t byte;
+};
 
 void assert_bytes_match(const uint8_t *a, const uint8_t *b, size_t len);
 void assert_all_bytes_are(const uint8_t *a, const uint8_t c, size_t len);
 void assert_all_zeroes(const uint8_t *a, size_t len);
+void assert_byte_from_buffer_matches(const uint8_t *buffer, struct store_byte_from_buffer *b);
+
+/**
+ * Nondeterministically selects a byte from array and stores it into a
+ * store_array_list_byte structure.
+ */
+void save_byte_from_array(uint8_t *array, size_t size, struct store_byte_from_buffer *storage);
+
+/**
+ * Asserts two aws_array_list structures are equivalent. Prior to using this function,
+ * it is necessary to select a non-deterministic byte from the rhs aws_array_list structure
+ * (use save_byte_from_array function), so it can properly assert all bytes match.
+ */
+void assert_array_list_equivalence(
+    struct aws_array_list *lhs,
+    struct aws_array_list *rhs,
+    struct store_byte_from_buffer *rhs_byte);

--- a/.cbmc-batch/jobs/Makefile.aws_array_list
+++ b/.cbmc-batch/jobs/Makefile.aws_array_list
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+
+# Sufficently long to get full coverage on the aws_array_list APIs
+# short enough that all proofs complete quickly
+MAX_ITEM_SIZE ?= 2
+
+# Necessary to get full coverage when using functions from math.h
+MAX_INITIAL_ITEM_ALLOCATION ?= 9223372036854775808
+
+DEFINES += -DMAX_ITEM_SIZE=$(MAX_ITEM_SIZE)
+DEFINES += -DMAX_INITIAL_ITEM_ALLOCATION=$(MAX_INITIAL_ITEM_ALLOCATION)

--- a/.cbmc-batch/jobs/aws_array_list_back/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_back/Makefile
@@ -12,14 +12,18 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+# This bound allow us to reach full coverage rate
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
@@ -16,40 +16,33 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m5.349s
+ * Runtime: 19s
  */
 void aws_array_list_back_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
 
-    void *val = malloc(list->item_size);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    if (!aws_array_list_back(list, val)) {
-        assert(list->data);
-        assert(list->length);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
+
+    /* perform operation under verification */
+    uint8_t *val = bounded_malloc(list.item_size);
+    if (aws_array_list_back(&list, val) == AWS_OP_SUCCESS) {
+        /* In the case aws_array_list_back is successful, we can ensure the list isn't empty */
+        assert(list.data != NULL);
+        assert(list.length != 0);
     }
 
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->length == length);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    assert_array_list_equivalence(&list, &old, &old_byte);
 }

--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_back_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--function;aws_array_list_back_harness"
 goto: aws_array_list_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/Makefile
@@ -12,11 +12,10 @@
 # limitations under the License.
 
 ###########
-# This size is suficcient to get full code coverage 
+# This size is suficcient to get full code coverage
 MAX_BUF_SIZE ?= 10
 DEFINES += -DMAX_BUF_SIZE=$(MAX_BUF_SIZE)
 
-#A hash entry is 24 bytes, which is 3 iters. So we need 3 * MAX_TABLE_SIZE + 1
 UNWINDSET += aws_byte_buf_append_with_lookup.0:$(shell echo $$(($(MAX_BUF_SIZE) + 1)))
 
 CBMCFLAGS +=

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -13,10 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/common.h>
-#include <proof_helpers/nondet.h>
 #include <proof_helpers/proof_allocators.h>
-#include <stdlib.h>
 
 /**
  * Use the can_fail_malloc() defined above to specalize allocation for finding bugs

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -16,7 +16,8 @@
 #include <proof_helpers/utils.h>
 
 void assert_bytes_match(const uint8_t *a, const uint8_t *b, size_t len) {
-    if (len > 0) {
+    assert(!a == !b);
+    if (len > 0 && a != NULL && b != NULL) {
         size_t i;
         __CPROVER_assume(i < len);
         assert(a[i] == b[i]);
@@ -24,7 +25,7 @@ void assert_bytes_match(const uint8_t *a, const uint8_t *b, size_t len) {
 }
 
 void assert_all_bytes_are(const uint8_t *a, const uint8_t c, size_t len) {
-    if (len > 0) {
+    if (len > 0 && a != NULL) {
         size_t i;
         __CPROVER_assume(i < len);
         assert(a[i] == c);
@@ -33,4 +34,31 @@ void assert_all_bytes_are(const uint8_t *a, const uint8_t c, size_t len) {
 
 void assert_all_zeroes(const uint8_t *a, size_t len) {
     assert_all_bytes_are(a, 0, len);
+}
+
+void assert_byte_from_buffer_matches(const uint8_t *buffer, struct store_byte_from_buffer *b) {
+    if (buffer) {
+        assert(*(buffer + b->index) == b->byte);
+    }
+}
+
+void save_byte_from_array(uint8_t *array, size_t size, struct store_byte_from_buffer *storage) {
+    if (size > 0) {
+        storage->index = nondet_size_t();
+        __CPROVER_assume(storage->index < size);
+        storage->byte = array[storage->index];
+    }
+}
+
+void assert_array_list_equivalence(
+    struct aws_array_list *lhs,
+    struct aws_array_list *rhs,
+    struct store_byte_from_buffer *rhs_byte) {
+    assert(lhs->alloc == rhs->alloc);
+    assert(lhs->current_size == rhs->current_size);
+    assert(lhs->length == rhs->length);
+    assert(lhs->item_size == rhs->item_size);
+    if (lhs->current_size > 0) {
+        assert_byte_from_buffer_matches((uint8_t *)lhs->data, rhs_byte);
+    }
 }

--- a/include/aws/common/array_list.h
+++ b/include/aws/common/array_list.h
@@ -69,6 +69,12 @@ void aws_array_list_init_static(
     size_t item_size);
 
 /**
+ * Set of properties of a valid aws_array_list.
+ */
+AWS_STATIC_IMPL
+bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list);
+
+/**
  * Deallocates any memory that was allocated for this list, and resets list for reuse or deletion.
  */
 AWS_STATIC_IMPL


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This PR proposes a new proof style for `aws_array_list_back`, in order to improve readability and code quality of our proofs, which transit from an imperative style to a more functional one. This new proof style will be gradually implemented in all proofs. This PR also adds pre and postconditions to `aws_array_list_back` function, so we can ensure they will always operate over valid `aws_array_list` structures.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.