### PR TITLE
 Memory-safety proofs for aws_byte_buf 

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -27,18 +27,15 @@
 
 #include <stdlib.h>
 
-#define MAX_STR_LEN 2
-#define MAX_BUF_LEN 2
-
-#define ASSUME_VALID_MEMORY(ptr) ptr = malloc(sizeof(*(ptr)))
-#define ASSUME_VALID_MEMORY_COUNT(ptr, count) ptr = malloc(sizeof(*(ptr)) * (count))
+#define ASSUME_VALID_MEMORY(ptr) ptr = bounded_malloc(sizeof(*(ptr)))
+#define ASSUME_VALID_MEMORY_COUNT(ptr, count) ptr = bounded_malloc(sizeof(*(ptr)) * (count))
 #define ASSUME_DEFAULT_ALLOCATOR(allocator) allocator = aws_default_allocator()
 #define ASSUME_CAN_FAIL_ALLOCATOR(allocator) allocator = can_fail_allocator()
 
 /*
  * Checks whether aws_byte_buf is bounded by max_size
  */
-bool is_bounded_byte_buf(const struct aws_byte_buf *const buf, const size_t max_size);
+bool aws_byte_buf_is_bounded(const struct aws_byte_buf *const buf, const size_t max_size);
 
 /*
  * Checks whether aws_byte_buf has the correct allocator
@@ -53,7 +50,7 @@ void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf)
 /*
  * Checks whether aws_byte_cursor is bounded by max_size
  */
-bool is_bounded_byte_cursor(const struct aws_byte_cursor *const cursor, const size_t max_size);
+bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, const size_t max_size);
 
 /*
  * Ensures aws_byte_cursor has a proper allocated buffer member

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -40,7 +40,7 @@ bool aws_byte_buf_is_bounded(const struct aws_byte_buf *const buf, const size_t 
 /*
  * Checks whether aws_byte_buf has the correct allocator
  */
-bool is_byte_buf_expected_alloc(const struct aws_byte_buf *const buf);
+bool aws_byte_buf_has_allocator(const struct aws_byte_buf *const buf);
 
 /*
  * Ensures aws_byte_buf has a proper allocated buffer member

--- a/.cbmc-batch/jobs/Makefile.aws_byte_buf
+++ b/.cbmc-batch/jobs/Makefile.aws_byte_buf
@@ -11,23 +11,10 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
-include ../Makefile.aws_byte_buf
+##########
 
-UNWINDSET +=
+# Sufficently long to get full coverage on the aws_byte_buf and aws_byte_cursor APIs
+# short enough that all proofs complete in less than a minute
+MAX_BUFFER_SIZE ?= 10
 
-CBMCFLAGS +=
-
-DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
-DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(HELPERDIR)/source/utils.c
-DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memset_override_no_op.c
-DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
-DEPENDENCIES += $(SRCDIR)/source/common.c
-
-ENTRY = aws_byte_buf_reserve_harness
-###########
-
-include ../Makefile.common
+DEFINES += -DMAX_BUFFER_SIZE=$(MAX_BUFFER_SIZE)

--- a/.cbmc-batch/jobs/aws_byte_buf_append/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_append/Makefile
@@ -12,13 +12,17 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_byte_buf_append/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--function;aws_byte_buf_append_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--unwind;1"
 goto: aws_byte_buf_append_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/Makefile
@@ -12,12 +12,15 @@
 # limitations under the License.
 
 ###########
-CBMC_UNWINDSET =
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
@@ -21,13 +21,27 @@ void aws_byte_buf_append_dynamic_harness() {
     ensure_byte_buf_has_allocated_buffer_member(&to);
     __CPROVER_assume(aws_byte_buf_is_valid(&to));
 
+    /* save current state of the data structure */
+    struct aws_byte_buf to_old = to;
+
     struct aws_byte_cursor from;
     ensure_byte_cursor_has_allocated_buffer_member(&from);
     __CPROVER_assume(aws_byte_cursor_is_valid(&from));
 
