### PR TITLE
Fix function names

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
@@ -18,16 +18,16 @@
 
 void aws_byte_buf_append_dynamic_harness() {
     struct aws_byte_buf to;
-    __CPROVER_assume(is_valid_byte_buf(&to));
+    __CPROVER_assume(aws_byte_buf_is_valid(&to));
     ensure_byte_buf_has_allocated_buffer_member(&to);
 
     struct aws_byte_cursor from;
-    __CPROVER_assume(is_valid_byte_cursor(&from));
+    __CPROVER_assume(aws_byte_cursor_is_valid(&from));
     ensure_byte_cursor_has_allocated_buffer_member(&from);
 
     aws_byte_buf_append_dynamic(&to, &from);
 
-    assert(is_valid_byte_buf(&to));
+    assert(aws_byte_buf_is_valid(&to));
     assert(is_byte_buf_expected_alloc(&to));
-    assert(is_valid_byte_cursor(&from));
+    assert(aws_byte_cursor_is_valid(&from));
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
@@ -19,12 +19,12 @@
 void aws_byte_buf_append_with_lookup_harness() {
     struct aws_byte_buf to;
     __CPROVER_assume(is_bounded_byte_buf(&to, MAX_BUF_SIZE));
-    __CPROVER_assume(is_valid_byte_buf(&to));
+    __CPROVER_assume(aws_byte_buf_is_valid(&to));
     ensure_byte_buf_has_allocated_buffer_member(&to);
 
     struct aws_byte_cursor from;
     __CPROVER_assume(is_bounded_byte_cursor(&from, MAX_BUF_SIZE));
-    __CPROVER_assume(is_valid_byte_cursor(&from));
+    __CPROVER_assume(aws_byte_cursor_is_valid(&from));
     ensure_byte_cursor_has_allocated_buffer_member(&from);
 
     /**
@@ -34,7 +34,7 @@ void aws_byte_buf_append_with_lookup_harness() {
     uint8_t *lookup_table[256];
     aws_byte_buf_append_with_lookup(&to, &from, lookup_table);
 
-    assert(is_valid_byte_buf(&to));
+    assert(aws_byte_buf_is_valid(&to));
     assert(is_byte_buf_expected_alloc(&to));
-    assert(is_valid_byte_cursor(&from));
+    assert(aws_byte_cursor_is_valid(&from));
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
@@ -18,7 +18,7 @@
 
 void aws_byte_buf_reserve_harness() {
     struct aws_byte_buf buf;
-    __CPROVER_assume(is_valid_byte_buf(&buf));
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
 
     struct aws_byte_buf old = buf;
@@ -28,6 +28,6 @@ void aws_byte_buf_reserve_harness() {
     if (rval == AWS_OP_SUCCESS) {
         assert(buf.capacity >= requested_capacity);
     }
-    assert(is_valid_byte_buf(&buf));
+    assert(aws_byte_buf_is_valid(&buf));
     assert(is_byte_buf_expected_alloc(&buf));
 }

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -117,13 +117,13 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
  * Set of properties of a valid aws_byte_buf.
  */
 AWS_COMMON_API
-bool is_valid_byte_buf(const struct aws_byte_buf *buf);
+bool aws_byte_buf_is_valid(const struct aws_byte_buf *buf);
 
 /**
  * Set of properties of a valid aws_byte_cursor.
  */
 AWS_COMMON_API
-bool is_valid_byte_cursor(const struct aws_byte_cursor *cursor);
+bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor);
 
 /**
  * Copies src buffer into dest and sets the correct len and capacity.

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -35,11 +35,11 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
     return AWS_OP_SUCCESS;
 }
 
-bool is_valid_byte_buf(const struct aws_byte_buf *buf) {
+bool aws_byte_buf_is_valid(const struct aws_byte_buf *buf) {
     return (buf->len <= buf->capacity) && (buf->allocator != NULL) && AWS_MEM_IS_WRITABLE(buf->buffer, buf->len);
 }
 
-bool is_valid_byte_cursor(const struct aws_byte_cursor *cursor) {
+bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor) {
     return (cursor->ptr != NULL && cursor->len != 0) && AWS_MEM_IS_WRITABLE(cursor->ptr, cursor->len);
 }
 
@@ -398,8 +398,8 @@ int aws_byte_buf_append_with_lookup(
     const uint8_t *lookup_table) {
     assert(from->ptr);
     assert(to->buffer);
-    AWS_PRECONDITION(is_valid_byte_buf(to));
-    AWS_PRECONDITION(is_valid_byte_cursor(from));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
     AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
 
     if (to->capacity - to->len < from->len) {
@@ -414,16 +414,16 @@ int aws_byte_buf_append_with_lookup(
         return AWS_OP_ERR;
     }
 
-    AWS_POSTCONDITION(is_valid_byte_buf(to));
-    AWS_POSTCONDITION(is_valid_byte_cursor(from));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
     return AWS_OP_SUCCESS;
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
     assert(from->ptr);
     assert(to->buffer);
-    AWS_PRECONDITION(is_valid_byte_buf(to));
-    AWS_PRECONDITION(is_valid_byte_cursor(from));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
 
     if (to->capacity - to->len < from->len) {
         /*
@@ -495,13 +495,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
     to->len += from->len;
 
-    AWS_POSTCONDITION(is_valid_byte_buf(to));
-    AWS_POSTCONDITION(is_valid_byte_cursor(from));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
     return AWS_OP_SUCCESS;
 }
 
 int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity) {
-    AWS_PRECONDITION(is_valid_byte_buf(buffer));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
     if (requested_capacity <= buffer->capacity) {
         return AWS_OP_SUCCESS;
     }
@@ -512,7 +512,7 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
 
     buffer->capacity = requested_capacity;
 
-    AWS_POSTCONDITION(is_valid_byte_buf(buffer));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Update function names to follow library standard.

`is_valid_byte_buf` -> `aws_byte_buf_is_valid`
`is_valid_byte_cursor` -> `aws_byte_cursor_is_valid`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
