### PR TITLE
Clean up proof_allocators

### DIFF
--- a/.cbmc-batch/include/proof_helpers/proof_allocators.h
+++ b/.cbmc-batch/include/proof_helpers/proof_allocators.h
@@ -45,7 +45,7 @@ struct aws_allocator *can_fail_allocator();
 void *can_fail_malloc(size_t size);
 
 /**
- * CBMC model of malloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * CBMC model of realloc never returns NULL, which can mask bugs in C programs. Thus function:
  * 1) Deterministically returns NULL more memory is requested than CBMC can represent
  * 2) Does the full range of valid behaviours if (newsize == 0)
  * 3) Nondeterminstically returns either valid memory or NULL otherwise

--- a/.cbmc-batch/include/proof_helpers/proof_allocators.h
+++ b/.cbmc-batch/include/proof_helpers/proof_allocators.h
@@ -39,14 +39,14 @@ struct aws_allocator *can_fail_allocator();
 
 /**
  * CBMC model of malloc never returns NULL, which can mask bugs in C programs. Thus function:
- * 1) Deterministically returns NULL more memory is requested than CBMC can represent
+ * 1) Deterministically returns NULL if more memory is requested than CBMC can represent
  * 2) Nondeterminstically returns either valid memory or NULL otherwise
  */
 void *can_fail_malloc(size_t size);
 
 /**
  * CBMC model of realloc never returns NULL, which can mask bugs in C programs. Thus function:
- * 1) Deterministically returns NULL more memory is requested than CBMC can represent
+ * 1) Deterministically returns NULL if more memory is requested than CBMC can represent
  * 2) Does the full range of valid behaviours if (newsize == 0)
  * 3) Nondeterminstically returns either valid memory or NULL otherwise
  */

--- a/.cbmc-batch/include/proof_helpers/proof_allocators.h
+++ b/.cbmc-batch/include/proof_helpers/proof_allocators.h
@@ -17,36 +17,37 @@
 #include <aws/common/common.h>
 
 /*
- * CBMC has an internal representation in which each object has an index and an offset
+ * CBMC has an internal representation in which each object has an index and a (signed) offset
  * A buffer cannot be larger than the max size of the offset
  * The Makefile is expected to set CBMC_OBJECT_BITS to the value of --object-bits
  */
 #define MAX_MALLOC (SIZE_MAX >> (CBMC_OBJECT_BITS + 1))
 
 /**
- * The standard allocator in CBMC cannot fail.
- * This one can, which allows us to
- * nondeterministically find more bugs
- */
-struct aws_allocator *can_fail_allocator();
-
-static void *can_fail_malloc_allocator(struct aws_allocator *allocator, size_t size);
-
-void *can_fail_malloc(size_t size);
-
-/**
- * CBMC considers malloc always successed for any given size. However, a real machine
- * can only provide the available size from the pointer until the end of the address space.
- * This function models the real machine behaviour.
+ * CBMC model of malloc always succeeds, even if the requested size is larger
+ * than CBMC can internally represent.  This function does a
+ *     __CPROVER_assume(size <= MAX_MALLOC);
+ * before calling malloc, and hence will never return an invalid pointer.
  */
 void *bounded_malloc(size_t size);
 
-static void can_fail_free(struct aws_allocator *allocator, void *ptr);
+/**
+ * Implemenation of aws_allocator specalized to allow CBMC to find
+ * as many bugs as possible
+ */
+struct aws_allocator *can_fail_allocator();
 
-static void *can_fail_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize);
+/**
+ * CBMC model of malloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * 1) Deterministically returns NULL more memory is requested than CBMC can represent
+ * 2) Nondeterminstically returns either valid memory or NULL otherwise
+ */
+void *can_fail_malloc(size_t size);
 
-static struct aws_allocator can_fail_allocator_static = {
-    .mem_acquire = can_fail_malloc_allocator,
-    .mem_release = can_fail_free,
-    .mem_realloc = can_fail_realloc,
-};
+/**
+ * CBMC model of malloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * 1) Deterministically returns NULL more memory is requested than CBMC can represent
+ * 2) Does the full range of valid behaviours if (newsize == 0)
+ * 3) Nondeterminstically returns either valid memory or NULL otherwise
+ */
+void *can_fail_realloc(void *ptr, size_t newsize);

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -77,7 +77,7 @@ REMOVE_FUNCTION_BODY += --remove-function-body s_default_malloc
 REMOVE_FUNCTION_BODY += --remove-function-body s_default_free
 REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
 REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
-
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_reallocate
 ################################################################
 
 # Here, whenever there is a change in any of ANSI-C source

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -62,9 +62,21 @@ ifneq ($(UNWINDSET),)
 CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
 endif
 