-    aws_byte_buf_append_dynamic(&to, &from);
+    /* save current state of the data structure */
+    struct aws_byte_cursor from_old = from;
+
+    if (aws_byte_buf_append_dynamic(&to, &from) == AWS_OP_SUCCESS) {
+        assert(to.len == to_old.len + from.len);
+    } else {
+        /* if the operation return an error, to must not change */
+        assert_bytes_match(to_old.buffer, to.buffer, to.len);
+        assert(to_old.len == to.len);
+    }
 
     assert(aws_byte_buf_is_valid(&to));
-    assert(is_byte_buf_expected_alloc(&to));
     assert(aws_byte_cursor_is_valid(&from));
+    assert(to_old.allocator == to.allocator);
+    assert_bytes_match(from_old.ptr, from.ptr, from.len);
+    assert(from_old.len == from.len);
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
 goto: aws_byte_buf_append_dynamic_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
@@ -18,23 +18,38 @@
 
 void aws_byte_buf_append_with_lookup_harness() {
     struct aws_byte_buf to;
-    __CPROVER_assume(is_bounded_byte_buf(&to, MAX_BUF_SIZE));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&to, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&to);
     __CPROVER_assume(aws_byte_buf_is_valid(&to));
 
+    /* save current state of the data structure */
+    struct aws_byte_buf to_old = to;
+
     struct aws_byte_cursor from;
-    __CPROVER_assume(is_bounded_byte_cursor(&from, MAX_BUF_SIZE));
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&from, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&from);
     __CPROVER_assume(aws_byte_cursor_is_valid(&from));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor from_old = from;
 
     /**
      * The specification for the function requires that the buffer
      * be at least 256 bytes.
      */
     uint8_t *lookup_table[256];
-    aws_byte_buf_append_with_lookup(&to, &from, lookup_table);
+    if (aws_byte_buf_append_with_lookup(&to, &from, lookup_table) == AWS_OP_SUCCESS) {
+        assert(to.len == to_old.len + from.len);
+    } else {
+        /* if the operation return an error, to must not change */
+        assert_bytes_match(to_old.buffer, to.buffer, to.len);
+        assert(to_old.len == to.len);
+    }
 
     assert(aws_byte_buf_is_valid(&to));
-    assert(is_byte_buf_expected_alloc(&to));
     assert(aws_byte_cursor_is_valid(&from));
+    assert(to_old.allocator == to.allocator);
+    assert(to_old.capacity == to.capacity);
+    assert_bytes_match(from_old.ptr, from.ptr, from.len);
+    assert(from_old.len == from.len);
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_byte_buf_append_with_lookup.0:11;--function;aws_byte_buf_append_with_lookup_harness"
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;aws_byte_buf_append_with_lookup.0:11;--unwind;1"
 goto: aws_byte_buf_append_with_lookup_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up/Makefile
@@ -14,7 +14,10 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += memset_impl.0:41
+MAX_BUFFER_SIZE=40
+
+# This bound allows us to reach 100% coverage rate
+UNWINDSET += memset_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up/Makefile
@@ -14,19 +14,18 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += aws_byte_buf_append_with_lookup.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET += memset_impl.0:41
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
-DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 
-ENTRY = aws_byte_buf_append_with_lookup_harness
+ENTRY = aws_byte_buf_clean_up_harness
 ###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up/aws_byte_buf_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up/aws_byte_buf_clean_up_harness.c
