### PR TITLE
Fixes implementation of aws_byte_buf_init_copy function

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
@@ -19,13 +19,13 @@
 void aws_byte_buf_append_with_lookup_harness() {
     struct aws_byte_buf to;
     __CPROVER_assume(is_bounded_byte_buf(&to, MAX_BUF_SIZE));
-    __CPROVER_assume(aws_byte_buf_is_valid(&to));
     ensure_byte_buf_has_allocated_buffer_member(&to);
+    __CPROVER_assume(aws_byte_buf_is_valid(&to));
 
     struct aws_byte_cursor from;
     __CPROVER_assume(is_bounded_byte_cursor(&from, MAX_BUF_SIZE));
-    __CPROVER_assume(aws_byte_cursor_is_valid(&from));
     ensure_byte_cursor_has_allocated_buffer_member(&from);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&from));
 
     /**
      * The specification for the function requires that the buffer

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+MAX_BUFFER_SIZE ?= 10
+DEFINES += -DMAX_BUFFER_SIZE=$(MAX_BUFFER_SIZE)
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_init_copy_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_buf_init_copy_harness() {
+    /* data structure */
+    struct aws_byte_buf *dest;
+
+    /* parameters */
+    struct aws_allocator *allocator;
+    struct aws_byte_buf src;
+
+    /* assumptions */
+    __CPROVER_assume(is_bounded_byte_buf(&src, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&src);
+    __CPROVER_assume(aws_byte_buf_is_valid(&src));
+
+    ASSUME_VALID_MEMORY(dest);
+    ASSUME_CAN_FAIL_ALLOCATOR(allocator);
+
+    /* operation under verification */
+    if (!aws_byte_buf_init_copy(dest, allocator, &src)) {
+        /* assertions */
+        assert(aws_byte_buf_is_valid(dest));
+        assert(is_byte_buf_expected_alloc(dest));
+        assert(dest->len == src.len);
+        assert(dest->capacity == src.capacity);
+        assert_bytes_match(dest->buffer, src.buffer, dest->len);
+        assert(aws_byte_buf_is_valid(&src));
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
@@ -29,9 +29,13 @@ void aws_byte_buf_init_copy_harness() {
     __CPROVER_assume(is_bounded_byte_buf(&src, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&src);
     __CPROVER_assume(aws_byte_buf_is_valid(&src));
-
     ASSUME_VALID_MEMORY(dest);
     ASSUME_CAN_FAIL_ALLOCATOR(allocator);
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old = src;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(src.buffer, src.len, &old_byte);
 
     /* operation under verification */
     if (!aws_byte_buf_init_copy(dest, allocator, &src)) {
@@ -42,5 +46,9 @@ void aws_byte_buf_init_copy_harness() {
         assert(dest->capacity == src.capacity);
         assert_bytes_match(dest->buffer, src.buffer, dest->len);
         assert(aws_byte_buf_is_valid(&src));
+        if (src.len > 0) {
+            assert_byte_from_buffer_matches(src.buffer, &old_byte);
+            assert_byte_from_buffer_matches(dest->buffer, &old_byte);
+        }
     }
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--unwind;1"
+goto: aws_byte_buf_init_copy_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -114,10 +114,18 @@ AWS_COMMON_API
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
 
 /**
+ * Initializes *dest by copying all the fields from *src.
+ */
+AWS_COMMON_API int aws_byte_buf_init_copy(
+    struct aws_byte_buf *dest,
+    struct aws_allocator *allocator,
+    const struct aws_byte_buf *src);
+
+/**
  * Set of properties of a valid aws_byte_buf.
  */
 AWS_COMMON_API
-bool aws_byte_buf_is_valid(const struct aws_byte_buf *buf);
+bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf);
 
 /**
  * Set of properties of a valid aws_byte_cursor.
@@ -466,15 +474,6 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *by
     cur.ptr = (uint8_t *)bytes;
     cur.len = len;
     return cur;
-}
-
-AWS_STATIC_IMPL int aws_byte_buf_init_copy(
-    struct aws_byte_buf *dest,
-    struct aws_allocator *allocator,
-    const struct aws_byte_buf *src) {
-
-    struct aws_byte_cursor src_cur = aws_byte_cursor_from_buf(src);
-    return aws_byte_buf_init_copy_from_cursor(dest, allocator, src_cur);
 }
 
 /**

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -114,7 +114,10 @@ AWS_COMMON_API
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
 
 /**
- * Initializes *dest by copying all the fields from *src.
+ * Initializes an aws_byte_buf structure base on another valid one.
+ * Requires: *src and *allocator are valid objects.
+ * Ensures: *dest is a valid aws_byte_buf with a new backing array dest->buffer
+ * which is a copy of the elements from src->buffer.
  */
 AWS_COMMON_API int aws_byte_buf_init_copy(
     struct aws_byte_buf *dest,
@@ -122,13 +125,15 @@ AWS_COMMON_API int aws_byte_buf_init_copy(
     const struct aws_byte_buf *src);
 
 /**
- * Set of properties of a valid aws_byte_buf.
+ * Evaluates the set of properties that define the shape of all valid aws_byte_buf structures.
+ * It is also a cheap check, in the sense it run in constant time (i.e., no loops or recursion).
  */
 AWS_COMMON_API
 bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf);
 
 /**
- * Set of properties of a valid aws_byte_cursor.
+ * Evaluates the set of properties that define the shape of all valid aws_byte_cursor structures.
+ * It is also a cheap check, in the sense it run in constant time (i.e., no loops or recursion).
  */
 AWS_COMMON_API
 bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor);

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -133,7 +133,7 @@ bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf);
 
 /**
  * Evaluates the set of properties that define the shape of all valid aws_byte_cursor structures.
- * It is also a cheap check, in the sense it run in constant time (i.e., no loops or recursion).
+ * It is also a cheap check, in the sense it runs in constant time (i.e., no loops or recursion).
  */
 AWS_COMMON_API
 bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor);

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -35,8 +35,32 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
     return AWS_OP_SUCCESS;
 }
 
