### PR TITLE
Add pre and postconditions to all functions for aws_array_list

### DIFF
--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -110,12 +110,11 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return aws_raise_error(AWS_ERROR_LIST_EXCEEDS_MAX_SIZE);
     }
 
-    if (err_code == AWS_OP_SUCCESS) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
-    }
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return err_code;
 }
 
@@ -128,6 +127,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
         return AWS_OP_SUCCESS;
     }
 
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -140,6 +140,7 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
         return AWS_OP_SUCCESS;
     }
 
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -176,6 +177,7 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
         return AWS_OP_SUCCESS;
     }
 
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -194,6 +196,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
         return AWS_OP_SUCCESS;
     }
 
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -231,8 +234,9 @@ AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    return list->current_size / list->item_size;
+    size_t capacity = list->current_size / list->item_size;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    return capacity;
 }
 
 AWS_STATIC_IMPL
@@ -243,8 +247,9 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      */
     AWS_FATAL_ASSERT(!list->length || list->data);
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-
-    return list->length;
+    size_t len = list->length;
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    return len;
 }
 
 AWS_STATIC_IMPL
@@ -255,6 +260,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
 }
 
@@ -266,6 +272,7 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
 }
 
@@ -274,10 +281,12 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
 
     if (aws_mul_size_checked(index_inc, list->item_size, necessary_size)) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -289,11 +298,13 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
 
     if (list->current_size < necessary_size) {
         if (aws_array_list_ensure_capacity(list, index)) {
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
     }
@@ -308,6 +319,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
      */
     if (index >= aws_array_list_length(list)) {
         if (aws_add_size_checked(index, 1, &list->length)) {
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
     }

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -19,6 +19,7 @@
 #include <stdlib.h> /* qsort */
 
 int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
@@ -40,6 +41,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             list->data = raw_data;
             list->current_size = ideal_size;
         }
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
 
@@ -49,6 +51,8 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
     AWS_FATAL_ASSERT(from->item_size == to->item_size);
     AWS_FATAL_ASSERT(from->data);
+    AWS_PRECONDITION(aws_array_list_is_valid(from));
+    AWS_PRECONDITION(aws_array_list_is_valid(to));
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -60,6 +64,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
             memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
+        AWS_POSTCONDITION(aws_array_list_is_valid(from));
+        AWS_POSTCONDITION(aws_array_list_is_valid(to));
         return AWS_OP_SUCCESS;
     }
     /* if to is in dynamic mode, we can just reallocate it and copy */
@@ -78,6 +84,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         to->data = tmp;
         to->length = from->length;
         to->current_size = copy_size;
+        AWS_POSTCONDITION(aws_array_list_is_valid(from));
+        AWS_POSTCONDITION(aws_array_list_is_valid(to));
         return AWS_OP_SUCCESS;
     }
 
@@ -85,6 +93,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 }
 
 int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index) {
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         return AWS_OP_ERR;
@@ -136,6 +145,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
         list->current_size = new_size;
     }
 
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return AWS_OP_SUCCESS;
 }
 
@@ -165,6 +175,7 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (a == b) {
         return;
     }
@@ -173,4 +184,5 @@ void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, siz
     aws_array_list_get_at_ptr(list, &item1, a);
     aws_array_list_get_at_ptr(list, &item2, b);
     aws_array_list_mem_swap(item1, item2, list->item_size);
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -23,6 +23,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
 
@@ -32,6 +33,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             if (ideal_size > 0) {
                 raw_data = aws_mem_acquire(list->alloc, ideal_size);
                 if (!raw_data) {
+                    AWS_POSTCONDITION(aws_array_list_is_valid(list));
                     return AWS_OP_ERR;
                 }
 
@@ -45,6 +47,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
         return AWS_OP_SUCCESS;
     }
 
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_STATIC_MODE_CANT_SHRINK);
 }
 
@@ -56,6 +59,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(from));
+        AWS_POSTCONDITION(aws_array_list_is_valid(to));
         return AWS_OP_ERR;
     }
 
@@ -73,6 +78,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         void *tmp = aws_mem_acquire(to->alloc, copy_size);
 
         if (!tmp) {
+            AWS_POSTCONDITION(aws_array_list_is_valid(from));
+            AWS_POSTCONDITION(aws_array_list_is_valid(to));
             return AWS_OP_ERR;
         }
 
@@ -96,11 +103,13 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
 
     if (list->current_size < necessary_size) {
         if (!list->alloc) {
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return aws_raise_error(AWS_ERROR_INVALID_INDEX);
         }
 
@@ -121,12 +130,14 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
              * most certainly out of addressable memory. But since we're simply
              * going to fail fast and say, sorry can't do it, we'll just tell
              * the user they can't grow the list anymore. */
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return aws_raise_error(AWS_ERROR_LIST_EXCEEDS_MAX_SIZE);
         }
 
         void *temp = aws_mem_acquire(list->alloc, new_size);
 
         if (!temp) {
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
 
@@ -176,7 +187,9 @@ void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, siz
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+
     if (a == b) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return;
     }
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This PR introduces pre and postconditions to functions related to `aws_array_list`, so we can ensure they will always operate over valid `aws_array_list` structures. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
