### PR TITLE
CBMC proof for hash_table_swap()

### DIFF
--- a/.cbmc-batch/jobs/aws_hash_table_swap/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_swap/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_table_swap_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_table_swap/aws_hash_table_swap_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_swap/aws_hash_table_swap_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/math.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_hash_table_swap_harness() {
+    struct aws_hash_table a;
+    struct aws_hash_table b;
+    bool inita;
+    bool initb;
+    struct store_byte_from_buffer stored_byte_a;
+    struct store_byte_from_buffer stored_byte_b;
+
+    // There are no loops in the code under test, so use the biggest possible value
+    if (inita) {
+        ensure_allocated_hash_table(&a, SIZE_MAX);
+        __CPROVER_assume(aws_hash_table_is_valid(&a));
+        save_byte_from_hash_table(&a, &stored_byte_a);
+    }
+
+    if (initb) {
+        ensure_allocated_hash_table(&b, SIZE_MAX);
+        __CPROVER_assume(aws_hash_table_is_valid(&b));
+        save_byte_from_hash_table(&b, &stored_byte_b);
+    }
+    aws_hash_table_swap(&a, &b);
+
+    if (inita) {
+        assert(aws_hash_table_is_valid(&b));
+        check_hash_table_unchanged(&b, &stored_byte_a);
+    }
+    if (initb) {
+        assert(aws_hash_table_is_valid(&a));
+        check_hash_table_unchanged(&a, &stored_byte_b);
+    }
+}

--- a/.cbmc-batch/jobs/aws_hash_table_swap/aws_hash_table_swap_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_swap/aws_hash_table_swap_harness.c
@@ -28,7 +28,7 @@ void aws_hash_table_swap_harness() {
     struct store_byte_from_buffer stored_byte_a;
     struct store_byte_from_buffer stored_byte_b;
 
-    // There are no loops in the code under test, so use the biggest possible value
+    /* There are no loops in the code under test, so use the biggest possible value */
     if (inita) {
         ensure_allocated_hash_table(&a, SIZE_MAX);
         __CPROVER_assume(aws_hash_table_is_valid(&a));

--- a/.cbmc-batch/jobs/aws_hash_table_swap/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_swap/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_hash_table_swap_harness.goto
+expected: "SUCCESSFUL"

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -231,6 +231,7 @@ void aws_hash_table_clean_up(struct aws_hash_table *map) {
 }
 
 void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_table *AWS_RESTRICT b) {
+    AWS_PRECONDITION(a != b);
     struct aws_hash_table tmp = *a;
     *a = *b;
     *b = tmp;


### PR DESCRIPTION
*Description of changes:*
CBMC proof for ```hash_table_swap()```.  

Due to the fact that either input to swap can be invalid, it's hard to come up with any good post-conditions for this function.  It might be possible to track some using ghost state, but that would put unnecessary overhead on the function itself.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
