### PR TITLE
Refactor aws_array_list harnesses with new proof style

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_ensure_capacity/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_ensure_capacity/Makefile
@@ -12,13 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_mem_release:1
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_ensure_capacity/aws_array_list_ensure_capacity_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_ensure_capacity/aws_array_list_ensure_capacity_harness.c
@@ -16,43 +16,33 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m9.181s
+ * Runtime: 9s
  */
 void aws_array_list_ensure_capacity_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    size_t index = nondet_size_t();
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    if (!aws_array_list_ensure_capacity(list, index)) {
-        size_t necessary_size = (index + 1) * list->item_size;
-        if (current_size < necessary_size) {
-            size_t next_allocation_size = current_size << 1;
-            size_t new_size = next_allocation_size > necessary_size ? next_allocation_size : necessary_size;
-            assert(list->current_size == new_size);
-        }
+    /* perform operation under verification */
+    size_t index;
+    if (!aws_array_list_ensure_capacity(&list, index)) {
+        /* assertions */
+        assert(aws_array_list_is_valid(&list));
+        assert(list.item_size == old.item_size);
+        assert(list.alloc == old.alloc);
+        assert(list.length == old.length);
+        assert(list.current_size >= old.current_size);
     } else {
-        assert(list->current_size == current_size);
+        assert_array_list_equivalence(&list, &old, &old_byte);
     }
-    assert(list->item_size == item_size);
-    assert(list->alloc == alloc);
-    assert(list->length == length);
 }

--- a/.cbmc-batch/jobs/aws_array_list_ensure_capacity/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_ensure_capacity/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_mem_release:1;--function;aws_array_list_ensure_capacity_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
 goto: aws_array_list_ensure_capacity_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_front/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_front/Makefile
@@ -12,14 +12,18 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+# This bound allow us to reach full coverage rate
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
@@ -16,40 +16,31 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m4.873s
+ * Runtime: 6s
  */
 void aws_array_list_front_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    void *val = malloc(list->item_size);
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    if (!aws_array_list_front(list, val)) {
-        assert(list->data);
-        assert(list->length);
+    /* perform operation under verification */
+    void *val = malloc(list.item_size);
+    if (!aws_array_list_front(&list, val)) {
+        assert(list.data);
+        assert(list.length);
     }
 
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->length == length);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    assert_array_list_equivalence(&list, &old, &old_byte);
 }

--- a/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_front_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
 goto: aws_array_list_front_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/Makefile
@@ -12,14 +12,18 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+# This bound allow us to reach full coverage rate
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
@@ -16,41 +16,32 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m5.428s
+ * Runtime: 9s
  */
 void aws_array_list_get_at_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    void *val = malloc(list->item_size);
-    size_t index = nondet_size_t();
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    if (!aws_array_list_get_at(list, val, index)) {
-        assert(list->data);
-        assert(list->length > index);
+    /* perform operation under verification */
+    void *val = malloc(list.item_size);
+    size_t index;
+    if (!aws_array_list_get_at(&list, val, index)) {
+        assert(list.data);
+        assert(list.length > index);
     }
 
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->length == length);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    assert_array_list_equivalence(&list, &old, &old_byte);
 }

--- a/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_get_at_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
 goto: aws_array_list_get_at_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/Makefile
@@ -12,14 +12,18 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+# This bound allow us to reach full coverage rate
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
@@ -16,41 +16,32 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m4.988s
+ * Runtime: 6s
  */
 void aws_array_list_get_at_ptr_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    void *val = malloc(list->item_size);
-    size_t index = nondet_size_t();
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    if (!aws_array_list_get_at_ptr(list, &val, index)) {
-        assert(list->data);
-        assert(list->length > index);
+    /* perform operation under verification */
+    void *val = malloc(list.item_size);
+    size_t index;
+    if (!aws_array_list_get_at_ptr(&list, &val, index)) {
+        assert(list.data);
+        assert(list.length > index);
     }
 
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->length == length);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    assert_array_list_equivalence(&list, &old, &old_byte);
 }

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;__builtin___memcpy_chk.0:11;--function;aws_array_list_get_at_ptr_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
 goto: aws_array_list_get_at_ptr_harness.goto
 expected: "SUCCESSFUL"


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This PR refactor the following proofs for `aws_array_list` with a new proof style:
 - aws_array_list_ensure_capacity
 - aws_array_list_front
 - aws_array_list_get_at
 - aws_array_list_get_at_ptr

The refactor aims to improve readability and code quality of our proofs, which transit from an imperative style to a more functional one. This new proof style will be gradually implemented in all proofs.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