+################################################################
+# Set defines that will be used by the projects
 CBMC_OBJECT_BITS ?= 8
 CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC=1
+
+################################################################
+# We always override allocator functions with our own allocator
+# Removing the function from the goto program helps CBMC's
+# function pointer analysis.
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_malloc
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_free
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
 
 ################################################################
 
@@ -72,9 +84,19 @@ DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 # dependency files, make will take action. However, to make
 # sure changes in the headers files will also trigger make,
 # the user must run make clean first.
-$(ENTRY)1.goto: $(ENTRY).c $(DEPENDENCIES)
+$(ENTRY)0.goto: $(ENTRY).c $(DEPENDENCIES)
 	$(GOTO_CC) $< --function $(ENTRY) $(DEPENDENCIES) $(INC) $(DEFINES) -o $@ \
 	        2>&1 | tee $(ENTRY)1.log
+
+$(ENTRY)1.goto: $(ENTRY)0.goto
+ifeq ($(REMOVE_FNCTION_BODY), "")
+	$(GOTO_INSTRUMENT) $< $@ \
+		2>&1 | tee $(ENTRY)2.log
+else
+	$(GOTO_INSTRUMENT) $(REMOVE_FUNCTION_BODY) $< $@ \
+		2>&1 | tee $(ENTRY)2.log
+endif
+
 
 $(ENTRY)2.goto: $(ENTRY)1.goto
 ifeq ($(ABSTRACTIONS), "")

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -90,8 +90,8 @@ $(ENTRY)0.goto: $(ENTRY).c $(DEPENDENCIES)
 
 $(ENTRY)1.goto: $(ENTRY)0.goto
 ifeq ($(REMOVE_FNCTION_BODY), "")
-	$(GOTO_INSTRUMENT) $< $@ \
-		2>&1 | tee $(ENTRY)2.log
+	cp $< $@
+	echo "Not removing function bodies" | tee $(ENTRY)1.log
 else
 	$(GOTO_INSTRUMENT) $(REMOVE_FUNCTION_BODY) $< $@ \
 		2>&1 | tee $(ENTRY)2.log
@@ -100,8 +100,8 @@ endif
 
 $(ENTRY)2.goto: $(ENTRY)1.goto
 ifeq ($(ABSTRACTIONS), "")