@@ -16,23 +16,15 @@
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void aws_byte_buf_reserve_harness() {
+void aws_byte_buf_clean_up_harness() {
     struct aws_byte_buf buf;
+
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 
-    struct aws_byte_buf old = buf;
-    size_t requested_capacity;
-
-    if (aws_byte_buf_reserve(&buf, requested_capacity) == AWS_OP_SUCCESS) {
-        assert(buf.capacity >= requested_capacity);
-        assert(is_byte_buf_expected_alloc(&buf));
-    }
-
-    assert(aws_byte_buf_is_valid(&buf));
-    assert(old.len == buf.len);
-    assert(old.allocator == buf.allocator);
-    if (!buf.buffer) {
-        assert_bytes_match(old.buffer, buf.buffer, buf.len);
-    }
+    aws_byte_buf_clean_up(&buf);
+    assert(buf.allocator == NULL);
+    assert(buf.buffer == NULL);
+    assert(buf.len == 0);
+    assert(buf.capacity == 0);
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_byte_buf_clean_up_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_from_array/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_array/Makefile
@@ -12,9 +12,7 @@
 # limitations under the License.
 
 ###########
-include ../Makefile.aws_byte_buf
-
-UNWINDSET += aws_byte_buf_append_with_lookup.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET +=
 
 CBMCFLAGS +=
 
@@ -22,11 +20,10 @@ DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 
-ENTRY = aws_byte_buf_append_with_lookup_harness
+ENTRY = aws_byte_buf_from_array_harness
 ###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
@@ -29,7 +29,6 @@ void aws_byte_buf_from_array_harness() {
 
     /* assertions */
     assert(aws_byte_buf_is_valid(&buf));
-    size_t debug_len = buf.len;
     assert(buf.len == length);
     assert(buf.capacity == length);
     assert(buf.allocator == NULL);

--- a/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
@@ -15,30 +15,25 @@
 
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
-#include <proof_helpers/proof_allocators.h>
 
-void aws_byte_buf_init_harness() {
-    /* data structure */
-    struct aws_byte_buf *buf;
-
+void aws_byte_buf_from_array_harness() {
     /* parameters */
-    struct aws_allocator *allocator;
-    size_t capacity;
+    size_t length;
+    uint8_t *array;
 
     /* assumptions */
-    ASSUME_VALID_MEMORY(buf);
-    if (nondet_bool()) {
-        ASSUME_CAN_FAIL_ALLOCATOR(allocator);
-    } else {
-        allocator = NULL;
-    }
-    __CPROVER_assume(capacity <= MAX_BUFFER_SIZE);
+    ASSUME_VALID_MEMORY_COUNT(array, length);
 
-    if (!aws_byte_buf_init(buf, allocator, capacity)) {
-        /* assertions */
-        assert(aws_byte_buf_is_valid(buf));
-        assert(buf->allocator == allocator);
-        assert(buf->len == 0);
-        assert(buf->capacity == capacity);
+    /* operation under verification */
+    struct aws_byte_buf buf = aws_byte_buf_from_array(array, length);
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&buf));
+    size_t debug_len = buf.len;
+    assert(buf.len == length);
+    assert(buf.capacity == length);
+    assert(buf.allocator == NULL);
+    if (buf.buffer) {
+        assert_bytes_match(buf.buffer, array, buf.len);
     }
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_from_array/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_array/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
+goto: aws_byte_buf_from_array_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
@@ -1,4 +1,0 @@
-jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;strlen.0:33;--function;aws_byte_buf_from_c_str_harness"
-goto: aws_byte_buf_from_c_str_harness.goto
-expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_from_empty_array/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_empty_array/Makefile
@@ -12,18 +12,18 @@
 # limitations under the License.
 
 ###########
-#NOTE: If we don't use the unwindset, leave it empty
-CBMC_UNWINDSET = --unwindset
-CBMC_UNWINDSET += strlen.0:33
+UNWINDSET +=
 
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 
-ENTRY = aws_byte_buf_from_c_str_harness
+ENTRY = aws_byte_buf_from_empty_array_harness
 ###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_from_empty_array/aws_byte_buf_from_empty_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_empty_array/aws_byte_buf_from_empty_array_harness.c
@@ -15,30 +15,19 @@
 
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
-#include <proof_helpers/proof_allocators.h>
 
-void aws_byte_buf_init_harness() {
-    /* data structure */
-    struct aws_byte_buf *buf;
-
-    /* parameters */
-    struct aws_allocator *allocator;
+void aws_byte_buf_from_empty_array_harness() {
     size_t capacity;
+    void *array;
 
-    /* assumptions */
-    ASSUME_VALID_MEMORY(buf);
-    if (nondet_bool()) {
-        ASSUME_CAN_FAIL_ALLOCATOR(allocator);
-    } else {
-        allocator = NULL;
-    }
-    __CPROVER_assume(capacity <= MAX_BUFFER_SIZE);
+    ASSUME_VALID_MEMORY_COUNT(array, capacity);
 
-    if (!aws_byte_buf_init(buf, allocator, capacity)) {
-        /* assertions */
-        assert(aws_byte_buf_is_valid(buf));
-        assert(buf->allocator == allocator);
-        assert(buf->len == 0);
-        assert(buf->capacity == capacity);
+    struct aws_byte_buf buf = aws_byte_buf_from_empty_array(array, capacity);
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(buf.len == 0);
+    assert(buf.capacity == capacity);
+    assert(buf.allocator == NULL);
+    if (buf.buffer) {
+        assert_bytes_match(buf.buffer, array, capacity);
     }
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_from_empty_array/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_empty_array/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
+goto: aws_byte_buf_from_empty_array_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_init/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_init/Makefile
@@ -12,8 +12,9 @@
 # limitations under the License.
 
 ###########
-#NOTE: If we don't use the unwindset, leave it empty
-#CBMC_UNWINDSET =
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_byte_buf_init/aws_byte_buf_init_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init/aws_byte_buf_init_harness.c
@@ -19,14 +19,13 @@
 
 void aws_byte_buf_init_harness() {
     /* data structure */
-    struct aws_byte_buf *buf;
+    struct aws_byte_buf buf;
 
     /* parameters */
     struct aws_allocator *allocator;
     size_t capacity;
 
     /* assumptions */
-    ASSUME_VALID_MEMORY(buf);
     if (nondet_bool()) {
         ASSUME_CAN_FAIL_ALLOCATOR(allocator);
     } else {
@@ -34,11 +33,11 @@ void aws_byte_buf_init_harness() {
     }
     __CPROVER_assume(capacity <= MAX_BUFFER_SIZE);
 
-    if (!aws_byte_buf_init(buf, allocator, capacity)) {
+    if (!aws_byte_buf_init(&buf, allocator, capacity)) {
         /* assertions */
-        assert(aws_byte_buf_is_valid(buf));
-        assert(buf->allocator == allocator);
-        assert(buf->len == 0);
-        assert(buf->capacity == capacity);
+        assert(aws_byte_buf_is_valid(&buf));
+        assert(buf.allocator == allocator);
+        assert(buf.len == 0);
+        assert(buf.capacity == capacity);
     }
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
 goto: aws_byte_buf_init_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
@@ -41,7 +41,7 @@ void aws_byte_buf_init_copy_harness() {
     if (!aws_byte_buf_init_copy(dest, allocator, &src)) {
         /* assertions */
         assert(aws_byte_buf_is_valid(dest));
-        assert(is_byte_buf_expected_alloc(dest));
+        assert(aws_byte_buf_has_allocator(dest));
         assert(dest->len == src.len);
         assert(dest->capacity == src.capacity);
         assert_bytes_match(dest->buffer, src.buffer, dest->len);

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy/aws_byte_buf_init_copy_harness.c
@@ -26,7 +26,7 @@ void aws_byte_buf_init_copy_harness() {
     struct aws_byte_buf src;
 
     /* assumptions */
-    __CPROVER_assume(is_bounded_byte_buf(&src, MAX_BUFFER_SIZE));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&src, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&src);
     __CPROVER_assume(aws_byte_buf_is_valid(&src));
     ASSUME_VALID_MEMORY(dest);

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/Makefile
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 ###########
-MAX_BUFFER_SIZE ?= 10
-DEFINES += -DMAX_BUFFER_SIZE=$(MAX_BUFFER_SIZE)
+include ../Makefile.aws_byte_buf
 
 UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
 

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/aws_byte_buf_init_copy_from_cursor_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/aws_byte_buf_init_copy_from_cursor_harness.c
@@ -19,27 +19,28 @@
 
 void aws_byte_buf_init_copy_from_cursor_harness() {
     /* data structure */
-    struct aws_byte_buf *buf;
+    struct aws_byte_buf buf;
 
     /* parameters */
     struct aws_allocator *allocator;
     struct aws_byte_cursor cursor;
 
     /* assumptions */
-    __CPROVER_assume(is_bounded_byte_cursor(&cursor, MAX_BUFFER_SIZE));
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cursor, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&cursor);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cursor));
-    ASSUME_VALID_MEMORY(buf);
+
     ASSUME_CAN_FAIL_ALLOCATOR(allocator);
 
-    if (!aws_byte_buf_init_copy_from_cursor(buf, allocator, cursor)) {
+    if (aws_byte_buf_init_copy_from_cursor(&buf, allocator, cursor) == AWS_OP_SUCCESS) {
         /* assertions */
-        assert(aws_byte_buf_is_valid(buf));
-        assert(buf->len == cursor.len);
-        assert(buf->capacity == cursor.len);
-        assert(buf->allocator == allocator);
-        assert_bytes_match(buf->buffer, cursor.ptr, buf->len);
+        assert(aws_byte_buf_is_valid(&buf));
+        assert(aws_byte_cursor_is_valid(&cursor));
+        assert(buf.len == cursor.len);
+        assert(buf.capacity == cursor.len);
+        assert(buf.allocator == allocator);
+        if (buf.buffer) {
+            assert_bytes_match(buf.buffer, cursor.ptr, buf.len);
+        }
     }
-    /* assertions */
-    assert(aws_byte_cursor_is_valid(&cursor));
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
@@ -26,7 +26,7 @@ void aws_byte_buf_reserve_harness() {
 
     if (aws_byte_buf_reserve(&buf, requested_capacity) == AWS_OP_SUCCESS) {
         assert(buf.capacity >= requested_capacity);
-        assert(is_byte_buf_expected_alloc(&buf));
+        assert(aws_byte_buf_has_allocator(&buf));
     }
 
     assert(aws_byte_buf_is_valid(&buf));

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
 goto: aws_byte_buf_reserve_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
@@ -27,7 +27,7 @@ void aws_byte_buf_reserve_relative_harness() {
 
     if (rval == AWS_OP_SUCCESS) {
         assert(buf.capacity >= (old.len + requested_capacity));
+        assert(is_byte_buf_expected_alloc(&buf));
     }
     assert(aws_byte_buf_is_valid(&buf));
-    assert(is_byte_buf_expected_alloc(&buf));
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
@@ -27,7 +27,7 @@ void aws_byte_buf_reserve_relative_harness() {
 
     if (rval == AWS_OP_SUCCESS) {
         assert(buf.capacity >= (old.len + requested_capacity));
-        assert(is_byte_buf_expected_alloc(&buf));
+        assert(aws_byte_buf_has_allocator(&buf));
     }
     assert(aws_byte_buf_is_valid(&buf));
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_secure_zero/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_secure_zero/Makefile
@@ -14,7 +14,10 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += memset_impl.0:41
+MAX_BUFFER_SIZE=40
+
+# This bound allows us to reach 100% coverage rate
+UNWINDSET += memset_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_byte_buf_secure_zero/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_secure_zero/Makefile
@@ -14,7 +14,7 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += aws_byte_buf_append_with_lookup.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET += memset_impl.0:41
 
 CBMCFLAGS +=
 
@@ -22,11 +22,11 @@ DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 
-ENTRY = aws_byte_buf_append_with_lookup_harness
+ENTRY = aws_byte_buf_secure_zero_harness
 ###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_secure_zero/aws_byte_buf_secure_zero_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_secure_zero/aws_byte_buf_secure_zero_harness.c
@@ -16,19 +16,17 @@
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void aws_byte_buf_from_c_str_harness() {
-    size_t len = nondet_size_t();
+void aws_byte_buf_secure_zero_harness() {
+    struct aws_byte_buf buf;
 
-    char *c_str;
-    ASSUME_VALID_MEMORY_COUNT(c_str, len);
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 
-    /* Need *c_str to be a '\0'-terminated C string, so assume an arbitrary character is 0 */
-    int index = nondet_int();
-    __CPROVER_assume(index >= 0 && index < len);
-    c_str[index] = 0;
+    /* operation under verification */
+    aws_byte_buf_secure_zero(&buf);
 
-    /* Assume the length of the string is bounded by some max length */
-    __CPROVER_assume(len <= MAX_STR_LEN);
-
-    aws_byte_buf_from_c_str(c_str);
+    assert(aws_byte_buf_is_valid(&buf));
+    assert_all_zeroes(buf.buffer, buf.capacity);
+    assert(buf.len == 0);
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_secure_zero/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_secure_zero/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_byte_buf_secure_zero_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -24,7 +24,7 @@ bool aws_byte_buf_is_bounded(const struct aws_byte_buf *const buf, const size_t 
     return (buf->capacity <= max_size);
 }
 
-bool is_byte_buf_expected_alloc(const struct aws_byte_buf *const buf) {
+bool aws_byte_buf_has_allocator(const struct aws_byte_buf *const buf) {
     return (buf->allocator == can_fail_allocator());
 }
 

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -20,8 +20,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-bool is_bounded_byte_buf(const struct aws_byte_buf *const buf, const size_t max_size) {
-    return buf->capacity <= max_size;
+bool aws_byte_buf_is_bounded(const struct aws_byte_buf *const buf, const size_t max_size) {
+    return (buf->capacity <= max_size);
 }
 
 bool is_byte_buf_expected_alloc(const struct aws_byte_buf *const buf) {
@@ -29,11 +29,11 @@ bool is_byte_buf_expected_alloc(const struct aws_byte_buf *const buf) {
 }
 
 void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf) {
-    buf->allocator = can_fail_allocator();
+    buf->allocator = (nondet_bool()) ? NULL : can_fail_allocator();
     buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * buf->capacity);
 }
 
-bool is_bounded_byte_cursor(const struct aws_byte_cursor *const cursor, const size_t max_size) {
+bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, const size_t max_size) {
     return cursor->len <= max_size;
 }
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -317,7 +317,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 /**
  * Copies from to to while converting bytes via the passed in lookup table.
  * If to is too small, AWS_ERROR_DEST_COPY_TOO_SMALL will be
- * returned. dest->len will contain the amount of data actually copied to dest.
+ * returned. to->len will contain its original size plus the amount of data actually copied to to.
  *
  * from and to should not be the same buffer (overlap is not handled)
  * lookup_table must be at least 256 bytes
@@ -458,20 +458,24 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
 }
 
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len) {
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len));
     struct aws_byte_buf buf;
-    buf.buffer = (uint8_t *)bytes;
+    buf.buffer = (len > 0) ? (uint8_t *)bytes : NULL;
     buf.len = len;
     buf.capacity = len;
     buf.allocator = NULL;
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;
 }
 
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity) {
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, capacity));
     struct aws_byte_buf buf;
-    buf.buffer = (uint8_t *)bytes;
+    buf.buffer = (capacity > 0) ? (uint8_t *)bytes : NULL;
     buf.len = 0;
     buf.capacity = capacity;
     buf.allocator = NULL;
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;
 }
 

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -89,8 +89,8 @@ int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length) {
 }
 
 int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
-    assert(to_encode->ptr);
-    assert(output->buffer);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
 
     size_t encoded_len = 0;
 
@@ -175,8 +175,8 @@ int aws_hex_compute_decoded_len(size_t to_decode_len, size_t *decoded_len) {
 }
 
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
-    assert(to_decode->ptr);
-    assert(output->buffer);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
 
     size_t decoded_length = 0;
 

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -220,9 +220,10 @@ AWS_TEST_CASE(test_buffer_init_copy_null_buffer, s_test_buffer_init_copy_null_bu
 static int s_test_buffer_init_copy_null_buffer_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    struct aws_byte_buf src = {0};
+    struct aws_byte_buf src;
+    AWS_ZERO_STRUCT(src);
     struct aws_byte_buf dest;
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_buf_init_copy(&dest, allocator, &src));
+    ASSERT_SUCCESS(aws_byte_buf_init_copy(&dest, allocator, &src));
 
     return 0;
 }

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -71,7 +71,11 @@ static int s_run_hex_encoding_test_case(
     ASSERT_INT_EQUALS(test_str_size - 1, output_size, "Output size on string should be %d", test_str_size - 1);
 
     output.capacity = output_size;
+    if (output.capacity == 0) {
+        output.buffer = NULL;
+    }
     output.len = 0;
+
     struct aws_byte_cursor expected_buf = aws_byte_cursor_from_array(expected, expected_size - 1);
     ASSERT_SUCCESS(aws_hex_decode(&expected_buf, &output), "decode call should have succeeded");
 
@@ -304,6 +308,7 @@ static int s_run_base64_encoding_test_case(
     ASSERT_INT_EQUALS(expected_size, output_size, "Output size on string should be %d", expected_size);
 
     struct aws_byte_cursor to_encode = aws_byte_cursor_from_array(test_str, test_str_size);
+
     struct aws_byte_buf allocation;
     ASSERT_SUCCESS(aws_byte_buf_init(&allocation, allocator, output_size + 2));
     memset(allocation.buffer, 0xdd, allocation.capacity);
@@ -333,7 +338,6 @@ static int s_run_base64_encoding_test_case(
     aws_byte_buf_clean_up(&allocation);
 
     /* Part 2: decoding */
-
     struct aws_byte_cursor expected_cur = aws_byte_cursor_from_array(expected, expected_size - 1);
     ASSERT_SUCCESS(
         aws_base64_compute_decoded_len(&expected_cur, &output_size),


### PR DESCRIPTION
*Description of changes:*

Adds preconditions, postconditions and proof harnesses for the following functions:
 - aws_byte_buf_append
 - aws_byte_buf_append_dynamic
 - aws_byte_buf_append_with_lookup
 - aws_byte_buf_clean_up
 - aws_byte_buf_from_array
 - aws_byte_buf_from_empty_array
 - aws_byte_buf_init
 - aws_byte_buf_init_copy_from_cursor
 - aws_byte_buf_reserve
 - aws_byte_buf_secure_zero

Updates the implementation of the following functions to correctly handle empty `aws_byte_buf` structures:
 - aws_byte_buf_from_array
 - aws_byte_buf_from_empty_array
 - aws_byte_buf_init
 - aws_byte_buf_init_copy
 - aws_byte_buf_is_valid
 - aws_byte_cursor_is_valid
 - aws_byte_buf_init_copy_from_cursor
 - aws_byte_buf_append_dynamic
 - aws_byte_buf_reserve
 - aws_byte_buf_reserve_relative
 - aws_hex_encode
 - aws_hex_decode

Updates the following test cases:
 - test_buffer_init_copy_null_buffer
 - s_run_hex_encoding_test_case

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
