### PR TITLE
Document that log subjects and error codes should overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ returning control to the caller, if you have an error to raise, use the `aws_rai
 returning control to the caller, if you have an error to raise, use the `aws_raise_error()` function.
 
 #### Log Subjects & Error Codes
-The error handling infrastructure is designed to support multiple libraries. For this to work, AWS maintained libraries
+The logging & error handling infrastructure is designed to support multiple libraries. For this to work, AWS maintained libraries
 have pre-slotted log subjects & error codes for each library. The currently allocated error ranges are:
 
 | Range | Library Name |

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ returning control to the caller, if you have an error to raise, use the `aws_rai
 * For APIs returning an allocated instance of an object, return the memory on success, and `NULL` on failure. Before
 returning control to the caller, if you have an error to raise, use the `aws_raise_error()` function.
 
-#### Error Codes
+#### Log Subjects & Error Codes
 The error handling infrastructure is designed to support multiple libraries. For this to work, AWS maintained libraries
-have pre-slotted error codes for each library. The currently allocated error ranges are:
+have pre-slotted log subjects & error codes for each library. The currently allocated error ranges are:
 
 | Range | Library Name |
 | --- | --- |


### PR DESCRIPTION
Make it clear that libraries should use the same range for error codes and log subjects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