-	$(GOTO_INSTRUMENT) $< $@ \
-		2>&1 | tee $(ENTRY)2.log
+	cp $< $@
+	echo "Not implementing abstractions" | tee $(ENTRY)2.log
 else
 	$(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
 		2>&1 | tee $(ENTRY)2.log
@@ -114,6 +114,7 @@ ifeq ($(UNWIND_GOTO), 1)
 		2>&1 | tee $(ENTRY)3.log
 else
 	cp $< $@
+	echo "Not unwinding goto program" | tee $(ENTRY)3.log
 endif
 
 # Skip simplify (and hence generate-function-body) until missing source locations debugged
@@ -123,6 +124,7 @@ ifeq ($(SIMPLIFY), 1)
 		2>&1 | tee $(ENTRY)4.log
 else
 	cp $< $@
+	echo "Not generating-function-bodies in goto program" | tee $(ENTRY)4.log
 endif
 
 # Skip simplify (and hence generate-function-body) until missing source locations debugged
@@ -132,6 +134,7 @@ ifeq ($(SIMPLIFY), 1)
 		2>&1 | tee $(ENTRY)5.log
 else
 	cp $< $@
+	echo "Not simplfying goto program" | tee $(ENTRY)5.log
 endif
 
 $(ENTRY)6.goto: $(ENTRY)5.goto

--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_back_harness"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_array_list_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_back_harness"
 goto: aws_array_list_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
@@ -18,12 +18,12 @@
 
 void aws_byte_buf_append_dynamic_harness() {
     struct aws_byte_buf to;
-    __CPROVER_assume(aws_byte_buf_is_valid(&to));
     ensure_byte_buf_has_allocated_buffer_member(&to);
+    __CPROVER_assume(aws_byte_buf_is_valid(&to));
 
     struct aws_byte_cursor from;
-    __CPROVER_assume(aws_byte_cursor_is_valid(&from));
     ensure_byte_cursor_has_allocated_buffer_member(&from);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&from));
 
     aws_byte_buf_append_dynamic(&to, &from);
 

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/Makefile
@@ -21,7 +21,6 @@ DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memset_override_no_op.c
-
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/Makefile
@@ -20,6 +20,8 @@ DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override_no_op.c
+
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
@@ -18,8 +18,8 @@
 
 void aws_byte_buf_reserve_harness() {
     struct aws_byte_buf buf;
-    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 
     struct aws_byte_buf old = buf;
     size_t requested_capacity;

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_byte_buf_reserve_harness"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_byte_buf_reserve_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -19,20 +19,40 @@
 #include <stdlib.h>
 
 /**
- * Use the same functions as the standard default allocator, but nondeterministically
- * have malloc return null.  This is needed because the CBMC model of malloc cannot
- * fail, so we cannot test the null case otherwise.
+ * Use the can_fail_malloc() defined above to specalize allocation for finding bugs
+ * using CBMC
  */
-static void *can_fail_malloc_allocator(struct aws_allocator *allocator, size_t size) {
+static void *s_can_fail_malloc_allocator(struct aws_allocator *allocator, size_t size) {
     (void)allocator;
     return can_fail_malloc(size);
 }
 
-void *can_fail_malloc(size_t size) {
-    if (size > MAX_MALLOC) {
-        return NULL;
-    }
-    return (nondet_bool()) ? NULL : malloc(size);
+/**
+ * Since we always allocate with "malloc()", just free with "free()"
+ */
+static void s_can_fail_free_allocator(struct aws_allocator *allocator, void *ptr) {
+    (void)allocator;
+    free(ptr);
+}
+
+/**
+ * Use the can_fail_realloc() defined above to specalize allocation for finding bugs
+ * using CBMC
+ */
+static void *s_can_fail_realloc_allocator(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
+    (void)allocator;
+    (void)oldsize;
+    return can_fail_realloc(ptr, newsize);
+}
+
+static struct aws_allocator s_can_fail_allocator_static = {
+    .mem_acquire = s_can_fail_malloc_allocator,
+    .mem_release = s_can_fail_free_allocator,
+    .mem_realloc = s_can_fail_realloc_allocator,
+};
+
+struct aws_allocator *can_fail_allocator() {
+    return &s_can_fail_allocator_static;
 }
 
 void *bounded_malloc(size_t size) {
@@ -40,20 +60,32 @@ void *bounded_malloc(size_t size) {
     return malloc(size);
 }
 
-static void can_fail_free(struct aws_allocator *allocator, void *ptr) {
-    (void)allocator;
-    free(ptr);
-}
-
-static void *can_fail_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
-    (void)allocator;
-    (void)oldsize;
-    if (newsize > MAX_MALLOC)
+void *can_fail_malloc(size_t size) {
+    if (size > MAX_MALLOC) {
         return NULL;
-    int nondet;
-    return (nondet) ? NULL : realloc(ptr, newsize);
+    }
+    return nondet_bool() ? NULL : malloc(size);
 }
 
-struct aws_allocator *can_fail_allocator() {
-    return &can_fail_allocator_static;
+/**
+ * https://en.cppreference.com/w/c/memory/realloc
+ * If there is not enough memory, the old memory block is not freed and null pointer is returned.
+ *
+ * If ptr is NULL, the behavior is the same as calling malloc(new_size).
+ *
+ * If new_size is zero, the behavior is implementation defined (null pointer may be returned (in which case the old
+ * memory block may or may not be freed), or some non-null pointer may be returned that may not be used to access
+ * storage).
+ */
+void *can_fail_realloc(void *ptr, size_t newsize) {
+    if (newsize > MAX_MALLOC) {
+        return NULL;
+    }
+    if (newsize == 0) {
+        if (nondet_bool()) {
+            free(ptr);
+        }
+        return nondet_voidp();
+    }
+    return nondet_bool() ? NULL : realloc(ptr, newsize);
 }

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -61,10 +61,7 @@ void *bounded_malloc(size_t size) {
 }
 
 void *can_fail_malloc(size_t size) {
-    if (size > MAX_MALLOC) {
-        return NULL;
-    }
-    return nondet_bool() ? NULL : malloc(size);
+    return nondet_bool() ? NULL : bounded_malloc(size);
 }
 
 /**

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -48,7 +48,7 @@ static void *s_can_fail_realloc_allocator(struct aws_allocator *allocator, void 
 static struct aws_allocator s_can_fail_allocator_static = {
     .mem_acquire = s_can_fail_malloc_allocator,
     .mem_release = s_can_fail_free_allocator,
-    .mem_realloc = s_can_fail_realloc_allocator,
+    .mem_realloc = nondet_bool() ? NULL : s_can_fail_realloc_allocator,
 };
 
 struct aws_allocator *can_fail_allocator() {


### PR DESCRIPTION
*Description of changes:*
Refactor the ```proof_allocators``` used by CBMC, which clearer comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
