### PR TITLE
Weak ref

### DIFF
--- a/include/aws/common/weak_ref.h
+++ b/include/aws/common/weak_ref.h
@@ -1,0 +1,76 @@
+#ifndef AWS_COMMON_WEAK_REF_H
+#define AWS_COMMON_WEAK_REF_H
+
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+#include <aws/common/common.h>
+
+struct aws_weak_ref;
+
+/*
+ * A simple API for a mutable ref-counted object reference.
+ *
+ * The object reference can only be used in the context of a lock-unlock pair.
+ *
+ * The object reference can be changed or invalidated by set.
+ *
+ * Acquire and release must be used to bracket the time period when a user
+ * may wish to access the object referenced. _new implicitly adds a reference during creation
+ *
+ */
+AWS_EXTERN_C_BEGIN
+
+/*
+ * Create a new weak reference.  data must initially be non-null.  The returned weak_ref has a ref count of 1.
+ */
+AWS_COMMON_API
+struct aws_weak_ref *aws_weak_ref_new(struct aws_allocator *allocator, void *object);
+
+/*
+ * Increment the object's ref count
+ */
+AWS_COMMON_API
+void aws_weak_ref_acquire(struct aws_weak_ref *ref);
+
+/*
+ * Decrements the object's ref count
+ */
+AWS_COMMON_API
+void aws_weak_ref_release(struct aws_weak_ref *ref);
+
+/*
+ * Locks the weak ref and returns the contained object.  The return value should be checked for validity.
+ */
+AWS_COMMON_API
+void *aws_weak_ref_lock(struct aws_weak_ref *ref);
+
+/*
+ * Release a lock held on the weak ref, allowing others to set or use its value.
+ */
+AWS_COMMON_API
+void aws_weak_ref_unlock(struct aws_weak_ref *ref);
+
+/*
+ * Update the value of the object tracked by the weak ref.  Most common use will be to set the object
+ * to NULL when its getting destroyed.
+ */
+AWS_COMMON_API
+void aws_weak_ref_set(struct aws_weak_ref *ref, void *object);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_WEAK_REF_H */

--- a/source/weak_ref.c
+++ b/source/weak_ref.c
@@ -22,7 +22,7 @@
 
 struct aws_weak_ref {
     struct aws_allocator *allocator;
-    void *data;
+    void *object;
     struct aws_mutex lock;
     struct aws_atomic_var ref_count;
 };
@@ -38,9 +38,9 @@ void s_aws_weak_ref_destroy(struct aws_weak_ref *ref) {
     aws_mem_release(ref->allocator, ref);
 }
 
