### PR TITLE
add calloc, and tests for it

### DIFF
--- a/.cbmc-batch/include/proof_helpers/proof_allocators.h
+++ b/.cbmc-batch/include/proof_helpers/proof_allocators.h
@@ -27,6 +27,14 @@
 #define MAX_MALLOC (SIZE_MAX >> (CBMC_OBJECT_BITS + 1))
 
 /**
+ * CBMC model of calloc always succeeds, even if the requested size is larger
+ * than CBMC can internally represent.  This function does a
+ *     __CPROVER_assume(size <= MAX_MALLOC);
+ * before calling calloc, and hence will never return an invalid pointer.
+ */
+void *bounded_calloc(size_t size);
+
+/**
  * CBMC model of malloc always succeeds, even if the requested size is larger
  * than CBMC can internally represent.  This function does a
  *     __CPROVER_assume(size <= MAX_MALLOC);
@@ -39,6 +47,13 @@ void *bounded_malloc(size_t size);
  * as many bugs as possible
  */
 struct aws_allocator *can_fail_allocator();
+
+/**
+ * CBMC model of calloc never returns NULL, which can mask bugs in C programs. Thus function:
+ * 1) Deterministically returns NULL if more memory is requested than CBMC can represent
+ * 2) Nondeterminstically returns either valid memory or NULL otherwise
+ */
+void *can_fail_calloc(size_t num, size_t size);
 
 /**
  * CBMC model of malloc never returns NULL, which can mask bugs in C programs. Thus function:

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -74,8 +74,11 @@ DEFINES += -DCBMC=1
 # Removing the function from the goto program helps CBMC's
 # function pointer analysis.
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body aws_default_allocator
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_allocate
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_preferred_size
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_reallocate
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_calloc
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_free
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_malloc
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -73,13 +73,15 @@ DEFINES += -DCBMC=1
 # We always override allocator functions with our own allocator
 # Removing the function from the goto program helps CBMC's
 # function pointer analysis.
-REMOVE_FUNCTION_BODY += --remove-function-body s_default_malloc
-REMOVE_FUNCTION_BODY += --remove-function-body s_default_free
-REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
-REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
-REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_reallocate
-REMOVE_FUNCTION_BODY += --remove-function-body aws_default_allocator
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body aws_default_allocator
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_reallocate
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_free
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_malloc
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
 ################################################################
+
+REMOVE_FUNCTION_BODY ?= $(DEFAULT_REMOVE_FUNCTION_BODY)
 
 # Here, whenever there is a change in any of ANSI-C source
 # dependency files, make will take action. However, to make

--- a/.cbmc-batch/jobs/aws_hash_table_init-bounded/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_init-bounded/Makefile
@@ -14,12 +14,15 @@
 ###########
 # Sufficient for coverage for bounded inputs
 # Additional coverage is given using the -unbounded version of this proof
-# Runtime aprox 5 min at this size.
-MAX_TABLE_SIZE ?= 4
+# 4 - 1 min
+# 8 - 2 min
+# 12 - 6 min
+MAX_TABLE_SIZE ?= 8
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
 
-#A hash entry is 24 bytes, which is 3 iters. So we need 3 * MAX_TABLE_SIZE + 1
-UNWINDSET += memset_override_0_impl.0:$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 1)))
+#The hash table struct itself is 80 bytes, which is 10 iters 
+#A hash entry is 24 bytes, which is 10 iters. So we need 3 * MAX_TABLE_SIZE + 10 + 1
+UNWINDSET += memset_override_0_impl.0:$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 11)))
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c

--- a/.cbmc-batch/jobs/aws_hash_table_init-bounded/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_init-bounded/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_override_0_impl.0:13;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_override_0_impl.0:35;--object-bits;8"
 goto: aws_hash_table_init_bounded_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -56,7 +56,10 @@ static struct aws_allocator s_can_fail_allocator_static = {
     .mem_acquire = s_can_fail_malloc_allocator,
     .mem_release = s_can_fail_free_allocator,
     .mem_realloc = nondet_bool() ? NULL : s_can_fail_realloc_allocator,
-    .mem_calloc = s_can_fail_calloc_allocator,
+    /* define .mem_calloc once the following issues are fixed in CBMC. Until then, use the fallback.
+     * https://github.com/diffblue/cbmc/issues/4603
+     * https://github.com/diffblue/cbmc/issues/4602
+     */
 };
 
 void *bounded_calloc(size_t num, size_t size) {

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -18,6 +18,7 @@
 
 #include <aws/common/exports.h>
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
@@ -201,6 +202,8 @@ struct aws_allocator {
     void (*mem_release)(struct aws_allocator *allocator, void *ptr);
     /* Optional method; if not supported, this pointer must be NULL */
     void *(*mem_realloc)(struct aws_allocator *allocator, void *oldptr, size_t oldsize, size_t newsize);
+    /* Optional method; if not supported, this pointer must be NULL */
+    void *(*mem_calloc)(struct aws_allocator *allocator, size_t num, size_t size);
     void *impl;
 };
 
@@ -231,11 +234,18 @@ AWS_COMMON_API
 void aws_wrapped_cf_allocator_destroy(CFAllocatorRef allocator);
 #endif
 
-/*
+/**
  * Returns at least `size` of memory ready for usage or returns NULL on failure.
  */
 AWS_COMMON_API
 void *aws_mem_acquire(struct aws_allocator *allocator, size_t size);
+
+/**
+ * Allocates a block of memory for an array of num elements, each of them size bytes long, and initializes all its bits to zero. 
+ * Returns null on failure.
+ */
+AWS_COMMON_API
+void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size);
 
 /**
  * Allocates many chunks of bytes into a single block. Expects to be called with alternating void ** (dest), size_t
@@ -249,7 +259,7 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size);
 AWS_COMMON_API
 void *aws_mem_acquire_many(struct aws_allocator *allocator, size_t count, ...);
 
-/*
+/**
  * Releases ptr back to whatever allocated it.
  */
 AWS_COMMON_API

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -558,10 +558,11 @@ static inline int enable_vt_mode(void) {
         AWS_MUTEX_INIT,                                                                                                \
     };                                                                                                                 \
     static struct aws_allocator name##_allocator = {                                                                   \
