### PR TITLE
Memory-safety proofs for aws_priority_queue functions

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -34,11 +34,6 @@
 #define ASSUME_VALID_MEMORY_COUNT(ptr, count) ptr = malloc(sizeof(*(ptr)) * (count))
 #define ASSUME_DEFAULT_ALLOCATOR(allocator) allocator = aws_default_allocator()
 #define ASSUME_CAN_FAIL_ALLOCATOR(allocator) allocator = can_fail_allocator()
-#define ASSUME_ARBITRARY_ARRAY_LIST(list, initial_item_allocation, item_size)                                          \
-    list = make_arbitrary_array_list((initial_item_allocation), (item_size))
-#define ASSUME_NONDET_ARRAY_LIST(list) list = make_nondet_array_list()
-#define ASSUME_BOUNDED_ARRAY_LIST(list, max_initial_item_allocation, max_item_size)                                    \
-    list = make_bounded_array_list((max_initial_item_allocation), (max_item_size))
 
 /*
  * Checks whether aws_byte_buf is bounded by max_size
@@ -87,22 +82,6 @@ bool aws_priority_queue_is_bounded(
  * Ensures members of an aws_priority_queue structure are correctly allocated
  */
 void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queue);
-
-/**
- * Makes an array list, with as much nondet as possible, defined initial_item_allocation and defined item_size
- */
-struct aws_array_list *make_arbitrary_array_list(size_t initial_item_allocation, size_t item_size);
-
-/**
- * Makes an array list, with as much nondet as possible
- */
-struct aws_array_list *make_nondet_array_list();
-
-/**
- * Makes an array list, with as much nondet as possible, initial_item_allocation < max_initial_item_allocation
- * item_size < max_item_size
- */
-struct aws_array_list *make_bounded_array_list(size_t max_initial_item_allocation, size_t max_item_size);
 
 /**
  * Makes a byte_buf, with as much nondet as possible, len < max, valid backing storage

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -18,6 +18,7 @@
 #include <aws/common/array_list.h>
 #include <aws/common/byte_buf.h>
 #include <aws/common/common.h>
+#include <aws/common/priority_queue.h>
 #include <aws/common/private/hash_table_impl.h>
 #include <aws/common/string.h>
 #include <proof_helpers/nondet.h>
@@ -73,6 +74,19 @@ bool aws_array_list_is_bounded(struct aws_array_list *list, size_t max_initial_i
  * Ensures the data member of an aws_array_list structure is correctly allocated
  */
 void ensure_array_list_has_allocated_data_member(struct aws_array_list *list);
+
+/*
+ * Checks whether aws_priority_queue is bounded by max_initial_item_allocation and max_item_size
+ */
+bool aws_priority_queue_is_bounded(
+    struct aws_priority_queue *queue,
+    size_t max_initial_item_allocation,
+    size_t max_item_size);
+
+/**
+ * Ensures members of an aws_priority_queue structure are correctly allocated
+ */
+void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queue);
 
 /**
  * Makes an array list, with as much nondet as possible, defined initial_item_allocation and defined item_size

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -38,50 +38,53 @@
 /*
  * Checks whether aws_byte_buf is bounded by max_size
  */
-bool is_bounded_byte_buf(struct aws_byte_buf *buf, size_t max_size);
+bool is_bounded_byte_buf(const struct aws_byte_buf *const buf, const size_t max_size);
 
 /*
  * Checks whether aws_byte_buf has the correct allocator
  */
-bool is_byte_buf_expected_alloc(struct aws_byte_buf *buf);
+bool is_byte_buf_expected_alloc(const struct aws_byte_buf *const buf);
 
 /*
  * Ensures aws_byte_buf has a proper allocated buffer member
  */
-void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *buf);
+void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf);
 
 /*
  * Checks whether aws_byte_cursor is bounded by max_size
  */
-bool is_bounded_byte_cursor(struct aws_byte_cursor *cursor, size_t max_size);
+bool is_bounded_byte_cursor(const struct aws_byte_cursor *const cursor, const size_t max_size);
 
 /*
  * Ensures aws_byte_cursor has a proper allocated buffer member
  */
-void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *cursor);
+void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *const cursor);
 
 /*
  * Checks whether aws_array_list is bounded by max_initial_item_allocation and max_item_size
  */
