### PR TITLE
Fixes implementation of the aws_byte_buf_init_copy_from_cursor function and its invariant

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+MAX_BUFFER_SIZE ?= 10
+DEFINES += -DMAX_BUFFER_SIZE=$(MAX_BUFFER_SIZE)
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_init_copy_from_cursor_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/aws_byte_buf_init_copy_from_cursor_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/aws_byte_buf_init_copy_from_cursor_harness.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_buf_init_copy_from_cursor_harness() {
+    /* data structure */
+    struct aws_byte_buf *buf;
+
+    /* parameters */
+    struct aws_allocator *allocator;
+    struct aws_byte_cursor cursor;
+
+    /* assumptions */
+    __CPROVER_assume(is_bounded_byte_cursor(&cursor, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cursor);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cursor));
+    ASSUME_VALID_MEMORY(buf);
+    ASSUME_CAN_FAIL_ALLOCATOR(allocator);
+
+    if (!aws_byte_buf_init_copy_from_cursor(buf, allocator, cursor)) {
+        /* assertions */
+        assert(aws_byte_buf_is_valid(buf));
+        assert(buf->len == cursor.len);
+        assert(buf->capacity == cursor.len);
+        assert(buf->allocator == allocator);
+        assert_bytes_match(buf->buffer, cursor.ptr, buf->len);
+    }
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cursor));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--unwind;1"
+goto: aws_byte_buf_init_copy_from_cursor_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -38,7 +38,7 @@ bool is_bounded_byte_cursor(const struct aws_byte_cursor *const cursor, const si
 }
 
 void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *const cursor) {
-    cursor->ptr = bounded_malloc(cursor->len);
+    cursor->ptr = (nondet_bool()) ? NULL : bounded_malloc(cursor->len);
 }
 
 bool aws_array_list_is_bounded(

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -63,7 +63,13 @@ bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf) {
 }
 
 bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor) {
-    return (cursor->ptr != NULL && cursor->len != 0) && AWS_MEM_IS_WRITABLE(cursor->ptr, cursor->len);
+    bool ptr_is_valid;
+    if (cursor->ptr) {
+        ptr_is_valid = (cursor->len && AWS_MEM_IS_WRITABLE(cursor->ptr, cursor->len));
+    } else {
+        ptr_is_valid = (!cursor->len);
+    }
+    return ptr_is_valid;
 }
 
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
@@ -112,7 +118,7 @@ int aws_byte_buf_init_copy_from_cursor(
     struct aws_byte_buf *dest,
     struct aws_allocator *allocator,
     struct aws_byte_cursor src) {
-    if (!allocator || !dest || !aws_byte_cursor_is_valid(&src)) {
+    if (!allocator || !dest || !aws_byte_cursor_is_valid(&src) || !src.ptr) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
@@ -415,8 +421,7 @@ int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,
     const uint8_t *lookup_table) {
-    assert(from->ptr);
-    assert(to->buffer);
+    AWS_PRECONDITION(from->ptr);
     AWS_PRECONDITION(aws_byte_buf_is_valid(to));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
     AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
@@ -439,8 +444,7 @@ int aws_byte_buf_append_with_lookup(
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    assert(from->ptr);
-    assert(to->buffer);
+    AWS_PRECONDITION(from->ptr);
     AWS_PRECONDITION(aws_byte_buf_is_valid(to));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

1. Since `aws_byte_cursor` can be empty, i.e., `ptr == NULL` and `len == 0`, this PR updates its invariant to reflect that;
2. Updates preconditions from `aws_byte_buf_init_copy_from_cursor`, `aws_byte_buf_append_dynamic`, and `aws_byte_buf_append_with_lookup`;
3. Adds proof harness for `aws_byte_buf_init_copy_from_cursor`;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
