### PR TITLE
WIP: Allow precondition checks to return an error instead of asserting

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
@@ -37,7 +37,7 @@ void aws_array_list_copy_harness() {
     if (aws_array_list_copy(&from, &to) == AWS_OP_SUCCESS) {
         /* In the case aws_array_list_copy is successful, both lists have the same length */
         assert(to.length == from.length);
-	assert(from.item_size == to.item_size);
+        assert(from.item_size == to.item_size);
         assert(to.current_size >= (from.length * from.item_size));
     }
 

--- a/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_copy/aws_array_list_copy_harness.c
@@ -34,14 +34,14 @@ void aws_array_list_copy_harness() {
     __CPROVER_assume(aws_array_list_is_valid(&to));
 
     /* perform operation under verification */
-    if (!aws_array_list_copy(&from, &to)) {
+    if (aws_array_list_copy(&from, &to) == AWS_OP_SUCCESS) {
         /* In the case aws_array_list_copy is successful, both lists have the same length */
         assert(to.length == from.length);
+	assert(from.item_size == to.item_size);
         assert(to.current_size >= (from.length * from.item_size));
     }
 
     /* assertions */
     assert(aws_array_list_is_valid(&from));
     assert(aws_array_list_is_valid(&to));
-    assert(from.item_size == to.item_size);
 }

--- a/.cbmc-batch/jobs/aws_array_list_copy/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_copy/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_array_list_copy_harness.goto
 expected: "SUCCESSFUL"

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -26,9 +26,7 @@ int aws_array_list_init_dynamic(
     struct aws_allocator *alloc,
     size_t initial_item_allocation,
     size_t item_size) {
-    if (item_size == 0) {
-        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
-    }
+    AWS_PRECONDITION_ERROR(item_size != 0);
 
     list->alloc = alloc;
     size_t allocation_size;
@@ -91,7 +89,7 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
     if (list->alloc && list->data) {
         aws_mem_release(list->alloc, list->data);
     }
@@ -106,7 +104,7 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
@@ -120,7 +118,7 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
 
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -133,7 +131,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -146,7 +144,7 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t n) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
     if (n >= aws_array_list_length(list)) {
         aws_array_list_clear(list);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -168,7 +166,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
 
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -183,7 +181,7 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
 
         AWS_FATAL_ASSERT(list->data);
@@ -202,7 +200,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
     if (list->data) {
 #ifdef DEBUG_BUILD
         memset(list->data, AWS_ARRAY_LIST_DEBUG_FILL, list->current_size);
@@ -220,8 +218,8 @@ void aws_array_list_swap_contents(
     AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
     AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
     AWS_FATAL_ASSERT(list_a != list_b);
-    AWS_PRECONDITION(aws_array_list_is_valid(list_a));
-    AWS_PRECONDITION(aws_array_list_is_valid(list_b));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list_a));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list_b));
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
@@ -233,7 +231,7 @@ void aws_array_list_swap_contents(
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
     size_t capacity = list->current_size / list->item_size;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return capacity;
@@ -246,7 +244,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * list.
      */
     AWS_FATAL_ASSERT(!list->length || list->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
     size_t len = list->length;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return len;
@@ -254,7 +252,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -266,7 +264,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -278,7 +276,7 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
 
 AWS_STATIC_IMPL
 int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list, size_t index, size_t *necessary_size) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -295,7 +293,7 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -330,7 +328,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
 
 AWS_STATIC_IMPL
 void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
     if (list->data) {
         qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -51,19 +51,30 @@
 otherwise they are checked
 */
 #ifdef CBMC
-#define AWS_PRECONDITION(cond) __CPROVER_assume(cond)
+#define AWS_PRECONDITION_ERROR(cond)                                                                                   \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);                                                        \
+        }                                                                                                              \
+    } while (0)
+#define AWS_PRECONDITION_ASSERT(cond) __CPROVER_assume(cond)
 #define AWS_POSTCONDITION(cond) assert(cond)
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else
-#define AWS_PRECONDITION(cond) assert(cond)
+#define AWS_PRECONDITION_ERROR(cond)                                                                                   \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);                                                        \
+        }                                                                                                              \
+    } while (0)
+#define AWS_PRECONDITION_ASSERT(cond) assert(cond)
 #define AWS_POSTCONDITION(cond) assert(cond)
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */
 #define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
 #define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 #endif
-
 
 
 #ifndef NO_STDBOOL

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -43,37 +43,30 @@
                                }                                                                                \
 
 /**
-* Define function contracts.
-* When the code is being verified using CBMC these contracts are formally verified;
-* When the code is built in debug mode, they are checked as much as possible using assertions
-* When the code is built in production mode, they are not checked.
-* Violations of the function contracts are undefined behaviour.
-otherwise they are checked
+ * Define function contracts.
+ * When the code is being verified using CBMC these contracts are formally verified;
+ * When the code is built in debug mode, they are checked as much as possible using assertions
+ * When the code is built in production mode, they are not checked.
+ * Violations of the function contracts are undefined behaviour.
+ otherwise they are checked
 */
