### PR TITLE
Proof for aws_hash_table_get_entry_count

### DIFF
--- a/.cbmc-batch/jobs/aws_hash_table_get_entry_count/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_get_entry_count/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_table_get_entry_count_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_table_get_entry_count/aws_hash_table_get_entry_count_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_get_entry_count/aws_hash_table_get_entry_count_harness.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/math.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_hash_table_get_entry_count_harness() {
+    struct aws_hash_table table;
+    // There are no loops in the code under test, so use the biggest possible value
+    ensure_allocated_hash_table(&table, SIZE_MAX);
+    __CPROVER_assume(aws_hash_table_is_valid(&table));
+
+    struct store_byte_from_buffer stored_byte;
+    save_byte_from_hash_table(&table, &stored_byte);
+
+    aws_hash_table_get_entry_count(&table);
+
+    // Ensure that the table remains valid
+    assert(aws_hash_table_is_valid(&table));
+
+    // Ensure that table is unchanged
+    check_hash_table_unchanged(&table, &stored_byte);
+}

--- a/.cbmc-batch/jobs/aws_hash_table_get_entry_count/aws_hash_table_get_entry_count_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_get_entry_count/aws_hash_table_get_entry_count_harness.c
@@ -22,18 +22,19 @@
 
 void aws_hash_table_get_entry_count_harness() {
     struct aws_hash_table table;
-    // There are no loops in the code under test, so use the biggest possible value
+    /* There are no loops in the code under test, so use the biggest possible value */
     ensure_allocated_hash_table(&table, SIZE_MAX);
     __CPROVER_assume(aws_hash_table_is_valid(&table));
+    struct hash_table_state *state = table.p_impl;
 
     struct store_byte_from_buffer stored_byte;
     save_byte_from_hash_table(&table, &stored_byte);
-
-    aws_hash_table_get_entry_count(&table);
-
-    // Ensure that the table remains valid
+    size_t old_entry_count = state->entry_count;
+    size_t rval = aws_hash_table_get_entry_count(&table);
+    assert(rval == old_entry_count);
+    /* Ensure that the table remains valid */
     assert(aws_hash_table_is_valid(&table));
 
-    // Ensure that table is unchanged
+    /* Ensure that table is unchanged */
     check_hash_table_unchanged(&table, &stored_byte);
 }

--- a/.cbmc-batch/jobs/aws_hash_table_get_entry_count/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_get_entry_count/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_hash_table_get_entry_count_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -70,7 +70,7 @@ bool hash_table_state_is_valid(const struct hash_table_state *map) {
     bool alloc_nonnull = (map->alloc != NULL);
     bool size_at_least_two = (map->size >= 2);
     bool size_is_power_of_two = aws_is_power_of_two(map->size);
-    bool entry_count = (map->entry_count < map->max_load);
+    bool entry_count = (map->entry_count <= map->max_load);
     bool max_load = (map->max_load < map->size);
     bool mask_is_correct = (map->mask == (map->size - 1));
     bool max_load_factor_bounded = (map->max_load_factor < 1.0);


### PR DESCRIPTION
1. Add proof for ```aws_hash_table_get_entry_count()```
1. update hash table invariants to handle entry-count correctly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