-struct aws_weak_ref *aws_weak_ref_new(struct aws_allocator *allocator, void *data) {
-    assert(data != NULL);
-    if (data == NULL) {
+struct aws_weak_ref *aws_weak_ref_new(struct aws_allocator *allocator, void *object) {
+    assert(object != NULL);
+    if (object == NULL) {
         return NULL;
     }
 
@@ -51,7 +51,7 @@ struct aws_weak_ref *aws_weak_ref_new(struct aws_allocator *allocator, void *dat
 
     AWS_ZERO_STRUCT(*weak_ref);
     weak_ref->allocator = allocator;
-    weak_ref->data = data;
+    weak_ref->object = object;
     if (aws_mutex_init(&weak_ref->lock)) {
         goto on_error;
     }
@@ -80,15 +80,15 @@ void aws_weak_ref_release(struct aws_weak_ref *ref) {
 
 void *aws_weak_ref_lock(struct aws_weak_ref *ref) {
     aws_mutex_lock(&ref->lock);
-    return ref->data;
+    return ref->object;
 }
 
 void aws_weak_ref_unlock(struct aws_weak_ref *ref) {
     aws_mutex_unlock(&ref->lock);
 }
 
-void aws_weak_ref_set(struct aws_weak_ref *ref, void *data) {
+void aws_weak_ref_set(struct aws_weak_ref *ref, void *object) {
     aws_mutex_lock(&ref->lock);
-    ref->data = data;
+    ref->object = object;
     aws_mutex_unlock(&ref->lock);
 }

--- a/source/weak_ref.c
+++ b/source/weak_ref.c
@@ -27,7 +27,7 @@ struct aws_weak_ref {
     struct aws_atomic_var ref_count;
 };
 
-void s_aws_weak_ref_destroy(struct aws_weak_ref *ref) {
+static void s_aws_weak_ref_destroy(struct aws_weak_ref *ref) {
     if (ref == NULL) {
         return;
     }

--- a/source/weak_ref.c
+++ b/source/weak_ref.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/weak_ref.h>
+
+#include <aws/common/atomics.h>
+#include <aws/common/mutex.h>
+
+#include <assert.h>
+
+struct aws_weak_ref {
+    struct aws_allocator *allocator;
+    void *data;
+    struct aws_mutex lock;
+    struct aws_atomic_var ref_count;
+};
+
+void s_aws_weak_ref_destroy(struct aws_weak_ref *ref) {
+    if (ref == NULL) {
+        return;
+    }
+
+    assert(aws_atomic_load_int(&ref->ref_count) == 0);
+
+    aws_mutex_clean_up(&ref->lock);
+    aws_mem_release(ref->allocator, ref);
+}
+
+struct aws_weak_ref *aws_weak_ref_new(struct aws_allocator *allocator, void *data) {
+    assert(data != NULL);
+    if (data == NULL) {
+        return NULL;
+    }
+
+    struct aws_weak_ref *weak_ref = aws_mem_acquire(allocator, sizeof(struct aws_weak_ref));
+    if (weak_ref == NULL) {
+        return NULL;
+    }
+
+    AWS_ZERO_STRUCT(*weak_ref);
+    weak_ref->allocator = allocator;
+    weak_ref->data = data;
+    if (aws_mutex_init(&weak_ref->lock)) {
+        goto on_error;
+    }
+
+    aws_atomic_init_int(&weak_ref->ref_count, 1);
+
+    return weak_ref;
+
+on_error:
+
+    s_aws_weak_ref_destroy(weak_ref);
+
+    return NULL;
+}
+
+void aws_weak_ref_acquire(struct aws_weak_ref *ref) {
+    aws_atomic_fetch_add(&ref->ref_count, 1);
+}
+
+void aws_weak_ref_release(struct aws_weak_ref *ref) {
+    size_t old_value = aws_atomic_fetch_sub(&ref->ref_count, 1);
+    if (old_value == 1) {
+        s_aws_weak_ref_destroy(ref);
+    }
+}
+
+void *aws_weak_ref_lock(struct aws_weak_ref *ref) {
+    aws_mutex_lock(&ref->lock);
+    return ref->data;
+}
+
+void aws_weak_ref_unlock(struct aws_weak_ref *ref) {
+    aws_mutex_unlock(&ref->lock);
+}
+
+void aws_weak_ref_set(struct aws_weak_ref *ref, void *data) {
+    aws_mutex_lock(&ref->lock);
+    ref->data = data;
+    aws_mutex_unlock(&ref->lock);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -288,6 +288,9 @@ add_test_case(long_argument_parse)
 add_test_case(unqualified_argument_parse)
 add_test_case(unknown_argument_parse)
 
+add_test_case(weak_ref_test_basic)
+add_test_case(weak_ref_test_counting)
+
 generate_test_driver(${CMAKE_PROJECT_NAME}-tests)
 
 if (NOT MSVC)

--- a/tests/weak_ref_test.c
+++ b/tests/weak_ref_test.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/weak_ref.h>
+
+#include <aws/common/string.h>
+
+#include <aws/testing/aws_test_harness.h>
+
+AWS_STATIC_STRING_FROM_LITERAL(s_test_data, "test");
+
+static int s_weak_ref_test_basic(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_weak_ref *ref = aws_weak_ref_new(allocator, (void *)s_test_data);
+    ASSERT_TRUE(ref != NULL);
+
+    struct aws_string *data = aws_weak_ref_lock(ref);
+    ASSERT_TRUE(data == s_test_data);
+
+    aws_weak_ref_unlock(ref);
+
+    aws_weak_ref_set(ref, NULL);
+
+    data = aws_weak_ref_lock(ref);
+    ASSERT_TRUE(data == NULL);
+
+    aws_weak_ref_release(ref);
+
+    return 0;
+}
+
+AWS_TEST_CASE(weak_ref_test_basic, s_weak_ref_test_basic)
+
+static int s_weak_ref_test_counting(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_weak_ref *ref = aws_weak_ref_new(allocator, (void *)s_test_data);
+    ASSERT_TRUE(ref != NULL);
+
+    aws_weak_ref_acquire(ref);
+    aws_weak_ref_acquire(ref);
+    aws_weak_ref_acquire(ref);
+
+    aws_weak_ref_release(ref);
+    aws_weak_ref_release(ref);
+    aws_weak_ref_release(ref);
+    aws_weak_ref_release(ref);
+
+    /* success = not leaking and not crashing */
+
+    return 0;
+}
+
+AWS_TEST_CASE(weak_ref_test_counting, s_weak_ref_test_counting)


### PR DESCRIPTION
This was a pattern I seemed to need for both the C connection manager and the truly-async credentials providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