-#ifdef CBMC
-#define AWS_PRECONDITION_ERROR(cond)                                                                                   \
-    do {                                                                                                               \
-        if (!(cond)) {                                                                                                 \
-            return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);                                                        \
-        }                                                                                                              \
-    } while (0)
-#define AWS_PRECONDITION_ASSERT(cond) __CPROVER_assume(cond)
-#define AWS_POSTCONDITION(cond) assert(cond)
-#define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
-#define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
-#else
-#define AWS_PRECONDITION_ERROR(cond)                                                                                   \
-    do {                                                                                                               \
-        if (!(cond)) {                                                                                                 \
-            return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);                                                        \
-        }                                                                                                              \
-    } while (0)
+#define AWS_PRECONDITION_SPECIFIED_ERROR(cond, err)	\
+  do {							\
+    if (!(cond)) {					\
+      return aws_raise_error(err);			\
+    }							\
+  } while (0)
+#define AWS_PRECONDITION_ERROR(cond) AWS_PRECONDITION_SPECIFIED_ERROR(cond, AWS_ERROR_INVALID_ARGUMENT)
 #define AWS_PRECONDITION_ASSERT(cond) assert(cond)
 #define AWS_POSTCONDITION(cond) assert(cond)
-/* the C runtime does not give a way to check these properties,
- * but we can at least check that the pointer is valid */
-#define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
-#define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
+
+#ifdef CBMC
+#    define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
+#    define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
+#else
+/* the C runtime does not give a way to check these properties, but we can at least check that the pointer is valid */
+#    define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
+#    define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 #endif
 
 

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -19,7 +19,7 @@
 #include <stdlib.h> /* qsort */
 
 int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
@@ -52,10 +52,10 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 }
 
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
-    AWS_FATAL_ASSERT(from->item_size == to->item_size);
-    AWS_FATAL_ASSERT(from->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(from));
-    AWS_PRECONDITION(aws_array_list_is_valid(to));
+    AWS_PRECONDITION_ERROR(from->item_size == to->item_size);
+    AWS_PRECONDITION_ERROR(from->data);
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(from));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(to));
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -100,7 +100,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 }
 
 int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ERROR(aws_array_list_is_valid(list));
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -186,7 +186,7 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION_ASSERT(aws_array_list_is_valid(list));
 
     if (a == b) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -36,9 +36,9 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
 }
 
 int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allocator, const struct aws_byte_buf *src) {
-    if (!allocator || !dest || !aws_byte_buf_is_valid(src)) {
-        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
-    }
+    AWS_PRECONDITION_ERROR(allocator);
+    AWS_PRECONDITION_ERROR(dest);
+    AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(src));
 
     *dest = *src;
     dest->allocator = allocator;
