### PR TITLE
Proofs for hash_table_iterator functions

### DIFF
--- a/.cbmc-batch/README.md
+++ b/.cbmc-batch/README.md
@@ -31,7 +31,7 @@ You can start the CBMC Batch jobs locally by running
 
 You can then check CBMC Batch results locally by running
 
-    bash cbmc-batch.sh --end
+	bash cbmc-batch.sh --end
 
 This will run until all the jobs have finished and output results in `results.txt`.
 

--- a/.cbmc-batch/README.md
+++ b/.cbmc-batch/README.md
@@ -31,7 +31,7 @@ You can start the CBMC Batch jobs locally by running
 
 You can then check CBMC Batch results locally by running
 
-	bash cbmc-batch.sh --end
+    bash cbmc-batch.sh --end
 
 This will run until all the jobs have finished and output results in `results.txt`.
 

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -133,3 +133,19 @@ void ensure_allocated_hash_table(struct aws_hash_table *map, size_t max_table_en
  * Makes a valid c string, with as much nondet as possible, len < max
  */
 const char *make_arbitrary_c_str(size_t max_size);
+
+/**
+ * A correct hash table has max_load < size.  This means that there is always one slot empty.
+ * This function is useful for assuming that there is some (nondet) slot which is empty
+ * which is necessary to prove termination for hash-table deletion code.  Should only be used inside
+ * an assume because of the way it does nondet.
+ */
+bool aws_hash_table_has_an_empty_slot(struct aws_hash_table *map, size_t *rval);
+
+/**
+ * A correct implementation of the hash_destroy function should never have a memory
+ * error on valid input. There is the question of whether the destroy functions themselves
+ * are correctly called (i.e. only on valid input, no double free, etc.).  Testing this would
+ * require a stronger function here.
+ */
+void hash_proof_destroy_noop(void *p);

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -140,7 +140,7 @@ const char *make_arbitrary_c_str(size_t max_size);
  * which is necessary to prove termination for hash-table deletion code.  Should only be used inside
  * an assume because of the way it does nondet.
  */
-bool aws_hash_table_has_an_empty_slot(struct aws_hash_table *map, size_t *rval);
+bool aws_hash_table_has_an_empty_slot(const struct aws_hash_table *const map, size_t *rval);
 
 /**
  * A correct implementation of the hash_destroy function should never have a memory

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define IMPLIES(a, b) (!(a) || (b))
+
 struct store_byte_from_buffer {
     size_t index;
     uint8_t byte;

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -75,6 +75,7 @@ DEFINES += -DCBMC=1
 # function pointer analysis.
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body aws_default_allocator
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_allocate
+DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_copy_description
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_preferred_size
 DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_reallocate

--- a/.cbmc-batch/jobs/aws_hash_iter_begin/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_begin/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#16: 6 seconds
+#32: 10s
+#128: 2m 45s
+MAX_TABLE_SIZE ?= 32
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
+
+UNWINDSET += s_get_next_element.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_iter_begin_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_iter_begin/aws_hash_iter_begin_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_begin/aws_hash_iter_begin_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_hash_iter_begin_harness() {
+    struct aws_hash_table map;
+
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_hash_table(&map, &old_byte);
+
+    struct aws_hash_iter iter = aws_hash_iter_begin(&map);
+
+    assert(aws_hash_iter_is_valid(&iter));
+    assert(iter.status == AWS_HASH_ITER_STATUS_DONE || iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    assert(aws_hash_table_is_valid(&map));
+    check_hash_table_unchanged(&map, &old_byte);
+}

--- a/.cbmc-batch/jobs/aws_hash_iter_begin/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_iter_begin/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_get_next_element.0:33;--object-bits;8"
+goto: aws_hash_iter_begin_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
@@ -12,9 +12,9 @@
 # limitations under the License.
 
 ###########
-#2: 1M 15s
-#4:  4m 40s
-MAX_TABLE_SIZE ?= 2
+#2: 1M 15s (tho note that this doens't give full coverage)
+#4:  4m 40s (gives full coverage)
+MAX_TABLE_SIZE ?= 4
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
 
 UNWINDSET += s_remove_entry.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
@@ -14,7 +14,7 @@
 ###########
 #2: 1M 15s
 #4:  4m 40s
-MAX_TABLE_SIZE ?= 4
+MAX_TABLE_SIZE ?= 2
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
 
 UNWINDSET += s_remove_entry.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 ###########
-#2: 1M 15s (tho note that this doens't give full coverage)
-#4:  4m 40s (gives full coverage)
+#4: 4m 40s (smallest size that gives full coverage)
 MAX_TABLE_SIZE ?= 4
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
 

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 ###########
-#4: 4m 40s (smallest size that gives full coverage)
+#4: 4m40s (smallest size that gives full coverage)
 MAX_TABLE_SIZE ?= 4
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
 

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#2: 1M 15s
+#4:  4m 40s
+MAX_TABLE_SIZE ?= 4
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
+
+UNWINDSET += s_remove_entry.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_iter_delete_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
@@ -19,23 +19,6 @@
 #include <proof_helpers/proof_allocators.h>
 #include <proof_helpers/utils.h>
 
-bool has_an_empty_slot(struct aws_hash_table *map, size_t *rval) {
-    struct hash_table_state *state = map->p_impl;
-    __CPROVER_assume(state->entry_count > 0);
-    size_t empty_slot_idx;
-    __CPROVER_assume(empty_slot_idx < state->size);
-    *rval = empty_slot_idx;
-    return state->slots[empty_slot_idx].hash_code == 0;
-}
-
-/**
- * A correct implementation of the hash_destroy function should never have a memory
- * error on valid input. There is the question of whether the destroy functions themselves
- * are correctly called (i.e. only on valid input, no double free, etc.).  This will be tested in
- * future proofs.
- */
-void hash_proof_destroy_noop(void *p) {}
-
 void aws_hash_iter_delete_harness() {
 
     struct aws_hash_table map;
@@ -44,7 +27,7 @@ void aws_hash_iter_delete_harness() {
     __CPROVER_assume(map.p_impl->destroy_key_fn == hash_proof_destroy_noop || !map.p_impl->destroy_key_fn);
     __CPROVER_assume(map.p_impl->destroy_value_fn == hash_proof_destroy_noop || !map.p_impl->destroy_value_fn);
     size_t empty_slot_idx;
-    __CPROVER_assume(has_an_empty_slot(&map, &empty_slot_idx));
+    __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
     struct hash_table_state *state = map.p_impl;
 
     struct aws_hash_iter iter;

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+bool has_an_empty_slot(struct aws_hash_table *map, size_t *rval) {
+    struct hash_table_state *state = map->p_impl;
+    __CPROVER_assume(state->entry_count > 0);
+    size_t empty_slot_idx;
+    __CPROVER_assume(empty_slot_idx < state->size);
+    *rval = empty_slot_idx;
+    return state->slots[empty_slot_idx].hash_code == 0;
+}
+
+void aws_hash_iter_delete_harness() {
+
+    struct aws_hash_table map;
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+    size_t empty_slot_idx;
+    __CPROVER_assume(has_an_empty_slot(&map, &empty_slot_idx));
+    struct hash_table_state *state = map.p_impl;
+
+    struct aws_hash_iter iter;
+    iter.map = &map;
+    __CPROVER_assume(iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    __CPROVER_assume(aws_hash_iter_is_valid(&iter));
+
+    aws_hash_iter_delete(&iter, false);
+    assert(iter.status == AWS_HASH_ITER_STATUS_DELETE_CALLED);
+    assert(aws_hash_iter_is_valid(&iter));
+
+    assert_hash_table_state_is_valid(map.p_impl);
+}

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
@@ -34,17 +34,15 @@ bool has_an_empty_slot(struct aws_hash_table *map, size_t *rval) {
  * are correctly called (i.e. only on valid input, no double free, etc.).  This will be tested in
  * future proofs.
  */
-void hash_proof_destroy_noop(void* p)
-{
-}
+void hash_proof_destroy_noop(void *p) {}
 
 void aws_hash_iter_delete_harness() {
 
     struct aws_hash_table map;
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));
-    __CPROVER_assume(map.p_impl->destroy_key_fn == hash_proof_destroy_noop);
-    __CPROVER_assume(map.p_impl->destroy_value_fn == hash_proof_destroy_noop);
+    __CPROVER_assume(map.p_impl->destroy_key_fn == hash_proof_destroy_noop || !map.p_impl->destroy_key_fn);
+    __CPROVER_assume(map.p_impl->destroy_value_fn == hash_proof_destroy_noop || !map.p_impl->destroy_value_fn);
     size_t empty_slot_idx;
     __CPROVER_assume(has_an_empty_slot(&map, &empty_slot_idx));
     struct hash_table_state *state = map.p_impl;
@@ -57,6 +55,4 @@ void aws_hash_iter_delete_harness() {
     aws_hash_iter_delete(&iter, nondet_bool());
     assert(iter.status == AWS_HASH_ITER_STATUS_DELETE_CALLED);
     assert(aws_hash_iter_is_valid(&iter));
-
-    assert_hash_table_state_is_valid(map.p_impl);
 }

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_remove_entry.0:3;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_remove_entry.0:5;--object-bits;8"
 goto: aws_hash_iter_delete_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_remove_entry.0:5;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_remove_entry.0:3;--object-bits;8"
 goto: aws_hash_iter_delete_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_hash_iter_delete/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_iter_delete/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_remove_entry.0:5;--object-bits;8"
+goto: aws_hash_iter_delete_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_hash_iter_done/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_done/Makefile
@@ -12,8 +12,9 @@
 # limitations under the License.
 
 ###########
+# ensure_allocated_hash_table expects some max table size
+# using SIZE_MAX leaves it maximally unconstrained.
 DEFINES += -DMAX_TABLE_SIZE=SIZE_MAX 
-
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_hash_iter_done/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_done/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+DEFINES += -DMAX_TABLE_SIZE=SIZE_MAX 
+
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_iter_done_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_iter_done/aws_hash_iter_done_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_done/aws_hash_iter_done_harness.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_hash_iter_done_harness() {
+
+    struct aws_hash_table map;
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+
+    struct aws_hash_iter iter;
+    iter.map = &map;
+    __CPROVER_assume(iter.status == AWS_HASH_ITER_STATUS_DONE || iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    __CPROVER_assume(aws_hash_iter_is_valid(&iter));
+    enum aws_hash_iter_status old_status = iter.status;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_hash_table(&map, &old_byte);
+
+    bool rval = aws_hash_iter_done(&iter);
+
+    assert(aws_hash_iter_is_valid(&iter));
+    AWS_POSTCONDITION(rval == (iter.status == AWS_HASH_ITER_STATUS_DONE));
+    assert(iter.status == old_status);
+    assert(aws_hash_table_is_valid(&map));
+    check_hash_table_unchanged(&map, &old_byte);
+}

--- a/.cbmc-batch/jobs/aws_hash_iter_done/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_iter_done/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_hash_iter_done_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_hash_iter_next/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_iter_next/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#4: 13 s
+#8: 40s
+#16: 1m 36s
+#24 3m 20s
+MAX_TABLE_SIZE ?= 8
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
+
+UNWINDSET += s_get_next_element.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_iter_next_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_iter_next/aws_hash_iter_next_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_next/aws_hash_iter_next_harness.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_hash_iter_next_harness() {
+
+    struct aws_hash_table map;
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+
+    struct aws_hash_iter iter;
+    iter.map = &map;
+    __CPROVER_assume(aws_hash_iter_is_valid(&iter));
+    enum aws_hash_iter_status old_status = iter.status;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_hash_table(&map, &old_byte);
+
+    aws_hash_iter_next(&iter);
+
+    assert(aws_hash_iter_is_valid(&iter));
+    assert(iter.status == AWS_HASH_ITER_STATUS_DONE || iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    assert(IMPLIES(old_status == AWS_HASH_ITER_STATUS_DONE, iter.status == AWS_HASH_ITER_STATUS_DONE));
+    assert(aws_hash_table_is_valid(&map));
+    check_hash_table_unchanged(&map, &old_byte);
+}

--- a/.cbmc-batch/jobs/aws_hash_iter_next/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_iter_next/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_get_next_element.0:9;--object-bits;8"
+goto: aws_hash_iter_next_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -159,3 +159,20 @@ const char *make_arbitrary_c_str(size_t max_size) {
     __CPROVER_assume(str[cap - 1] == 0);
     return str;
 }
+
+bool aws_hash_table_has_an_empty_slot(struct aws_hash_table *map, size_t *rval) {
+    struct hash_table_state *state = map->p_impl;
+    __CPROVER_assume(state->entry_count > 0);
+    size_t empty_slot_idx;
+    __CPROVER_assume(empty_slot_idx < state->size);
+    *rval = empty_slot_idx;
+    return state->slots[empty_slot_idx].hash_code == 0;
+}
+
+/**
+ * A correct implementation of the hash_destroy function should never have a memory
+ * error on valid input. There is the question of whether the destroy functions themselves
+ * are correctly called (i.e. only on valid input, no double free, etc.).  This will be tested in
+ * future proofs.
+ */
+void hash_proof_destroy_noop(void *p) {}

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -160,7 +160,7 @@ const char *make_arbitrary_c_str(size_t max_size) {
     return str;
 }
 
-bool aws_hash_table_has_an_empty_slot(struct aws_hash_table *map, size_t *rval) {
+bool aws_hash_table_has_an_empty_slot(const struct aws_hash_table *const map, size_t *rval) {
     struct hash_table_state *state = map->p_impl;
     __CPROVER_assume(state->entry_count > 0);
     size_t empty_slot_idx;

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -139,7 +139,7 @@ struct aws_string *make_arbitrary_aws_string_nondet_len_with_max(struct aws_allo
 
 void ensure_allocated_hash_table(struct aws_hash_table *map, size_t max_table_entries) {
     size_t num_entries;
-    __CPROVER_assume(num_entries < max_table_entries);
+    __CPROVER_assume(num_entries <= max_table_entries);
     __CPROVER_assume(aws_is_power_of_two(num_entries));
 
     size_t required_bytes;

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -35,6 +35,8 @@ function(aws_set_common_properties target)
         # /volatile:iso relaxes some implicit memory barriers that MSVC normally applies for volatile accesses
         # Since we want to be compatible with user builds using /volatile:iso, use it for the tests.
         list(APPEND AWS_C_FLAGS /volatile:iso)
+        # Disable unknown pragma warnings
+        list(APPEND AWS_C_FLAGS /wd4068)
 
         string(TOUPPER "${CMAKE_BUILD_TYPE}" _CMAKE_BUILD_TYPE)
         if(STATIC_CRT)
@@ -57,7 +59,7 @@ function(aws_set_common_properties target)
         endif()
 
         # Warning disables always go last to avoid future flags re-enabling them
-        list(APPEND AWS_C_FLAGS -Wno-long-long)
+        list(APPEND AWS_C_FLAGS -Wno-long-long -Wno-unknown-pragmas)
 
         # Avoid exporting symbols we don't intend to export
         list(APPEND AWS_C_FLAGS -fvisibility=hidden)

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -111,13 +111,12 @@
 #include <aws/common/assert.inl>
 
 /**
-* Define function contracts.
-* When the code is being verified using CBMC these contracts are formally verified;
-* When the code is built in debug mode, they are checked as much as possible using assertions
-* When the code is built in production mode, they are not checked.
-* Violations of the function contracts are undefined behaviour.
-otherwise they are checked
-*/
+ * Define function contracts.
+ * When the code is being verified using CBMC these contracts are formally verified;
+ * When the code is built in debug mode, they are checked as much as possible using assertions
+ * When the code is built in production mode, they are not checked.
+ * Violations of the function contracts are undefined behaviour.
+ */
 #ifdef CBMC
 #define AWS_PRECONDITION(cond) __CPROVER_assume(cond)
 #define AWS_POSTCONDITION(cond) assert(cond)

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -81,24 +81,20 @@ enum aws_hash_iter_status {
     AWS_HASH_ITER_STATUS_READY_FOR_USE,
 };
 
-/* aws_hash_iter has reserved fields of type void*. If this assertion below is true, we can
- * use intptr_t in these fields without issue.
- */
-AWS_STATIC_ASSERT(sizeof(intptr_t) == sizeof(void *));
-
 struct aws_hash_iter {
     const struct aws_hash_table *map;
     struct aws_hash_element element;
     size_t slot;
     size_t limit;
     /* Holds an enum aws_hash_iter_status */
-    intptr_t status;
+    enum aws_hash_iter_status status;
     /*
      * Reserving extra fields for binary compatibility with future expansion of
      * iterator in case hash table implementation changes.
      */
-    void *unused_0;
+    int unused_0;
     void *unused_1;
+    void *unused_2;
 };
 
 /**

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -86,7 +86,6 @@ struct aws_hash_iter {
     struct aws_hash_element element;
     size_t slot;
     size_t limit;
-    /* Holds an enum aws_hash_iter_status */
     enum aws_hash_iter_status status;
     /*
      * Reserving extra fields for binary compatibility with future expansion of

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -54,8 +54,9 @@
  * memory barrier must be used when transitioning from single-threaded mutating
  * usage to multithreaded usage.
  */
+struct hash_table_state; /* Opaque pointer */
 struct aws_hash_table {
-    void *p_impl;
+    struct hash_table_state *p_impl;
 };
 
 /**
@@ -74,18 +75,30 @@ struct aws_hash_element {
     void *value;
 };
 
+enum aws_hash_iter_status {
+    AWS_HASH_ITER_STATUS_DONE,
+    AWS_HASH_ITER_STATUS_DELETE_CALLED,
+    AWS_HASH_ITER_STATUS_READY_FOR_USE,
+};
+
+/* aws_hash_iter has reserved fields of type void*. If this assertion below is true, we can
+ * use intptr_t in these fields without issue.
+ */
+AWS_STATIC_ASSERT(sizeof(intptr_t) == sizeof(void *));
+
 struct aws_hash_iter {
     const struct aws_hash_table *map;
     struct aws_hash_element element;
     size_t slot;
     size_t limit;
+    /* Holds an enum aws_hash_iter_status */
+    intptr_t status;
     /*
      * Reserving extra fields for binary compatibility with future expansion of
      * iterator in case hash table implementation changes.
      */
     void *unused_0;
     void *unused_1;
-    void *unused_2;
 };
 
 /**
@@ -207,6 +220,9 @@ bool aws_hash_iter_done(const struct aws_hash_iter *iter);
  *     value_type value = *(value_type *)iter.element.value;
  *     // etc.
  * }
+ *
+ * Note that calling this on an iter which is "done" is idempotent:
+ * i.e. it will return another iter which is "done".
  */
 AWS_COMMON_API
 void aws_hash_iter_next(struct aws_hash_iter *iter);

--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -91,6 +91,41 @@ bool aws_hash_table_is_valid(const struct aws_hash_table *map) {
 }
 
 /**
+ * Given a pointer to a hash_iter, checks that it is well-formed, with all data-structure invariants.
+ */
+AWS_STATIC_IMPL
+bool aws_hash_iter_is_valid(const struct aws_hash_iter *iter) {
+    if (!iter) {
+        return false;
+    }
+    if (!iter->map) {
+        return false;
+    }
+    if (!aws_hash_table_is_valid(iter->map)) {
+        return false;
+    }
+    if (iter->limit > iter->map->p_impl->size) {
+        return false;
+    }
+
+    switch (iter->status) {
+        case AWS_HASH_ITER_STATUS_DONE:
+            /* Done iff slot == limit */
+            return iter->slot == iter->limit;
+        case AWS_HASH_ITER_STATUS_DELETE_CALLED:
+            /* iter->slot can underflow to SIZE_MAX after a delete
+             * see the comments for aws_hash_iter_delete() */
+            return iter->slot <= iter->limit || iter->slot == SIZE_MAX;
+        case AWS_HASH_ITER_STATUS_READY_FOR_USE:
+            /* A slot must point to a valid location (i.e. hash_code != 0) */
+            return iter->slot < iter->limit && iter->map->p_impl->slots[iter->slot].hash_code != 0;
+        default:
+            /* Invalid status code */
+            return false;
+    }
+}
+
+/**
  * Determine the total number of bytes needed for a hash-table with
  * "size" slots. If the result would overflow a size_t, return
  * AWS_OP_ERR; otherwise, return AWS_OP_SUCCESS with the result in

--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -119,10 +119,9 @@ bool aws_hash_iter_is_valid(const struct aws_hash_iter *iter) {
         case AWS_HASH_ITER_STATUS_READY_FOR_USE:
             /* A slot must point to a valid location (i.e. hash_code != 0) */
             return iter->slot < iter->limit && iter->map->p_impl->slots[iter->slot].hash_code != 0;
-        default:
-            /* Invalid status code */
-            return false;
     }
+    /* Invalid status code */
+    return false;
 }
 
 /**

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -56,6 +56,7 @@ static size_t s_index_for(struct hash_table_state *map, struct hash_table_entry 
     AWS_PRECONDITION(hash_table_state_is_valid(map));
     size_t index = entry - map->slots;
     AWS_POSTCONDITION(index < map->size);
+    AWS_PRECONDITION(hash_table_state_is_valid(map));
     return index;
 }
 
@@ -694,9 +695,8 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
 }
 
 bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(iter);
-    AWS_PRECONDITION(iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
     AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
+    AWS_PRECONDITION(iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
     /*
      * SIZE_MAX is a valid (non-terminal) value for iter->slot in the event that
      * we delete slot 0. See comments in aws_hash_iter_delete.

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -534,7 +534,6 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
     /* There is always at least one empty slot in the hash table, so this loop always terminates */
     while (1) {
         size_t next_index = (index + 1) & state->mask;
-        // uint64_t hash_code = state->slots[next_index].hash_code;
 
         /* If we hit an empty slot, stop */
         if (!state->slots[next_index].hash_code) {


### PR DESCRIPTION
*Description of changes:*
1. Added proofs for ```hash_iter*``` functions
1. As part of this, made explicit the state machine that hash iterators are expected to follow
1. ~~In order to keep ABI compatability, I use an ```intptr_t``` to store the new enum.  If this is not essential, I'd rather use an ```enum``` to store it, to make the intent clearer.~~
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