-        s_mem_acquire_malloc,                                                                                          \
-        s_mem_release_free,                                                                                            \
-        NULL,                                                                                                          \
-        &name##_alloc_impl,                                                                                            \
+        .mem_acquire = s_mem_acquire_malloc,                                                                           \
+        .mem_release = s_mem_release_free,                                                                             \
+        .mem_realloc = NULL,                                                                                           \
+        .mem_calloc = NULL,                                                                                            \
+        .impl = &name##_alloc_impl,                                                                                    \
     };
 
 #define AWS_TEST_CASE_SUPRESSION(name, fn, s)                                                                          \

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -144,16 +144,14 @@ static struct hash_table_state *s_alloc_state(const struct hash_table_state *tem
         return NULL;
     }
 
-    struct hash_table_state *state = aws_mem_acquire(template->alloc, required_bytes);
+    /* An empty slot has hashcode 0. So this marks all slots as empty */
+    struct hash_table_state *state = aws_mem_calloc(template->alloc, 1, required_bytes);
 
     if (state == NULL) {
         return state;
     }
 
     *state = *template;
-    /* An empty slot has hashcode 0. So this marks all slots as empty */
-    memset(&state->slots[0], 0, state->size * sizeof(state->slots[0]));
-
     return state;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,8 +232,11 @@ add_test_case(test_realloc_passthrough_oom)
 add_test_case(test_cf_allocator_wrapper)
 add_test_case(test_acquire_many)
 
-add_test_case(test_calloc_fallback)
+add_test_case(test_calloc_override)
+add_test_case(test_calloc_fallback_from_default_allocator)
+add_test_case(test_calloc_fallback_from_given)
 add_test_case(test_calloc_from_default_allocator)
+add_test_case(test_calloc_from_given_allocator)
 
 add_test_case(test_lru_cache_overflow_static_members)
 add_test_case(test_lru_cache_lru_ness_static_members)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,6 +232,9 @@ add_test_case(test_realloc_passthrough_oom)
 add_test_case(test_cf_allocator_wrapper)
 add_test_case(test_acquire_many)
 
+add_test_case(test_calloc_fallback)
+add_test_case(test_calloc_from_default_allocator)
+
 add_test_case(test_lru_cache_overflow_static_members)
 add_test_case(test_lru_cache_lru_ness_static_members)
 add_test_case(test_lru_cache_entries_cleanup)

--- a/tests/calloc_test.c
+++ b/tests/calloc_test.c
@@ -16,26 +16,29 @@
 #include <aws/common/common.h>
 #include <aws/common/math.h>
 #include <aws/testing/aws_test_harness.h>