-bool aws_array_list_is_bounded(struct aws_array_list *list, size_t max_initial_item_allocation, size_t max_item_size);
+bool aws_array_list_is_bounded(
+    const struct aws_array_list *const list,
+    const size_t max_initial_item_allocation,
+    const size_t max_item_size);
 
 /**
  * Ensures the data member of an aws_array_list structure is correctly allocated
  */
-void ensure_array_list_has_allocated_data_member(struct aws_array_list *list);
+void ensure_array_list_has_allocated_data_member(struct aws_array_list *const list);
 
 /*
  * Checks whether aws_priority_queue is bounded by max_initial_item_allocation and max_item_size
  */
 bool aws_priority_queue_is_bounded(
-    struct aws_priority_queue *queue,
-    size_t max_initial_item_allocation,
-    size_t max_item_size);
+    const struct aws_priority_queue *const queue,
+    const size_t max_initial_item_allocation,
+    const size_t max_item_size);
 
 /**
  * Ensures members of an aws_priority_queue structure are correctly allocated
  */
-void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queue);
+void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *const queue);
 
 /**
  * Makes a byte_buf, with as much nondet as possible, len < max, valid backing storage

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -25,17 +25,32 @@ struct store_byte_from_buffer {
     uint8_t byte;
 };
 
-void assert_bytes_match(const uint8_t *a, const uint8_t *b, size_t len);
-void assert_all_bytes_are(const uint8_t *a, const uint8_t c, size_t len);
-void assert_all_zeroes(const uint8_t *a, size_t len);
-void assert_byte_from_buffer_matches(const uint8_t *buffer, struct store_byte_from_buffer *b);
+/**
+ * Asserts whether all bytes from two arrays of same length match.
+ */
+void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len);
+
+/**
+ * Asserts whether all bytes from an array are equal to c.
+ */
+void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len);
+
+/**
+ * Asserts whether all bytes from an array are equal to 0.
+ */
+void assert_all_zeroes(const uint8_t *const a, const size_t len);
+
+/**
+ * Asserts whether the byte in storage correspond to the byte in the same position in buffer.
+ */
+void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct store_byte_from_buffer *const b);
 
 /**
  * Nondeterministically selects a byte from array and stores it into a store_array_list_byte
  * structure. Afterwards, one can prove using the assert_array_list_equivalence function
  * whether no byte in the array has changed.
  */
-void save_byte_from_array(const uint8_t *array, size_t size, struct store_byte_from_buffer *storage);
+void save_byte_from_array(const uint8_t *const array, const size_t size, struct store_byte_from_buffer *const storage);
 
 /**
  * Asserts two aws_array_list structures are equivalent. Prior to using this function,
@@ -43,9 +58,9 @@ void save_byte_from_array(const uint8_t *array, size_t size, struct store_byte_f
  * (use save_byte_from_array function), so it can properly assert all bytes match.
  */
 void assert_array_list_equivalence(
-    struct aws_array_list *lhs,
-    struct aws_array_list *rhs,
-    struct store_byte_from_buffer *rhs_byte);
+    const struct aws_array_list *const lhs,
+    const struct aws_array_list *const rhs,
+    const struct store_byte_from_buffer *const rhs_byte);
 
 /**
  * Nondeterministically selects a byte from a hash_table implementation and stores it into a
@@ -59,6 +74,6 @@ void save_byte_from_hash_table(const struct aws_hash_table *map, struct store_by
 void check_hash_table_unchanged(const struct aws_hash_table *map, const struct store_byte_from_buffer *storage);
 
 /**
- * Standard stub function to compare two items
+ * Standard stub function to compare two items.
  */
