### PR TITLE
Memory safety proofs for new aws_byte_buf functions

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -37,6 +37,31 @@
 #define ASSUME_BOUNDED_ARRAY_LIST(list, max_initial_item_allocation, max_item_size)                                    \
     list = make_bounded_array_list((max_initial_item_allocation), (max_item_size))
 
+/*
+ * Checks whether aws_byte_buf is bounded by max_size
+ */
+bool is_bounded_byte_buf(struct aws_byte_buf *buf, size_t max_size);
+
+/*
+ * Checks whether aws_byte_buf has the correct allocator
+ */
+bool is_byte_buf_expected_alloc(struct aws_byte_buf *buf);
+
+/*
+ * Ensures aws_byte_buf has a proper allocated buffer member
+ */
+void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *buf);
+
+/*
+ * Checks whether aws_byte_cursor is bounded by max_size
+ */
+bool is_bounded_byte_cursor(struct aws_byte_cursor *cursor, size_t max_size);
+
+/*
+ * Ensures aws_byte_cursor has a proper allocated buffer member
+ */
+void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *cursor);
+
 /**
  * Makes an array list, with as much nondet as possible, defined initial_item_allocation and defined item_size
  */

--- a/.cbmc-batch/include/proof_helpers/proof_allocators.h
+++ b/.cbmc-batch/include/proof_helpers/proof_allocators.h
@@ -32,6 +32,13 @@ static void *can_fail_malloc_allocator(struct aws_allocator *allocator, size_t s
 
 void *can_fail_malloc(size_t size);
 
+/**
+ * CBMC considers malloc always successed for any given size. However, a real machine
+ * can only provide the available size from the pointer until the end of the address space.
+ * This function models the real machine behaviour.
+ */
+void *bounded_malloc(size_t size);
+
 static void can_fail_free(struct aws_allocator *allocator, void *ptr);
 
 static void *can_fail_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize);

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+CBMC_UNWINDSET =
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_append_dynamic_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_append_dynamic_harness() {
+    struct aws_byte_buf to;
+    __CPROVER_assume(is_valid_byte_buf(&to));
+    ensure_byte_buf_has_allocated_buffer_member(&to);
+
+    struct aws_byte_cursor from;
+    __CPROVER_assume(is_valid_byte_cursor(&from));
+    ensure_byte_cursor_has_allocated_buffer_member(&from);
+
+    aws_byte_buf_append_dynamic(&to, &from);
+
+    assert(is_valid_byte_buf(&to));
+    assert(is_byte_buf_expected_alloc(&to));
+    assert(is_valid_byte_cursor(&from));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_byte_buf_append_dynamic_harness"
+goto: aws_byte_buf_append_dynamic_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# This size is suficcient to get full code coverage 
+MAX_BUF_SIZE ?= 10
+DEFINES += -DMAX_BUF_SIZE=$(MAX_BUF_SIZE)
+
+#A hash entry is 24 bytes, which is 3 iters. So we need 3 * MAX_TABLE_SIZE + 1
+UNWINDSET += aws_byte_buf_append_with_lookup.0:$(shell echo $$(($(MAX_BUF_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_append_with_lookup_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_append_with_lookup_harness() {
+    struct aws_byte_buf to;
+    __CPROVER_assume(is_bounded_byte_buf(&to, MAX_BUF_SIZE));
+    __CPROVER_assume(is_valid_byte_buf(&to));
+    ensure_byte_buf_has_allocated_buffer_member(&to);
+
+    struct aws_byte_cursor from;
+    __CPROVER_assume(is_bounded_byte_cursor(&from, MAX_BUF_SIZE));
+    __CPROVER_assume(is_valid_byte_cursor(&from));
+    ensure_byte_cursor_has_allocated_buffer_member(&from);
+
+    /**
+     * The specification for the function requires that the buffer
+     * be at least 256 bytes.
+     */
+    uint8_t *lookup_table[256];
+    aws_byte_buf_append_with_lookup(&to, &from, lookup_table);
+
+    assert(is_valid_byte_buf(&to));
+    assert(is_byte_buf_expected_alloc(&to));
+    assert(is_valid_byte_cursor(&from));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_byte_buf_append_with_lookup.0:11;--function;aws_byte_buf_append_with_lookup_harness"
+goto: aws_byte_buf_append_with_lookup_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+CBMC_UNWINDSET =
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_reserve_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_reserve_harness() {
+    struct aws_byte_buf buf;
+    __CPROVER_assume(is_valid_byte_buf(&buf));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+
+    struct aws_byte_buf old = buf;
+    size_t requested_capacity;
+    int rval = aws_byte_buf_reserve(&buf, requested_capacity);
+
+    if (rval == AWS_OP_SUCCESS) {
+        assert(buf.capacity >= requested_capacity);
+    }
+    assert(is_valid_byte_buf(&buf));
+    assert(is_byte_buf_expected_alloc(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_byte_buf_reserve_harness"
+goto: aws_byte_buf_reserve_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -21,6 +21,27 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+bool is_bounded_byte_buf(struct aws_byte_buf *buf, size_t max_size) {
+    return buf->capacity <= max_size;
+}
+
+bool is_byte_buf_expected_alloc(struct aws_byte_buf *buf) {
+    return (buf->allocator == can_fail_allocator());
+}
+
+void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *buf) {
+    buf->allocator = can_fail_allocator();
+    buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * buf->capacity);
+}
+
+bool is_bounded_byte_cursor(struct aws_byte_cursor *cursor, size_t max_size) {
+    return cursor->len <= max_size;
+}
+
+void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *cursor) {
+    cursor->ptr = bounded_malloc(cursor->len);
+}
+
 struct aws_array_list *make_arbitrary_array_list(size_t initial_item_allocation, size_t item_size) {
     struct aws_array_list *list;
     /* Assume list is allocated */

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -38,6 +38,17 @@ void *can_fail_malloc(size_t size) {
     return (nondet) ? NULL : malloc(size);
 }
 
+void *bounded_malloc(size_t size) {
+    void *rval = malloc(size);
+    /*
+     * Malloc can only perform a successful allocation up to the amount of
+     * remaining memory: i.e. from the pointer until the end of the address space.
+     * On reasonable architectures, SIZE_MAX is the same # of bits as the address space.
+     */
+    __CPROVER_assume(size < SIZE_MAX - (size_t)(rval));
+    return rval;
+}
+
 static void can_fail_free(struct aws_allocator *allocator, void *ptr) {
     (void)allocator;
     free(ptr);

--- a/.cbmc-batch/stubs/memcpy_override_no_op.c
+++ b/.cbmc-batch/stubs/memcpy_override_no_op.c
@@ -35,8 +35,8 @@ void *memcpy_impl(void *dst, const void *src, size_t n) {
         __CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src) ||
             ((const char *)src >= (const char *)dst + n) || ((const char *)dst >= (const char *)src + n),
         "memcpy src/dst overlap");
-    __CPROVER_precondition(__CPROVER_r_ok(src, n), "memcpy source region readable");
-    __CPROVER_precondition(__CPROVER_w_ok(dst, n), "memcpy destination region writeable");
+    __CPROVER_precondition(src != NULL && __CPROVER_r_ok(src, n), "memcpy source region readable");
+    __CPROVER_precondition(dst != NULL && __CPROVER_w_ok(dst, n), "memcpy destination region writeable");
 
     return dst;
 }

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -114,6 +114,18 @@ AWS_COMMON_API
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
 
 /**
+ * Set of properties of a valid aws_byte_buf.
+ */
+AWS_COMMON_API
+bool is_valid_byte_buf(const struct aws_byte_buf *buf);
+
+/**
+ * Set of properties of a valid aws_byte_cursor.
+ */
+AWS_COMMON_API
+bool is_valid_byte_cursor(const struct aws_byte_cursor *cursor);
+
+/**
  * Copies src buffer into dest and sets the correct len and capacity.
  * A new memory zone is allocated for dest->buffer. When dest is no longer needed it will have to be cleaned-up using
  * aws_byte_buf_clean_up(dest).

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -40,6 +40,30 @@
                                     abort();                                                                    \
                                }                                                                                \
 
+/**
+* Define function contracts.
+* When the code is being verified using CBMC these contracts are formally verified;
+* When the code is built in debug mode, they are checked as much as possible using assertions
+* When the code is built in production mode, they are not checked.
+* Violations of the function contracts are undefined behaviour.
+otherwise they are checked
+*/
+#ifdef CBMC
+#define AWS_PRECONDITION(cond) __CPROVER_assume(cond)
+#define AWS_POSTCONDITION(cond) assert(cond)
+#define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok(base, len)
+#define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok(base, len)
+#else
+#define AWS_PRECONDITION(cond) assert(cond)
+#define AWS_POSTCONDITION(cond) assert(cond)
+/* the C runtime does not give a way to check these properties,
+ * but we can at least check that the pointer is valid */
+#define AWS_MEM_IS_READABLE(base, len) (len == 0 || base)
+#define AWS_MEM_IS_WRITABLE(base, len) (len == 0 || base)
+#endif
+
+
+
 #ifndef NO_STDBOOL
 #    include <stdbool.h>
 #else


### PR DESCRIPTION
*Description of changes:*

We now have a set of memory safety proofs for `aws_byte_buf_append_dynamic`, `aws_byte_buf_append_with_lookup` and `aws_byte_buf_reserve`.

We also added guards in the functions, in order to make sure they will always operate over valid `aws_byte_buf` structures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