+#include <stdlib.h>
 
-#ifdef __MACH__
-#    include <CoreFoundation/CoreFoundation.h>
-#endif
+static void *s_calloc_stub(struct aws_allocator *allocator, size_t num, size_t size) {
+    allocator->impl = (void *)(num * size);
+    return calloc(num, size);
+}
 
-AWS_TEST_CASE(test_calloc_fallback, s_test_calloc_fallback_fn)
-static int s_test_calloc_fallback_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+static void s_mem_release_stub(struct aws_allocator *allocator, void *ptr) {
+    allocator->impl = 0;
+    free(ptr);
+}
 
-    struct aws_allocator my_alloc = *aws_default_allocator();
-    my_alloc.mem_calloc = NULL;
-
+static int s_test_calloc_on_given_allocator(struct aws_allocator *allocator, bool using_calloc_stub_impl) {
     /* Check that calloc gives 0ed memory */
-    char *p = aws_mem_calloc(&my_alloc, 2, 4);
+    char *p = aws_mem_calloc(allocator, 2, 4);
     ASSERT_NOT_NULL(p);
     for (size_t i = 0; i < 2 * 4; ++i) {
         ASSERT_TRUE(p[i] == 0);
     }
-    aws_mem_release(&my_alloc, p);
+    if (using_calloc_stub_impl) {
+        ASSERT_TRUE((intptr_t)allocator->impl == 8);
+    }
+    aws_mem_release(allocator, p);
     /* Check that calloc handles overflow securely, by returning null
      * Choose values such that [small_val == (small_val)*(large_val)(mod 2**SIZE_BITS)]
      */
@@ -44,33 +47,55 @@ static int s_test_calloc_fallback_fn(struct aws_allocator *allocator, void *ctx)
         size_t small_val = (size_t)1 << small_bits;
         size_t large_val = ((size_t)1 << large_bits) + 1;
         ASSERT_TRUE(small_val * large_val == small_val);
-        ASSERT_NULL(aws_mem_calloc(&my_alloc, small_val, large_val));
+        ASSERT_NULL(aws_mem_calloc(allocator, small_val, large_val));
+        if (using_calloc_stub_impl) {
+            /* Calloc should never even be called if overflow could occur */
+            ASSERT_TRUE((intptr_t)allocator->impl == 0);
+        }
     }
     return 0;
+}
+
+AWS_TEST_CASE(test_calloc_override, s_test_calloc_override_fn)
+static int s_test_calloc_override_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+    struct aws_allocator my_alloc = {
+        .mem_calloc = s_calloc_stub,
+        .mem_release = s_mem_release_stub,
+    };
+    return s_test_calloc_on_given_allocator(&my_alloc, true);
+}
+
+AWS_TEST_CASE(test_calloc_fallback_from_default_allocator, s_test_calloc_fallback_from_default_allocator_fn)
+static int s_test_calloc_fallback_from_default_allocator_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct aws_allocator my_alloc = *aws_default_allocator();
+    my_alloc.mem_calloc = NULL;
+    return s_test_calloc_on_given_allocator(&my_alloc, false);
+}
+
+AWS_TEST_CASE(test_calloc_fallback_from_given, s_test_calloc_fallback_from_given_fn)
+static int s_test_calloc_fallback_from_given_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct aws_allocator my_alloc = *allocator;
+    my_alloc.mem_calloc = NULL;
+    return s_test_calloc_on_given_allocator(&my_alloc, false);
 }
 
 AWS_TEST_CASE(test_calloc_from_default_allocator, s_test_calloc_from_default_allocator_fn)
 static int s_test_calloc_from_default_allocator_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
+    return s_test_calloc_on_given_allocator(aws_default_allocator(), false);
+}
 
-    struct aws_allocator *alloc = aws_default_allocator();
-    /* Check that calloc gives 0ed memory */
-    char *p = aws_mem_calloc(alloc, 2, 4);
-    ASSERT_NOT_NULL(p);
-    for (size_t i = 0; i < 2 * 4; ++i) {
-        ASSERT_TRUE(p[i] == 0);
-    }
-    aws_mem_release(alloc, p);
-    /* Check that calloc handles overflow securely, by returning null
-     * Choose values such that [small_val == (small_val)*(large_val)(mod 2**SIZE_BITS)]
-     */
-    for (size_t small_bits = 1; small_bits < 9; ++small_bits) {
-        size_t large_bits = SIZE_BITS - small_bits;
-        size_t small_val = (size_t)1 << small_bits;
-        size_t large_val = ((size_t)1 << large_bits) + 1;
-        ASSERT_TRUE(small_val * large_val == small_val);
-        ASSERT_NULL(aws_mem_calloc(alloc, small_val, large_val));
-    }
-    return 0;
+AWS_TEST_CASE(test_calloc_from_given_allocator, s_test_calloc_from_given_allocator_fn)
+static int s_test_calloc_from_given_allocator_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    return s_test_calloc_on_given_allocator(allocator, false);
 }