-int nondet_compare(const void *a, const void *b);
+int nondet_compare(const void *const a, const void *const b);

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -61,4 +61,4 @@ void check_hash_table_unchanged(const struct aws_hash_table *map, const struct s
 /**
  * Standard stub function to compare two items
  */
-int s_compare(const void *a, const void *b);
+int nondet_compare(const void *a, const void *b);

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -57,3 +57,8 @@ void save_byte_from_hash_table(const struct aws_hash_table *map, struct store_by
  * Checks that a no bytes in the hash_table have changed from when "storage" was stored.
  */
 void check_hash_table_unchanged(const struct aws_hash_table *map, const struct store_byte_from_buffer *storage);
+
+/**
+ * Standard stub function to compare two items
+ */
+int s_compare(const void *a, const void *b);

--- a/.cbmc-batch/jobs/aws_priority_queue_capacity/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_capacity/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+
+# This is the minimum bound to reach full coverage rate
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_priority_queue_capacity_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_priority_queue_capacity/aws_priority_queue_capacity_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_capacity/aws_priority_queue_capacity_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Runtime: 12s
+ */
+void aws_priority_queue_capacity_harness() {
+    /* data structure */
+    struct aws_priority_queue queue;
+
+    /* assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_priority_queue_has_allocated_members(&queue);
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+
+    /* save current state of the container structure */
+    struct aws_array_list old_container = queue.container;
+    struct store_byte_from_buffer old_byte_container;
+    save_byte_from_array((uint8_t *)old_container.data, old_container.current_size, &old_byte_container);
+
+    /* save current state of the backpointers structure */
+    struct aws_array_list old_backpointers = queue.backpointers;
+    struct store_byte_from_buffer old_byte_backpointers;
+    save_byte_from_array((uint8_t *)old_backpointers.data, old_backpointers.current_size, &old_byte_backpointers);
+
+    /* perform operation under verification */
+    size_t capacity = aws_priority_queue_capacity(&queue);
+
+    /* assertions */
+    assert(aws_priority_queue_is_valid(&queue));
+    assert(capacity == queue.container.current_size / queue.container.item_size);
+    assert_array_list_equivalence(&queue.container, &old_container, &old_byte_container);
+    assert_array_list_equivalence(&queue.backpointers, &old_backpointers, &old_byte_backpointers);
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_capacity/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_capacity/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_priority_queue_capacity_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_clean_up/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+
+# This is the minimum bound to reach full coverage rate
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_priority_queue_clean_up_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_priority_queue_clean_up/aws_priority_queue_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_clean_up/aws_priority_queue_clean_up_harness.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Runtime: 8s
+ */
+void aws_priority_queue_clean_up_harness() {
+    /* data structure */
+    struct aws_priority_queue queue;
+
+    /* assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_priority_queue_has_allocated_members(&queue);
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+
+    /* perform operation under verification */
+    aws_priority_queue_clean_up(&queue);
+
+    /* assertions */
+    assert(aws_priority_queue_is_valid(&queue));
+    assert(queue.container.alloc == NULL);
+    assert(queue.container.current_size == 0);
+    assert(queue.container.length == 0);
+    assert(queue.container.item_size == 0);
+    assert(queue.container.data == NULL);
+    assert(queue.backpointers.alloc == NULL);
+    assert(queue.backpointers.current_size == 0);
+    assert(queue.backpointers.length == 0);
+    assert(queue.backpointers.item_size == 0);
+    assert(queue.backpointers.data == NULL);
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_clean_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_priority_queue_clean_up_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+
+# This bound allow us to reach full coverage rate
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_priority_queue_init_dynamic_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/aws_priority_queue_init_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/aws_priority_queue_init_dynamic_harness.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Runtime: 9s
+ */
+void aws_priority_queue_init_dynamic_harness() {
+
+    /* data structure */
+    struct aws_priority_queue *queue;
+
+    /* parameters */
+    struct aws_allocator *allocator;
+    size_t item_size;
+    size_t initial_item_allocation;
+    size_t len;
+
+    /* assumptions */
+    ASSUME_VALID_MEMORY(queue);
+    ASSUME_CAN_FAIL_ALLOCATOR(allocator);
+    __CPROVER_assume(initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION);
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    __CPROVER_assume(!aws_mul_size_checked(initial_item_allocation, item_size, &len));
+
+    /* perform operation under verification */
+    uint8_t *raw_array = bounded_malloc(len);
+    if (!aws_priority_queue_init_dynamic(queue, allocator, initial_item_allocation, item_size, s_compare)) {
+        /* assertions */
+        assert(aws_priority_queue_is_valid(queue));
+        assert(queue->container.alloc == allocator);
+        assert(queue->container.item_size == item_size);
+        assert(queue->container.length == 0);
+        assert(
+            (queue->container.data == NULL && queue->container.current_size == 0) ||
+            (queue->container.data && queue->container.current_size == (initial_item_allocation * item_size)));
+    }
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/aws_priority_queue_init_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/aws_priority_queue_init_dynamic_harness.c
@@ -39,7 +39,7 @@ void aws_priority_queue_init_dynamic_harness() {
 
     /* perform operation under verification */
     uint8_t *raw_array = bounded_malloc(len);
-    if (!aws_priority_queue_init_dynamic(queue, allocator, initial_item_allocation, item_size, s_compare)) {
+    if (!aws_priority_queue_init_dynamic(queue, allocator, initial_item_allocation, item_size, nondet_compare)) {
         /* assertions */
         assert(aws_priority_queue_is_valid(queue));
         assert(queue->container.alloc == allocator);

--- a/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_dynamic/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_priority_queue_init_dynamic_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_init_static/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_static/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+
+# This is the minimum bound to reach full coverage rate
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_priority_queue_init_static_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_priority_queue_init_static/aws_priority_queue_init_static_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_static/aws_priority_queue_init_static_harness.c
@@ -37,7 +37,7 @@ void aws_priority_queue_init_static_harness() {
 
     /* perform operation under verification */
     uint8_t *raw_array = bounded_malloc(len);
-    aws_priority_queue_init_static(queue, raw_array, initial_item_allocation, item_size, s_compare);
+    aws_priority_queue_init_static(queue, raw_array, initial_item_allocation, item_size, nondet_compare);
 
     /* assertions */
     assert(aws_priority_queue_is_valid(queue));

--- a/.cbmc-batch/jobs/aws_priority_queue_init_static/aws_priority_queue_init_static_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_static/aws_priority_queue_init_static_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Runtime: 8s
+ */
+void aws_priority_queue_init_static_harness() {
+
+    /* data structure */
+    struct aws_priority_queue *queue;
+
+    /* parameters */
+    size_t item_size;
+    size_t initial_item_allocation;
+    size_t len;
+
+    /* assumptions */
+    ASSUME_VALID_MEMORY(queue);
+    __CPROVER_assume(initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION);
+    __CPROVER_assume(item_size <= MAX_ITEM_SIZE);
+    __CPROVER_assume(!aws_mul_size_checked(initial_item_allocation, item_size, &len));
+
+    /* perform operation under verification */
+    uint8_t *raw_array = bounded_malloc(len);
+    aws_priority_queue_init_static(queue, raw_array, initial_item_allocation, item_size, s_compare);
+
+    /* assertions */
+    assert(aws_priority_queue_is_valid(queue));
+    assert(queue->container.alloc == NULL);
+    assert(queue->container.item_size == item_size);
+    assert(queue->container.length == 0);
+    assert(queue->container.current_size == initial_item_allocation * item_size);
+    assert_bytes_match((uint8_t *)queue->container.data, raw_array, len);
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_init_static/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_init_static/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_priority_queue_init_static_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_size/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_size/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+
+# This is the minimum bound to reach full coverage rate
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_priority_queue_size_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_priority_queue_size/aws_priority_queue_size_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_size/aws_priority_queue_size_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Runtime: 13s
+ */
+void aws_priority_queue_size_harness() {
+    /* data structure */
+    struct aws_priority_queue queue;
+
+    /* assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_priority_queue_has_allocated_members(&queue);
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+
+    /* save current state of the container structure */
+    struct aws_array_list old_container = queue.container;
+    struct store_byte_from_buffer old_byte_container;
+    save_byte_from_array((uint8_t *)old_container.data, old_container.current_size, &old_byte_container);
+
+    /* save current state of the backpointers structure */
+    struct aws_array_list old_backpointers = queue.backpointers;
+    struct store_byte_from_buffer old_byte_backpointers;
+    save_byte_from_array((uint8_t *)old_backpointers.data, old_backpointers.current_size, &old_byte_backpointers);
+
+    /* perform operation under verification */
+    size_t size = aws_priority_queue_size(&queue);
+
+    /* assertions */
+    assert(aws_priority_queue_is_valid(&queue));
+    assert_array_list_equivalence(&queue.container, &old_container, &old_byte_container);
+    assert_array_list_equivalence(&queue.backpointers, &old_backpointers, &old_byte_backpointers);
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_size/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_size/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_priority_queue_size_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_top/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_top/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+
+# This is the minimum bound to reach full coverage rate
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_priority_queue_top_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_priority_queue_top/aws_priority_queue_top_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_top/aws_priority_queue_top_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Runtime: 21s
+ */
+void aws_priority_queue_top_harness() {
+    /* data structure */
+    struct aws_priority_queue queue;
+
+    /* assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_priority_queue_has_allocated_members(&queue);
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+
+    /* save current state of the container structure */
+    struct aws_array_list old_container = queue.container;
+    struct store_byte_from_buffer old_byte_container;
+    save_byte_from_array((uint8_t *)old_container.data, old_container.current_size, &old_byte_container);
+
+    /* save current state of the backpointers structure */
+    struct aws_array_list old_backpointers = queue.backpointers;
+    struct store_byte_from_buffer old_byte_backpointers;
+    save_byte_from_array((uint8_t *)old_backpointers.data, old_backpointers.current_size, &old_byte_backpointers);
+
+    /* perform operation under verification */
+    void *top_val_ptr = bounded_malloc(queue.container.item_size);
+    aws_priority_queue_top(&queue, &top_val_ptr);
+
+    /* assertions */
+    assert(aws_priority_queue_is_valid(&queue));
+    assert_array_list_equivalence(&queue.container, &old_container, &old_byte_container);
+    assert_array_list_equivalence(&queue.backpointers, &old_backpointers, &old_byte_backpointers);
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_top/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_top/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_priority_queue_top_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -57,6 +57,23 @@ void ensure_array_list_has_allocated_data_member(struct aws_array_list *list) {
     }
 }
 
+bool aws_priority_queue_is_bounded(
+    struct aws_priority_queue *queue,
+    size_t max_initial_item_allocation,
+    size_t max_item_size) {
+    bool container_is_bounded =
+        aws_array_list_is_bounded(&queue->container, max_initial_item_allocation, max_item_size);
+    bool backpointers_is_bounded =
+        aws_array_list_is_bounded(&queue->backpointers, max_initial_item_allocation, max_item_size);
+    return container_is_bounded && backpointers_is_bounded;
+}
+
+void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queue) {
+    ensure_array_list_has_allocated_data_member(&queue->container);
+    ensure_array_list_has_allocated_data_member(&queue->backpointers);
+    queue->pred = s_compare;
+}
+
 struct aws_array_list *make_arbitrary_array_list(size_t initial_item_allocation, size_t item_size) {
     struct aws_array_list *list;
     /* Assume list is allocated */

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -74,46 +74,6 @@ void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queu
     queue->pred = nondet_compare;
 }
 
-struct aws_array_list *make_arbitrary_array_list(size_t initial_item_allocation, size_t item_size) {
-    struct aws_array_list *list;
-    /* Assume list is allocated */
-    ASSUME_VALID_MEMORY(list);
-
-    if (nondet_int()) { /* dynamic */
-        struct aws_allocator *allocator;
-        ASSUME_CAN_FAIL_ALLOCATOR(allocator);
-        __CPROVER_assume(
-            aws_array_list_init_dynamic(list, allocator, initial_item_allocation, item_size) == AWS_OP_SUCCESS);
-    } else { /* static */
-        size_t len;
-        __CPROVER_assume(!aws_mul_size_checked(initial_item_allocation, item_size, &len));
-        void *raw_array = can_fail_malloc(len);
-        aws_array_list_init_static(list, raw_array, initial_item_allocation, item_size);
-    }
-    list->length = nondet_size_t();
-    __CPROVER_assume(list->length <= initial_item_allocation);
-
-    return list;
-}
-
-struct aws_array_list *make_nondet_array_list() {
-    size_t initial_item_allocation = nondet_size_t();
-    size_t item_size = nondet_size_t();
-    struct aws_array_list *list;
-    ASSUME_ARBITRARY_ARRAY_LIST(list, initial_item_allocation, item_size);
-    return list;
-}
-
-struct aws_array_list *make_bounded_array_list(size_t max_initial_item_allocation, size_t max_item_size) {
-    size_t initial_item_allocation = nondet_size_t();
-    __CPROVER_assume(initial_item_allocation <= max_initial_item_allocation);
-    size_t item_size = nondet_size_t();
-    __CPROVER_assume(item_size <= max_item_size);
-    struct aws_array_list *list;
-    ASSUME_ARBITRARY_ARRAY_LIST(list, initial_item_allocation, item_size);
-    return list;
-}
-
 struct aws_byte_cursor make_arbitrary_byte_cursor_nondet_len_max(size_t max) {
     size_t len;
     __CPROVER_assume(len <= max);

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -20,34 +20,37 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-bool is_bounded_byte_buf(struct aws_byte_buf *buf, size_t max_size) {
+bool is_bounded_byte_buf(const struct aws_byte_buf *const buf, const size_t max_size) {
     return buf->capacity <= max_size;
 }
 
-bool is_byte_buf_expected_alloc(struct aws_byte_buf *buf) {
+bool is_byte_buf_expected_alloc(const struct aws_byte_buf *const buf) {
     return (buf->allocator == can_fail_allocator());
 }
 
-void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *buf) {
+void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf) {
     buf->allocator = can_fail_allocator();
     buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * buf->capacity);
 }
 
-bool is_bounded_byte_cursor(struct aws_byte_cursor *cursor, size_t max_size) {
+bool is_bounded_byte_cursor(const struct aws_byte_cursor *const cursor, const size_t max_size) {
     return cursor->len <= max_size;
 }
 
-void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *cursor) {
+void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *const cursor) {
     cursor->ptr = bounded_malloc(cursor->len);
 }
 
-bool aws_array_list_is_bounded(struct aws_array_list *list, size_t max_initial_item_allocation, size_t max_item_size) {
+bool aws_array_list_is_bounded(
+    const struct aws_array_list *const list,
+    const size_t max_initial_item_allocation,
+    const size_t max_item_size) {
     bool item_size_is_bounded = list->item_size <= max_item_size;
     bool length_is_bounded = list->length <= max_initial_item_allocation;
     return item_size_is_bounded && length_is_bounded;
 }
 
-void ensure_array_list_has_allocated_data_member(struct aws_array_list *list) {
+void ensure_array_list_has_allocated_data_member(struct aws_array_list *const list) {
     if (list->current_size == 0 && list->length == 0) {
         __CPROVER_assume(list->data == NULL);
         list->alloc = can_fail_allocator();
@@ -58,9 +61,9 @@ void ensure_array_list_has_allocated_data_member(struct aws_array_list *list) {
 }
 
 bool aws_priority_queue_is_bounded(
-    struct aws_priority_queue *queue,
-    size_t max_initial_item_allocation,
-    size_t max_item_size) {
+    const struct aws_priority_queue *const queue,
+    const size_t max_initial_item_allocation,
+    const size_t max_item_size) {
     bool container_is_bounded =
         aws_array_list_is_bounded(&queue->container, max_initial_item_allocation, max_item_size);
     bool backpointers_is_bounded =
@@ -68,7 +71,7 @@ bool aws_priority_queue_is_bounded(
     return container_is_bounded && backpointers_is_bounded;
 }
 
-void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queue) {
+void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *const queue) {
     ensure_array_list_has_allocated_data_member(&queue->container);
     ensure_array_list_has_allocated_data_member(&queue->backpointers);
     queue->pred = nondet_compare;

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -71,7 +71,7 @@ bool aws_priority_queue_is_bounded(
 void ensure_priority_queue_has_allocated_members(struct aws_priority_queue *queue) {
     ensure_array_list_has_allocated_data_member(&queue->container);
     ensure_array_list_has_allocated_data_member(&queue->backpointers);
-    queue->pred = s_compare;
+    queue->pred = nondet_compare;
 }
 
 struct aws_array_list *make_arbitrary_array_list(size_t initial_item_allocation, size_t item_size) {

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -16,7 +16,7 @@
 #include <aws/common/private/hash_table_impl.h>
 #include <proof_helpers/utils.h>
 
-void assert_bytes_match(const uint8_t *a, const uint8_t *b, size_t len) {
+void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const size_t len) {
     assert(!a == !b);
     if (len > 0 && a != NULL && b != NULL) {
         size_t i;
@@ -25,7 +25,7 @@ void assert_bytes_match(const uint8_t *a, const uint8_t *b, size_t len) {
     }
 }
 
-void assert_all_bytes_are(const uint8_t *a, const uint8_t c, size_t len) {
+void assert_all_bytes_are(const uint8_t *const a, const uint8_t c, const size_t len) {
     if (len > 0 && a != NULL) {
         size_t i;
         __CPROVER_assume(i < len);
@@ -33,17 +33,17 @@ void assert_all_bytes_are(const uint8_t *a, const uint8_t c, size_t len) {
     }
 }
 
-void assert_all_zeroes(const uint8_t *a, size_t len) {
+void assert_all_zeroes(const uint8_t *const a, const size_t len) {
     assert_all_bytes_are(a, 0, len);
 }
 
-void assert_byte_from_buffer_matches(const uint8_t *buffer, struct store_byte_from_buffer *b) {
+void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct store_byte_from_buffer *const b) {
     if (buffer) {
         assert(*(buffer + b->index) == b->byte);
     }
 }
 
-void save_byte_from_array(const uint8_t *array, size_t size, struct store_byte_from_buffer *storage) {
+void save_byte_from_array(const uint8_t *const array, const size_t size, struct store_byte_from_buffer *const storage) {
     if (size > 0) {
         storage->index = nondet_size_t();
         __CPROVER_assume(storage->index < size);
@@ -52,9 +52,9 @@ void save_byte_from_array(const uint8_t *array, size_t size, struct store_byte_f
 }
 
 void assert_array_list_equivalence(
-    struct aws_array_list *lhs,
-    struct aws_array_list *rhs,
-    struct store_byte_from_buffer *rhs_byte) {
+    const struct aws_array_list *const lhs,
+    const struct aws_array_list *const rhs,
+    const struct store_byte_from_buffer *const rhs_byte) {
     assert(lhs->alloc == rhs->alloc);
     assert(lhs->current_size == rhs->current_size);
     assert(lhs->length == rhs->length);
@@ -77,7 +77,7 @@ void check_hash_table_unchanged(const struct aws_hash_table *map, const struct s
     assert(byte_array[storage->index] == storage->byte);
 }
 
-int nondet_compare(const void *a, const void *b) {
+int nondet_compare(const void *const a, const void *const b) {
     assert(a != NULL);
     assert(b != NULL);
     int nondet;

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -76,3 +76,10 @@ void check_hash_table_unchanged(const struct aws_hash_table *map, const struct s
     uint8_t *byte_array = (uint8_t *)state;
     assert(byte_array[storage->index] == storage->byte);
 }
+
+int s_compare(const void *a, const void *b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    int nondet;
+    return nondet;
+}

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -77,7 +77,7 @@ void check_hash_table_unchanged(const struct aws_hash_table *map, const struct s
     assert(byte_array[storage->index] == storage->byte);
 }
 
-int s_compare(const void *a, const void *b) {
+int nondet_compare(const void *a, const void *b) {
     assert(a != NULL);
     assert(b != NULL);
     int nondet;

--- a/include/aws/common/priority_queue.h
+++ b/include/aws/common/priority_queue.h
@@ -95,7 +95,7 @@ void aws_priority_queue_init_static(
  * Set of properties of a valid aws_priority_queue.
  */
 AWS_COMMON_API
-bool aws_priority_queue_is_valid(struct aws_priority_queue *queue);
+bool aws_priority_queue_is_valid(const struct aws_priority_queue *const queue);
 
 /**
  * Cleans up any internally allocated memory and resets the struct for reuse or deletion.

--- a/include/aws/common/priority_queue.h
+++ b/include/aws/common/priority_queue.h
@@ -92,6 +92,12 @@ void aws_priority_queue_init_static(
     aws_priority_queue_compare_fn *pred);
 
 /**
+ * Set of properties of a valid aws_priority_queue.
+ */
+AWS_COMMON_API
+bool aws_priority_queue_is_valid(struct aws_priority_queue *queue);
+
+/**
  * Cleans up any internally allocated memory and resets the struct for reuse or deletion.
  */
 AWS_COMMON_API

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -157,7 +157,7 @@ void aws_priority_queue_init_static(
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 }
 
-bool aws_priority_queue_is_valid(struct aws_priority_queue *queue) {
+bool aws_priority_queue_is_valid(const struct aws_priority_queue *const queue) {
     if (!queue) {
         return false;
     }

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -157,6 +157,16 @@ void aws_priority_queue_init_static(
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 }
 
+bool aws_priority_queue_is_valid(struct aws_priority_queue *queue) {
+    if (!queue) {
+        return false;
+    }
+    bool pred_is_valid = (queue->pred != NULL);
+    bool container_is_valid = aws_array_list_is_valid(&queue->container);
+    bool backpointers_is_valid = aws_array_list_is_valid(&queue->backpointers);
+    return pred_is_valid && container_is_valid && backpointers_is_valid;
+}
+
 void aws_priority_queue_clean_up(struct aws_priority_queue *queue) {
     aws_array_list_clean_up(&queue->container);
     aws_array_list_clean_up(&queue->backpointers);


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Adds invariant for `aws_priority_queue` structure and proof harnesses for the following functions:
 - aws_priority_queue_init_dynamic
 - aws_priority_queue_init_static
 - aws_priority_queue_clean_up
 - aws_priority_queue_top
 - aws_priority_queue_size
 - aws_priority_queue_capacity

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
