### PR TITLE
Refactor aws_array_list harnesses with new proof style

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--function;aws_array_list_back_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
 goto: aws_array_list_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_capacity/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_capacity/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c

--- a/.cbmc-batch/jobs/aws_array_list_capacity/aws_array_list_capacity_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_capacity/aws_array_list_capacity_harness.c
@@ -16,36 +16,28 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m4.951s
+ * Runtime: 5s
  */
 void aws_array_list_capacity_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    size_t capacity = aws_array_list_capacity(list);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    assert(capacity == list->current_size / list->item_size);
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->length == length);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* perform operation under verification */
+    size_t capacity = aws_array_list_capacity(&list);
+
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    assert_array_list_equivalence(&list, &old, &old_byte);
+    assert(capacity == list.current_size / list.item_size);
 }

--- a/.cbmc-batch/jobs/aws_array_list_capacity/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_capacity/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_capacity_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
 goto: aws_array_list_capacity_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_clean_up/Makefile
@@ -12,8 +12,9 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_mem_release:1
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_array_list_clean_up/aws_array_list_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_clean_up/aws_array_list_clean_up_harness.c
@@ -16,30 +16,26 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m4.908s
+ * Runtime: 4s
  */
 void aws_array_list_clean_up_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    aws_array_list_clean_up(list);
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+
+    /* perform operation under verification */
+    aws_array_list_clean_up(&list);
 
     /* assertions */
-    assert(list->alloc == NULL);
-    assert(list->current_size == 0);
-    assert(list->length == 0);
-    assert(list->item_size == 0);
-    assert(list->data == NULL);
+    assert(aws_array_list_is_valid(&list));
+    assert(list.alloc == NULL);
+    assert(list.current_size == 0);
+    assert(list.length == 0);
+    assert(list.item_size == 0);
+    assert(list.data == NULL);
 }

--- a/.cbmc-batch/jobs/aws_array_list_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_clean_up/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_mem_release:1;--function;aws_array_list_clean_up_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
 goto: aws_array_list_clean_up_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_clear/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_clear/Makefile
@@ -12,7 +12,9 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_array_list_clear/aws_array_list_clear_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_clear/aws_array_list_clear_harness.c
@@ -16,35 +16,29 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m4.327s
+ * Runtime: 5s
  */
 void aws_array_list_clear_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    aws_array_list_clear(list);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
 
-    (list->data) ? assert(list->length == 0) : assert(list->length == length);
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* perform operation under verification */
+    aws_array_list_clear(&list);
+
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    (list.data) ? assert(list.length == 0) : assert(list.length == old.length);
+    assert(list.alloc == old.alloc);
+    assert(list.current_size == old.current_size);
+    assert(list.item_size == old.item_size);
+    assert(list.data == old.data);
 }

--- a/.cbmc-batch/jobs/aws_array_list_clear/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_clear/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_clear_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
 goto: aws_array_list_clear_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_comparator_string/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_comparator_string/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17,memcpy_impl.0:17,memset_impl.0:17,strlen.0:17"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17,memcpy_impl.0:17,memset_impl.0:17,strlen.0:17;--object-bits;8"
 goto: aws_array_list_comparator_string_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_copy/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_copy/Makefile
@@ -12,13 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_mem_release:1
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
@@ -16,61 +16,30 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m13.098s
+ * Runtime: 10s
  */
 void aws_array_list_copy_harness() {
-    struct aws_array_list *from;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic from->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic from->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic from->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(from, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
-    struct aws_allocator *from_alloc = from->alloc;
-    size_t from_current_size = from->current_size;
-    size_t from_length = from->length;
-    size_t from_item_size = from->item_size;
-    void *from_data = from->data;
+    /* data structure */
+    struct aws_array_list from;
+    struct aws_array_list to;
 
-    struct aws_array_list *to;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic to->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic to->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic to->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(to, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&from, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&from);
+    __CPROVER_assume(aws_array_list_is_valid(&from));
 
-    struct aws_allocator *to_alloc = to->alloc;
-    size_t to_current_size = to->current_size;
-    size_t to_length = to->length;
-    size_t to_item_size = to->item_size;
-    void *to_data = to->data;
+    __CPROVER_assume(aws_array_list_is_bounded(&to, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&to);
+    __CPROVER_assume(aws_array_list_is_valid(&to));
 
-    __CPROVER_assume(from->item_size == to->item_size);
-
-    if (!aws_array_list_copy(from, to)) {
-        assert(to->length == from->length);
-        assert(to->current_size >= (from->length * from->item_size));
-    } else {
-        assert(to->length == to_length);
-        assert(to->alloc == to_alloc);
-        assert(to->current_size == to_current_size);
-        assert(to->item_size == to_item_size);
-        assert(to->data == to_data);
+    if (!aws_array_list_copy(&from, &to)) {
+        assert(to.length == from.length);
+        assert(to.current_size >= (from.length * from.item_size));
     }
-    assert(from->item_size == to->item_size);
-    assert(from->length == from_length);
-    assert(from->alloc == from_alloc);
-    assert(from->current_size == from_current_size);
-    assert(from->item_size == from_item_size);
-    assert(from->data == from_data);
+
+    /* assertions */
+    assert(aws_array_list_is_valid(&from));
+    assert(aws_array_list_is_valid(&to));
+    assert(from.item_size == to.item_size);
 }

--- a/.cbmc-batch/jobs/aws_array_list_copy/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_copy/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_mem_release:1;--function;aws_array_list_copy_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
 goto: aws_array_list_copy_harness.goto
 expected: "SUCCESSFUL"

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -77,12 +77,14 @@ void aws_array_list_init_static(
 
 AWS_STATIC_IMPL
 bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
+    if(!list) {
+        return false;
+    }
     size_t required_size;
     bool required_size_is_valid = aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS;
     bool current_size_is_valid = list->current_size >= required_size;
-    bool item_size_is_valid = list->item_size != 0;
     bool data_is_valid = ((list->current_size == 0 && list->data == NULL) || AWS_MEM_IS_WRITABLE(list->data, list->current_size));
-    return required_size_is_valid && current_size_is_valid && item_size_is_valid && data_is_valid;
+    return required_size_is_valid && current_size_is_valid && data_is_valid;
 }
 
 AWS_STATIC_IMPL


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This PR refactor the following proofs for `aws_array_list` with a new proof style:
 - aws_array_list_capacity
 - aws_array_list_clean_up
 - aws_array_list_clear
 - aws_array_list_copy

The refactor aims to improve readability and code quality of our proofs, which transit from an imperative style to a more functional one. This new proof style will be gradually implemented in all proofs.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