--- a/tests/calloc_test.c
+++ b/tests/calloc_test.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/common.h>
+#include <aws/common/math.h>
+#include <aws/testing/aws_test_harness.h>
+
+#ifdef __MACH__
+#    include <CoreFoundation/CoreFoundation.h>
+#endif
+
+AWS_TEST_CASE(test_calloc_fallback, s_test_calloc_fallback_fn)
+static int s_test_calloc_fallback_fn(struct aws_allocator *allocator, void *ctx) {
+    struct aws_allocator my_alloc = *aws_default_allocator();
+    my_alloc.mem_calloc = NULL;
+
+    /* Check that calloc gives 0ed memory */
+    char *p = aws_mem_calloc(&my_alloc, 2, 4);
+    ASSERT_NOT_NULL(p);
+    for (size_t i = 0; i < 2 * 4; ++i) {
+        ASSERT_TRUE(p[i] == 0);
+    }
+    aws_mem_release(&my_alloc, p);
+    /* Check that calloc handles overflow securely, by returning null
+     * Choose values such that [small_val == (small_val)*(large_val)(mod 2**SIZE_BITS)]
+     */
+    for (size_t small_bits = 1; small_bits < 9; ++small_bits) {
+        size_t large_bits = SIZE_BITS - small_bits;
+        size_t small_val = (size_t)1 << small_bits;
+        size_t large_val = ((size_t)1 << large_bits) + 1;
+        ASSERT_TRUE(small_val * large_val == small_val);
+        ASSERT_NULL(aws_mem_calloc(&my_alloc, small_val, large_val));
+    }
+    return 0;
+}
+
+AWS_TEST_CASE(test_calloc_from_default_allocator, s_test_calloc_from_default_allocator_fn)
+static int s_test_calloc_from_default_allocator_fn(struct aws_allocator *allocator, void *ctx) {
+    struct aws_allocator *alloc = aws_default_allocator();
+    /* Check that calloc gives 0ed memory */
+    char *p = aws_mem_calloc(alloc, 2, 4);
+    ASSERT_NOT_NULL(p);
+    for (size_t i = 0; i < 2 * 4; ++i) {
+        ASSERT_TRUE(p[i] == 0);
+    }
+    aws_mem_release(alloc, p);
+    /* Check that calloc handles overflow securely, by returning null
+     * Choose values such that [small_val == (small_val)*(large_val)(mod 2**SIZE_BITS)]
+     */
+    for (size_t small_bits = 1; small_bits < 9; ++small_bits) {
+        size_t large_bits = SIZE_BITS - small_bits;
+        size_t small_val = (size_t)1 << small_bits;
+        size_t large_val = ((size_t)1 << large_bits) + 1;
+        ASSERT_TRUE(small_val * large_val == small_val);
+        ASSERT_NULL(aws_mem_calloc(alloc, small_val, large_val));
+    }
+    return 0;
+}

--- a/tests/calloc_test.c
+++ b/tests/calloc_test.c
@@ -23,6 +23,9 @@
 
 AWS_TEST_CASE(test_calloc_fallback, s_test_calloc_fallback_fn)
 static int s_test_calloc_fallback_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
     struct aws_allocator my_alloc = *aws_default_allocator();
     my_alloc.mem_calloc = NULL;
 
@@ -48,6 +51,9 @@ static int s_test_calloc_fallback_fn(struct aws_allocator *allocator, void *ctx)
 
 AWS_TEST_CASE(test_calloc_from_default_allocator, s_test_calloc_from_default_allocator_fn)
 static int s_test_calloc_from_default_allocator_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
     struct aws_allocator *alloc = aws_default_allocator();
     /* Check that calloc gives 0ed memory */
     char *p = aws_mem_calloc(alloc, 2, 4);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```calloc``` can be faster than ```malloc``` + ```memset```.  Add optional support for ```calloc``` to the allocator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
