### PR TITLE
Refactor aws_array_list harnesses with new proof style

### DIFF
--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -31,8 +31,9 @@ void assert_all_zeroes(const uint8_t *a, size_t len);
 void assert_byte_from_buffer_matches(const uint8_t *buffer, struct store_byte_from_buffer *b);
 
 /**
- * Nondeterministically selects a byte from array and stores it into a
- * store_array_list_byte structure.
+ * Nondeterministically selects a byte from array and stores it into a store_array_list_byte
+ * structure. Afterwards, one can prove using the assert_array_list_equivalence function
+ * whether no byte in the array has changed.
  */
 void save_byte_from_array(const uint8_t *array, size_t size, struct store_byte_from_buffer *storage);
 

--- a/.cbmc-batch/jobs/aws_array_list_back/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_back/Makefile
@@ -14,7 +14,7 @@
 ###########
 include ../Makefile.aws_array_list
 
-# This bound allow us to reach full coverage rate
+# This bound allows us to reach 100% coverage rate
 UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=

--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
 goto: aws_array_list_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_capacity/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_capacity/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_capacity_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_clean_up/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_clean_up_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_clear/aws_array_list_clear_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_clear/aws_array_list_clear_harness.c
@@ -36,7 +36,7 @@ void aws_array_list_clear_harness() {
 
     /* assertions */
     assert(aws_array_list_is_valid(&list));
-    (list.data) ? assert(list.length == 0) : assert(list.length == old.length);
+    assert(list.length == 0);
     assert(list.alloc == old.alloc);
     assert(list.current_size == old.current_size);
     assert(list.item_size == old.item_size);

--- a/.cbmc-batch/jobs/aws_array_list_clear/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_clear/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_clear_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_comparator_string/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_comparator_string/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17,memcpy_impl.0:17,memset_impl.0:17,strlen.0:17;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17,memcpy_impl.0:17,memset_impl.0:17,strlen.0:17"
 goto: aws_array_list_comparator_string_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
@@ -33,7 +33,9 @@ void aws_array_list_copy_harness() {
     ensure_array_list_has_allocated_data_member(&to);
     __CPROVER_assume(aws_array_list_is_valid(&to));
 
+    /* perform operation under verification */
     if (!aws_array_list_copy(&from, &to)) {
+        /* In the case aws_array_list_copy is successful, both lists have the same length */
         assert(to.length == from.length);
         assert(to.current_size >= (from.length * from.item_size));
     }

--- a/.cbmc-batch/jobs/aws_array_list_copy/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_copy/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_copy_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_ensure_capacity/aws_array_list_ensure_capacity_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_ensure_capacity/aws_array_list_ensure_capacity_harness.c
@@ -43,6 +43,7 @@ void aws_array_list_ensure_capacity_harness() {
         assert(list.length == old.length);
         assert(list.current_size >= old.current_size);
     } else {
+        /* In the case aws_array_list_ensure_capacity is not successful, the list must not change */
         assert_array_list_equivalence(&list, &old, &old_byte);
     }
 }

--- a/.cbmc-batch/jobs/aws_array_list_ensure_capacity/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_ensure_capacity/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_ensure_capacity_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_front/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_front/Makefile
@@ -14,7 +14,7 @@
 ###########
 include ../Makefile.aws_array_list
 
-# This bound allow us to reach full coverage rate
+# This bound allows us to reach 100% coverage rate
 UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=

--- a/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
@@ -36,6 +36,7 @@ void aws_array_list_front_harness() {
     /* perform operation under verification */
     void *val = malloc(list.item_size);
     if (!aws_array_list_front(&list, val)) {
+        /* In the case aws_array_list_front is successful, we can ensure the list isn't empty */
         assert(list.data);
         assert(list.length);
     }

--- a/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
 goto: aws_array_list_front_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/Makefile
@@ -14,7 +14,7 @@
 ###########
 include ../Makefile.aws_array_list
 
-# This bound allow us to reach full coverage rate
+# This bound allows us to reach 100% coverage rate
 UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=

--- a/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
@@ -37,6 +37,9 @@ void aws_array_list_get_at_harness() {
     void *val = malloc(list.item_size);
     size_t index;
     if (!aws_array_list_get_at(&list, val, index)) {
+        /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
+         * and index is within bounds.
+         */
         assert(list.data);
         assert(list.length > index);
     }

--- a/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
 goto: aws_array_list_get_at_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/Makefile
@@ -14,7 +14,7 @@
 ###########
 include ../Makefile.aws_array_list
 
-# This bound allow us to reach full coverage rate
+# This bound allows us to reach 100% coverage rate
 UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
@@ -37,6 +37,9 @@ void aws_array_list_get_at_ptr_harness() {
     void *val = malloc(list.item_size);
     size_t index;
     if (!aws_array_list_get_at_ptr(&list, &val, index)) {
+        /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
+         * and index is within bounds.
+         */
         assert(list.data);
         assert(list.length > index);
     }

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1;--object-bits;8"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
 goto: aws_array_list_get_at_ptr_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_init_dynamic/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_init_dynamic/Makefile
@@ -12,12 +12,14 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c

--- a/.cbmc-batch/jobs/aws_array_list_init_dynamic/aws_array_list_init_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_init_dynamic/aws_array_list_init_dynamic_harness.c
@@ -16,29 +16,31 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m3.955s
+ * Runtime: 6s
  */
 void aws_array_list_init_dynamic_harness() {
+    /* data structure */
     struct aws_array_list *list;
-    ASSUME_VALID_MEMORY(list);
+
+    /* parameters */
     struct aws_allocator *allocator;
+    size_t item_size;
+    size_t initial_item_allocation;
+
+    /* assumptions */
+    ASSUME_VALID_MEMORY(list);
     ASSUME_CAN_FAIL_ALLOCATOR(allocator);
-    size_t initial_item_allocation = nondet_size_t();
     __CPROVER_assume(initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION);
-    size_t item_size = nondet_size_t();
     __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
 
+    /* perform operation under verification */
     if (!aws_array_list_init_dynamic(list, allocator, initial_item_allocation, item_size)) {
+        /* assertions */
+        assert(aws_array_list_is_valid(list));
         assert(list->alloc == allocator);
         assert(list->item_size == item_size);
         assert(list->length == 0);
-        assert(
-            (list->data == NULL && list->current_size == 0) ||
-            (list->data && list->current_size == (initial_item_allocation * item_size)));
+        assert(list->current_size == item_size * initial_item_allocation);
     }
 }

--- a/.cbmc-batch/jobs/aws_array_list_init_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_init_dynamic/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_init_dynamic_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_init_dynamic_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_init_static/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_init_static/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 

--- a/.cbmc-batch/jobs/aws_array_list_init_static/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_init_static/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_init_static_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_init_static_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_length/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_length/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c

--- a/.cbmc-batch/jobs/aws_array_list_length/aws_array_list_length_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_length/aws_array_list_length_harness.c
@@ -16,34 +16,27 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m5.865s
+ * Runtime: 7s
  */
 void aws_array_list_length_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    size_t len = aws_array_list_length(list);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(len == list->length);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    /* perform operation under verification */
+    size_t len = aws_array_list_length(&list);
+
+    /* assertions */
+    assert(aws_array_list_is_valid(&list));
+    assert_array_list_equivalence(&list, &old, &old_byte);
 }

--- a/.cbmc-batch/jobs/aws_array_list_length/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_length/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_length_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_length_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_pop_back/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_pop_back/Makefile
@@ -12,14 +12,18 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+# This bound allows us to reach 100% coverage rate
+UNWINDSET += memset_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memset_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_array_list_pop_back/aws_array_list_pop_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_pop_back/aws_array_list_pop_back_harness.c
@@ -16,39 +16,33 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m7.830s
+ * Runtime: 9s
  */
 void aws_array_list_pop_back_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    if (!aws_array_list_pop_back(list)) {
-        assert(list->length == length - 1);
-        assert(list->data);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
+
+    /* perform operation under verification and assertions */
+    if (!aws_array_list_pop_back(&list)) {
+        assert(list.length == old.length - 1);
+        assert(list.data);
+        assert(list.alloc == old.alloc);
+        assert(list.current_size == old.current_size);
+        assert(list.item_size == old.item_size);
     } else {
-        assert(list->length == length);
+        /* In the case aws_array_list_pop_back is not successful, the list must not change */
+        assert_array_list_equivalence(&list, &old, &old_byte);
     }
-
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    assert(aws_array_list_is_valid(&list));
 }

--- a/.cbmc-batch/jobs/aws_array_list_pop_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_pop_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_pop_back_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:3;--unwind;1"
 goto: aws_array_list_pop_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_pop_front/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_pop_front/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memmove_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_pop_front/aws_array_list_pop_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_pop_front/aws_array_list_pop_front_harness.c
@@ -16,37 +16,33 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m7.093s
+ * Runtime: 9s
  */
 void aws_array_list_pop_front_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t current_size = list->current_size;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
-    void *data = list->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    if (!aws_array_list_pop_front(list)) {
-        assert(list->length == length - 1);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
+
+    /* perform operation under verification and assertions */
+    if (!aws_array_list_pop_front(&list)) {
+        assert(list.length == old.length - 1);
+        assert(list.data);
+        assert(list.alloc == old.alloc);
+        assert(list.current_size == old.current_size);
+        assert(list.item_size == old.item_size);
     } else {
-        assert(list->length == length);
+        /* In the case aws_array_list_pop_front is not successful, the list must not change */
+        assert_array_list_equivalence(&list, &old, &old_byte);
     }
-    assert(list->alloc == alloc);
-    assert(list->current_size == current_size);
-    assert(list->item_size == item_size);
-    assert(list->data == data);
+    assert(aws_array_list_is_valid(&list));
 }

--- a/.cbmc-batch/jobs/aws_array_list_pop_front/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_pop_front/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;--function;aws_array_list_pop_front_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_pop_front_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_pop_front_n/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_pop_front_n/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memmove_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_pop_front_n/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_pop_front_n/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;--function;aws_array_list_pop_front_n_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_pop_front_n_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_push_back/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/Makefile
@@ -12,13 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_mem_release:1
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
@@ -16,35 +16,30 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m9.234s
+ * Runtime: 18s
  */
 void aws_array_list_push_back_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    struct aws_allocator *alloc = list->alloc;
-    size_t length = list->length;
-    size_t item_size = list->item_size;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    void *val = malloc(list->item_size);
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
-    if (!aws_array_list_push_back(list, val)) {
-        assert(list->length == length + 1);
+    /* perform operation under verification and assertions */
+    void *val = malloc(list.item_size);
+    if (!aws_array_list_push_back(&list, val)) {
+        assert(list.length == old.length + 1);
     } else {
-        assert(list->length == length);
+        /* In the case aws_array_list_push_back is not successful, the list must not change */
+        assert_array_list_equivalence(&list, &old, &old_byte);
     }
-    assert(list->alloc == alloc);
-    assert(list->item_size == item_size);
+    assert(aws_array_list_is_valid(&list));
 }

--- a/.cbmc-batch/jobs/aws_array_list_push_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_mem_release:1;--function;aws_array_list_push_back_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_push_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_set_at/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/Makefile
@@ -12,13 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_mem_release:1
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_mem_release:1;--function;aws_array_list_set_at_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_set_at_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_shrink_to_fit/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_shrink_to_fit/Makefile
@@ -12,13 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_mem_release:1
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memmove_override_no_op.c

--- a/.cbmc-batch/jobs/aws_array_list_shrink_to_fit/aws_array_list_shrink_to_fit_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_shrink_to_fit/aws_array_list_shrink_to_fit_harness.c
@@ -15,31 +15,35 @@
 
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
-
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m51.653s
+ * Runtime: 13s
  */
 void aws_array_list_shrink_to_fit_harness() {
-    struct aws_array_list *list;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic list->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic list->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic list->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list list;
 
-    size_t n = nondet_size_t();
-    aws_array_list_pop_front_n(list, n);
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&list);
+    __CPROVER_assume(aws_array_list_is_valid(&list));
 
-    if (!aws_array_list_shrink_to_fit(list)) {
+    /* remove some elements before shrinking the data structure */
+    size_t n;
+    aws_array_list_pop_front_n(&list, n);
+
+    /* save current state of the data structure */
+    struct aws_array_list old = list;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
+
+    /* perform operation under verification and assertions */
+    if (!aws_array_list_shrink_to_fit(&list)) {
         assert(
-            (list->length == 0 && list->data == NULL) ||
-            (list->data != NULL && list->current_size == list->length * list->item_size));
+            (list.current_size == 0 && list.data == NULL) ||
+            (list.data != NULL && list.current_size == list.length * list.item_size));
+    } else {
+        /* In the case aws_array_list_shrink_to_fit is not successful, the list must not change */
+        assert_array_list_equivalence(&list, &old, &old_byte);
     }
+    assert(aws_array_list_is_valid(&list));
 }

--- a/.cbmc-batch/jobs/aws_array_list_shrink_to_fit/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_shrink_to_fit/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_mem_release:1;--function;aws_array_list_shrink_to_fit_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_shrink_to_fit_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_sort/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_sort/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/qsort_override.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_sort/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_sort/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_sort_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_swap/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_swap/Makefile
@@ -12,13 +12,16 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += aws_array_list_mem_swap.0:2
+include ../Makefile.aws_array_list
+
+# This bound allows us to reach 100% coverage rate
+UNWINDSET += aws_array_list_mem_swap.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c

--- a/.cbmc-batch/jobs/aws_array_list_swap/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_swap/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_array_list_mem_swap.0:2;--function;aws_array_list_swap_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_array_list_mem_swap.0:3;--unwind;1"
 goto: aws_array_list_swap_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_swap_contents/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_swap_contents/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_array_list
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
-DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(SRCDIR)/source/array_list.c
 DEPENDENCIES += $(SRCDIR)/source/common.c

--- a/.cbmc-batch/jobs/aws_array_list_swap_contents/aws_array_list_swap_contents_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_swap_contents/aws_array_list_swap_contents_harness.c
@@ -16,62 +16,38 @@
 #include <aws/common/array_list.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-/* These values allow us to reach a higher coverage rate */
-#define MAX_ITEM_SIZE 2
-#define MAX_INITIAL_ITEM_ALLOCATION (UINT64_MAX / MAX_ITEM_SIZE) + 1
-
 /**
- * Runtime: 0m6.435s
+ * Runtime: 7s
  */
 void aws_array_list_swap_contents_harness() {
-    struct aws_array_list *from;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic from->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic from->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic from->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(from, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    /* data structure */
+    struct aws_array_list from;
+    struct aws_array_list to;
 
-    struct aws_allocator *from_alloc = from->alloc;
-    size_t from_current_size = from->current_size;
-    size_t from_length = from->length;
-    size_t from_item_size = from->item_size;
-    void *from_data = from->data;
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&from, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&from);
+    __CPROVER_assume(aws_array_list_is_valid(&from));
 
-    struct aws_array_list *to;
-    /*
-     * Assumptions:
-     *     - a valid non-deterministic aws_array_list bounded by initial_item_allocation and item_size;
-     *     - non-deterministic to->initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION;
-     *     - non-deterministic to->item_size <= MAX_ITEM_SIZE;
-     *     - non-deterministic to->length <= initial_item_allocation;
-     */
-    ASSUME_BOUNDED_ARRAY_LIST(to, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE);
+    __CPROVER_assume(aws_array_list_is_bounded(&to, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&to);
+    __CPROVER_assume(aws_array_list_is_valid(&to));
 
-    struct aws_allocator *to_alloc = to->alloc;
-    size_t to_current_size = to->current_size;
-    size_t to_length = to->length;
-    size_t to_item_size = to->item_size;
-    void *to_data = to->data;
+    /* save current state of the data structure */
+    struct aws_array_list old_from = from;
+    struct store_byte_from_buffer old_byte_from;
+    save_byte_from_array((uint8_t *)from.data, from.current_size, &old_byte_from);
 
-    __CPROVER_assume(from->alloc);
-    __CPROVER_assume(from->alloc == to->alloc);
-    __CPROVER_assume(from->item_size == to->item_size);
+    struct aws_array_list old_to = to;
+    struct store_byte_from_buffer old_byte_to;
+    save_byte_from_array((uint8_t *)to.data, to.current_size, &old_byte_to);
 
-    aws_array_list_swap_contents(from, to);
+    /* perform operation under verification */
+    aws_array_list_swap_contents(&from, &to);
 
-    assert(from->item_size == to_item_size);
-    assert(from->length == to_length);
-    assert(from->alloc == to_alloc);
-    assert(from->current_size == to_current_size);
-    assert(from->item_size == to_item_size);
-    assert(from->data == to_data);
-    assert(to->item_size == from_item_size);
-    assert(to->length == from_length);
-    assert(to->alloc == from_alloc);
-    assert(to->current_size == from_current_size);
-    assert(to->item_size == from_item_size);
-    assert(to->data == from_data);
+    /* assertions */
+    assert(aws_array_list_is_valid(&from));
+    assert(aws_array_list_is_valid(&to));
+    assert_array_list_equivalence(&from, &old_to, &old_byte_to);
+    assert_array_list_equivalence(&to, &old_from, &old_byte_from);
 }

--- a/.cbmc-batch/jobs/aws_array_list_swap_contents/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_swap_contents/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_array_list_swap_contents_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
 goto: aws_array_list_swap_contents_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -48,7 +48,7 @@ bool aws_array_list_is_bounded(struct aws_array_list *list, size_t max_initial_i
 }
 
 void ensure_array_list_has_allocated_data_member(struct aws_array_list *list) {
-    if (list->current_size == 0) {
+    if (list->current_size == 0 && list->length == 0) {
         __CPROVER_assume(list->data == NULL);
         list->alloc = can_fail_allocator();
     } else {

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -81,8 +81,8 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
         return false;
     }
     size_t required_size;
-    bool required_size_is_valid = aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS;
-    bool current_size_is_valid = list->current_size >= required_size;
+    bool required_size_is_valid = (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS);
+    bool current_size_is_valid = (list->current_size >= required_size);
     bool data_is_valid = ((list->current_size == 0 && list->data == NULL) || AWS_MEM_IS_WRITABLE(list->data, list->current_size));
     return required_size_is_valid && current_size_is_valid && data_is_valid;
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This PR refactor the following proofs for `aws_array_list` with a new proof style:
 - aws_array_list_init_dynamic
 - aws_array_list_init_static
 - aws_array_list_length
 - aws_array_list_pop_back
 - aws_array_list_pop_front
 - aws_array_list_pop_front_n
 - aws_array_list_push_back
 - aws_array_list_set_at
 - aws_array_list_shrink_to_fit
 - aws_array_list_sort
 - aws_array_list_swap
 - aws_array_list_swap_contents

The refactor aims to improve readability and code quality of our proofs, which transit from an imperative style to a more functional one. This new proof style will be gradually implemented in all proofs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