-bool aws_byte_buf_is_valid(const struct aws_byte_buf *buf) {
-    return (buf->len <= buf->capacity) && (buf->allocator != NULL) && AWS_MEM_IS_WRITABLE(buf->buffer, buf->len);
+int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allocator, const struct aws_byte_buf *src) {
+    if (!allocator || !dest || !aws_byte_buf_is_valid(src)) {
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
+
+    *dest = *src;
+    dest->allocator = allocator;
+    dest->buffer = (uint8_t *)aws_mem_acquire(allocator, src->capacity);
+    if (dest->buffer == NULL) {
+        *dest = (struct aws_byte_buf){0};
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(src));
+        return AWS_OP_ERR;
+    }
+    memcpy(dest->buffer, src->buffer, src->len);
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(src));
+    return AWS_OP_SUCCESS;
+}
+
+bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf) {
+    if (!buf) {
+        return false;
+    }
+    bool buffer_is_valid = buf->buffer && AWS_MEM_IS_WRITABLE(buf->buffer, buf->len);
+    bool capacity_is_valid = (buf->len <= buf->capacity);
+    return capacity_is_valid && buffer_is_valid;
 }
 
 bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor) {
@@ -89,19 +113,16 @@ int aws_byte_buf_init_copy_from_cursor(
     struct aws_byte_buf *dest,
     struct aws_allocator *allocator,
     struct aws_byte_cursor src) {
-    assert(allocator);
-    assert(dest);
-
-    dest->len = 0;
-    dest->capacity = 0;
-    dest->allocator = NULL;
-    if (src.ptr == NULL) {
-        dest->buffer = NULL;
-        return AWS_OP_SUCCESS;
+    if (!allocator || !dest || !aws_byte_cursor_is_valid(&src)) {
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    dest->buffer = (uint8_t *)aws_mem_acquire(allocator, sizeof(uint8_t) * src.len);
+    /* clear the dest before updating it. */
+    *dest = (struct aws_byte_buf){0};
+
+    dest->buffer = (uint8_t *)aws_mem_acquire(allocator, src.len);
     if (dest->buffer == NULL) {
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(&src));
         return AWS_OP_ERR;
     }
 
@@ -109,6 +130,8 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     memcpy(dest->buffer, src.ptr, src.len);
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&src));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
     return AWS_OP_SUCCESS;
 }
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -44,13 +44,11 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     dest->allocator = allocator;
     dest->buffer = (uint8_t *)aws_mem_acquire(allocator, src->capacity);
     if (dest->buffer == NULL) {
-        *dest = (struct aws_byte_buf){0};
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(src));
+        AWS_ZERO_STRUCT(*dest);
         return AWS_OP_ERR;
     }
     memcpy(dest->buffer, src->buffer, src->len);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(src));
     return AWS_OP_SUCCESS;
 }
 
@@ -118,12 +116,10 @@ int aws_byte_buf_init_copy_from_cursor(
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    /* clear the dest before updating it. */
-    *dest = (struct aws_byte_buf){0};
+    AWS_ZERO_STRUCT(*dest);
 
     dest->buffer = (uint8_t *)aws_mem_acquire(allocator, src.len);
     if (dest->buffer == NULL) {
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(&src));
         return AWS_OP_ERR;
     }
 
@@ -131,7 +127,6 @@ int aws_byte_buf_init_copy_from_cursor(
     dest->capacity = src.len;
     dest->allocator = allocator;
     memcpy(dest->buffer, src.ptr, src.len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&src));
     AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
     return AWS_OP_SUCCESS;
 }

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -58,9 +58,10 @@ bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf) {
     if (!buf) {
         return false;
     }
-    bool buffer_is_valid = buf->buffer && AWS_MEM_IS_WRITABLE(buf->buffer, buf->len);
-    bool capacity_is_valid = (buf->len <= buf->capacity);
-    return capacity_is_valid && buffer_is_valid;
+    bool buffer_is_valid = (buf->buffer && AWS_MEM_IS_WRITABLE(buf->buffer, buf->len));
+    bool capacity_is_valid = (buf->capacity > 0);
+    bool len_is_valid = (buf->len <= buf->capacity);
+    return capacity_is_valid && buffer_is_valid && len_is_valid;
 }
 
 bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor) {

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -220,17 +220,10 @@ AWS_TEST_CASE(test_buffer_init_copy_null_buffer, s_test_buffer_init_copy_null_bu
 static int s_test_buffer_init_copy_null_buffer_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    struct aws_byte_buf src;
-    src.buffer = NULL;
-    src.len = 5;
-
+    struct aws_byte_buf src = {0};
     struct aws_byte_buf dest;
-    ASSERT_SUCCESS(aws_byte_buf_init_copy(&dest, allocator, &src));
-    ASSERT_PTR_EQUALS(0, dest.allocator);
-    ASSERT_INT_EQUALS(0, dest.capacity);
-    ASSERT_INT_EQUALS(0, dest.len);
-    ASSERT_PTR_EQUALS(0, dest.buffer);
-    aws_byte_buf_clean_up(&dest);
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_buf_init_copy(&dest, allocator, &src));
+
     return 0;
 }
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Previous implementation did not copy the capacity field from src structure. In addition, it allowed the construction of an `aws_byte_buf` structure with a `buffer` field set to `NULL`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
