### PR TITLE
stream offset + non-static strings

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -160,6 +160,18 @@ AWS_STATIC_ASSERT(sizeof(intptr_t) == sizeof(void *));
 AWS_STATIC_ASSERT(sizeof(char) == 1);
 #endif
 
+#if defined(_MSC_VER)
+typedef int64_t aws_off_t;
+#else
+#   if _FILE_OFFSET_BITS == 64 || _POSIX_C_SOURCE >= 200112L
+typedef off_t aws_off_t;
+#   else
+typedef long aws_off_t;
+#   endif
+#endif
+
+AWS_STATIC_ASSERT(sizeof(int64_t) >= sizeof(aws_off_t));
+
 #ifdef __cplusplus
 #    define AWS_EXTERN_C_BEGIN extern "C" {
 #    define AWS_EXTERN_C_END }

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -188,6 +188,17 @@ AWS_EXTERN_C_END
     } name##_s = {NULL, sizeof(literal) - 1, literal};                                                                 \
     static const struct aws_string *(name) = (struct aws_string *)(&name##_s)
 
+/*
+ * A related macro that declares the string pointer without static, allowing it to be externed as a global constant
+ */
+#define AWS_STRING_FROM_LITERAL(name, literal)                                                                         \
+    static const struct {                                                                                              \
+        struct aws_allocator *const allocator;                                                                         \
+        const size_t len;                                                                                              \
+        const uint8_t bytes[sizeof(literal)];                                                                          \
+    } name##_s = {NULL, sizeof(literal) - 1, literal};                                                                 \
+    const struct aws_string *(name) = (struct aws_string *)(&name##_s)
+
 /**
  * Copies all bytes from string to buf.
  *

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,6 @@ add_test_case(thread_creation_join_test)
 
 add_test_case(mutex_aquire_release_test)
 add_test_case(mutex_is_actually_mutex_test)
-add_test_case(test_mutex_safe_to_cleanup_zeroed)
 
 add_test_case(conditional_notify_one)
 add_test_case(conditional_notify_all)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_test_case(thread_creation_join_test)
 
 add_test_case(mutex_aquire_release_test)
 add_test_case(mutex_is_actually_mutex_test)
+add_test_case(test_mutex_safe_to_cleanup_zeroed)
 
 add_test_case(conditional_notify_one)
 add_test_case(conditional_notify_all)

--- a/tests/mutex_test.c
+++ b/tests/mutex_test.c
@@ -111,19 +111,5 @@ static int s_test_mutex_is_actually_mutex(struct aws_allocator *allocator, void 
     return 0;
 }
 
-static int s_test_mutex_safe_to_cleanup_zeroed(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
-
-    struct aws_mutex lock;
-
-    AWS_ZERO_STRUCT(lock);
-
-    aws_mutex_clean_up(&lock);
-
-    return 0;
-}
-
 AWS_TEST_CASE(mutex_aquire_release_test, s_test_mutex_acquire_release)
 AWS_TEST_CASE(mutex_is_actually_mutex_test, s_test_mutex_is_actually_mutex)
-AWS_TEST_CASE(test_mutex_safe_to_cleanup_zeroed, s_test_mutex_safe_to_cleanup_zeroed)

--- a/tests/mutex_test.c
+++ b/tests/mutex_test.c
@@ -112,7 +112,8 @@ static int s_test_mutex_is_actually_mutex(struct aws_allocator *allocator, void 
 }
 
 static int s_test_mutex_safe_to_cleanup_zeroed(struct aws_allocator *allocator, void *ctx) {
-    (void) ctx;
+    (void)ctx;
+    (void)allocator;
 
     struct aws_mutex lock;
 

--- a/tests/mutex_test.c
+++ b/tests/mutex_test.c
@@ -111,5 +111,18 @@ static int s_test_mutex_is_actually_mutex(struct aws_allocator *allocator, void 
     return 0;
 }
 
+static int s_test_mutex_safe_to_cleanup_zeroed(struct aws_allocator *allocator, void *ctx) {
+    (void) ctx;
+
+    struct aws_mutex lock;
+
+    AWS_ZERO_STRUCT(lock);
+
+    aws_mutex_clean_up(&lock);
+
+    return 0;
+}
+
 AWS_TEST_CASE(mutex_aquire_release_test, s_test_mutex_acquire_release)
 AWS_TEST_CASE(mutex_is_actually_mutex_test, s_test_mutex_is_actually_mutex)
+AWS_TEST_CASE(test_mutex_safe_to_cleanup_zeroed, s_test_mutex_safe_to_cleanup_zeroed)


### PR DESCRIPTION
A few miscellaneous pieces of functionality used in the sigv4 signable update:

* aws_off_t signed offset type for stream seeking (in aws-c-io)
* a macro for declaring non-static string constants


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