@@ -421,10 +421,10 @@ int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,
     const uint8_t *lookup_table) {
-    AWS_PRECONDITION(from->ptr);
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
-    AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
+    AWS_PRECONDITION_ERROR(from->ptr);
+    AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION_ERROR(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION_ERROR(AWS_MEM_IS_READABLE(lookup_table, 256));
 
     if (to->capacity - to->len < from->len) {
         return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
@@ -444,9 +444,9 @@ int aws_byte_buf_append_with_lookup(
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(from->ptr);
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION_ERROR(from->ptr);
+    AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION_ERROR(aws_byte_cursor_is_valid(from));
 
     if (to->capacity - to->len < from->len) {
         /*
@@ -524,7 +524,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 }
 
 int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
+    AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(buffer));
     if (requested_capacity <= buffer->capacity) {
         return AWS_OP_SUCCESS;
     }
@@ -540,7 +540,7 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
 }
 
 int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional_length) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
+    AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(buffer));
 
     size_t requested_capacity = 0;
     if (AWS_UNLIKELY(aws_add_size_checked(buffer->len, additional_length, &requested_capacity))) {

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -118,9 +118,9 @@ int aws_byte_buf_init_copy_from_cursor(
     struct aws_byte_buf *dest,
     struct aws_allocator *allocator,
     struct aws_byte_cursor src) {
-    if (!allocator || !dest || !aws_byte_cursor_is_valid(&src) || !src.ptr) {
-        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
-    }
+    AWS_PRECONDITION_ERROR(allocator);
+    AWS_PRECONDITION_ERROR(dest);
+    AWS_PRECONDITION_ERROR(aws_byte_cursor_is_valid(&src));
 
     AWS_ZERO_STRUCT(*dest);
 
@@ -405,12 +405,9 @@ bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *cursor, 
 }
 
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    assert(from->ptr);
-    assert(to->buffer);
-
-    if (to->capacity - to->len < from->len) {
-        return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
-    }
+    AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION_ERROR(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION_SPECIFIED_ERROR(to->capacity - to->len >= from->len, AWS_ERROR_DEST_COPY_TOO_SMALL);
 
     memcpy(to->buffer + to->len, from->ptr, from->len);
     to->len += from->len;
@@ -425,10 +422,7 @@ int aws_byte_buf_append_with_lookup(
     AWS_PRECONDITION_ERROR(aws_byte_buf_is_valid(to));
     AWS_PRECONDITION_ERROR(aws_byte_cursor_is_valid(from));
     AWS_PRECONDITION_ERROR(AWS_MEM_IS_READABLE(lookup_table, 256));
-
-    if (to->capacity - to->len < from->len) {
-        return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
-    }
+    AWS_PRECONDITION_SPECIFIED_ERROR(to->capacity - to->len >= from->len, AWS_ERROR_DEST_COPY_TOO_SMALL);
 
     for (size_t i = 0; i < from->len; ++i) {
         to->buffer[to->len + i] = lookup_table[from->ptr[i]];

--- a/source/common.c
+++ b/source/common.c
@@ -74,7 +74,7 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
 }
 
 void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
-    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION_ASSERT(allocator);
 
     /* Defensive check: never use calloc with size * num that would overflow
      * https://wiki.sei.cmu.edu/confluence/display/c/MEM07-C.+Ensure+that+the+arguments+to+calloc%28%29%2C+when+multiplied%2C+do+not+wrap

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -191,7 +191,7 @@ int aws_hash_table_init(
     aws_hash_callback_eq_fn *equals_fn,
     aws_hash_callback_destroy_fn *destroy_key_fn,
     aws_hash_callback_destroy_fn *destroy_value_fn) {
-    AWS_PRECONDITION(map && alloc && hash_fn && equals_fn);
+    AWS_PRECONDITION_ERROR(map && alloc && hash_fn && equals_fn);
 
     struct hash_table_state template;
     template.hash_fn = hash_fn;
@@ -237,7 +237,7 @@ void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_
 }
 
 void aws_hash_table_move(struct aws_hash_table *AWS_RESTRICT to, struct aws_hash_table *AWS_RESTRICT from) {
-    AWS_PRECONDITION(to != NULL && from != NULL && to != from && aws_hash_table_is_valid(from));
+    AWS_PRECONDITION_ASSERT(to != NULL && from != NULL && to != from && aws_hash_table_is_valid(from));
     *to = *from;
     AWS_ZERO_STRUCT(*from);
     AWS_POSTCONDITION(aws_hash_table_is_valid(to));

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -794,8 +794,8 @@ uint64_t aws_hash_ptr(const void *item) {
 }
 
 bool aws_hash_callback_c_str_eq(const void *a, const void *b) {
-    AWS_PRECONDITION(aws_c_string_is_valid(a));
-    AWS_PRECONDITION(aws_c_string_is_valid(b));
+    AWS_PRECONDITION_ASSERT(aws_c_string_is_valid(a));
+    AWS_PRECONDITION_ASSERT(aws_c_string_is_valid(b));
     bool rval = !strcmp(a, b);
     AWS_POSTCONDITION(aws_c_string_is_valid(a));
     AWS_POSTCONDITION(aws_c_string_is_valid(b));
@@ -803,8 +803,8 @@ bool aws_hash_callback_c_str_eq(const void *a, const void *b) {
 }
 
 bool aws_hash_callback_string_eq(const void *a, const void *b) {
-    AWS_PRECONDITION(aws_string_is_valid(a));
-    AWS_PRECONDITION(aws_string_is_valid(b));
+    AWS_PRECONDITION_ASSERT(aws_string_is_valid(a));
+    AWS_PRECONDITION_ASSERT(aws_string_is_valid(b));
     bool rval = aws_string_eq(a, b);
     AWS_POSTCONDITION(aws_string_is_valid(a));
     AWS_POSTCONDITION(aws_string_is_valid(b));
@@ -812,7 +812,7 @@ bool aws_hash_callback_string_eq(const void *a, const void *b) {
 }
 
 void aws_hash_callback_string_destroy(void *a) {
-    AWS_PRECONDITION(aws_string_is_valid(a));
+    AWS_PRECONDITION_ASSERT(aws_string_is_valid(a));
     aws_string_destroy(a);
 }
 


### PR DESCRIPTION
Functions which return error codes can simply return ```AWS_ERROR_INVALID_ARGUMENT``` instead of asserting.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
