### PR TITLE
Add aws_byte_buf_reset() function

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_reset/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/Makefile
@@ -13,7 +13,7 @@
 
 ###########
 include ../Makefile.aws_byte_buf
-UNWINDSET += memset_impl.0:41
+UNWINDSET += memset_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/Makefile
@@ -19,6 +19,7 @@ CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
 DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+UNWINDSET += memset_impl.0:41
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_reset_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/aws_byte_buf_reset_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/aws_byte_buf_reset_harness.c
@@ -20,10 +20,9 @@
 void aws_byte_buf_reset_harness() {
     struct aws_byte_buf buf;
 
-    __CPROVER_assume(is_bounded_byte_buf(&buf, MAX_BUFFER_SIZE));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    assert(buf.capacity <= MAX_BUFFER_SIZE);
 
     struct aws_byte_buf old = buf;
     bool zero_contents;

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/aws_byte_buf_reset_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/aws_byte_buf_reset_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+ #include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+ void aws_byte_buf_reset_harness() {
+    struct aws_byte_buf buf;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+     ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    struct aws_byte_buf old = buf;
+    bool zero_contents;
+    aws_byte_buf_reset(&buf, zero_contents);
+    assert(buf.len == 0);
+    assert(buf.allocator == old.allocator);
+    assert(buf.buffer == old.buffer);
+    assert(buf.capacity == old.capacity);
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/aws_byte_buf_reset_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/aws_byte_buf_reset_harness.c
@@ -13,15 +13,17 @@
  * permissions and limitations under the License.
  */
 
- #include <aws/common/byte_buf.h>
+#include <aws/common/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
 
- void aws_byte_buf_reset_harness() {
+void aws_byte_buf_reset_harness() {
     struct aws_byte_buf buf;
 
-    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
-     ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(is_bounded_byte_buf(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    assert(buf.capacity <= MAX_BUFFER_SIZE);
 
     struct aws_byte_buf old = buf;
     bool zero_contents;
@@ -30,4 +32,7 @@
     assert(buf.allocator == old.allocator);
     assert(buf.buffer == old.buffer);
     assert(buf.capacity == old.capacity);
+    if (zero_contents) {
+        assert_all_bytes_are(buf.buffer, 0, buf.capacity);
+    }
 }

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_impl.0:41;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_impl.0:11;--object-bits;8"
 goto: aws_byte_buf_reset_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_reset/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_reset/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_impl.0:41;--object-bits;8"
+goto: aws_byte_buf_reset_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -163,6 +163,13 @@ AWS_COMMON_API
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf);
 
 /**
+ * Resets the len of the buffer to 0, but does not free the memory. The buffer can then be reused.
+ * Optionally zeroes the contents, if the "zero_contents" flag is true.
+ */
+AWS_COMMON_API
+void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents);
+
+/**
  * Sets all bytes of buffer to zero and resets len to zero.
  */
 AWS_COMMON_API

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -74,6 +74,13 @@ bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor) {
            ((cursor->len == 0) || (cursor->len > 0 && cursor->ptr && AWS_MEM_IS_WRITABLE(cursor->ptr, cursor->len)));
 }
 
+void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents) {
+    if (zero_contents) {
+        aws_byte_buf_secure_zero(buf);
+    }
+    buf->len = 0;
+}
+
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     if (buf->allocator && buf->buffer) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -221,6 +221,7 @@ add_test_case(test_byte_buf_append_lookup_success)
 add_test_case(test_byte_buf_append_lookup_failure)
 add_test_case(test_byte_buf_reserve)
 add_test_case(test_byte_buf_reserve_relative)
+add_test_case(test_byte_buf_reset)
 
 add_test_case(byte_swap_test)
 

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -40,7 +40,6 @@ static int s_run_hex_encoding_test_case(
     memset(allocation.buffer, 0xdd, allocation.capacity);
 
     struct aws_byte_buf output = aws_byte_buf_from_empty_array(allocation.buffer + 1, output_size);
-    output.len = 0;
 
     ASSERT_SUCCESS(aws_hex_encode(&to_encode, &output), "encode call should have succeeded");
 
@@ -69,12 +68,7 @@ static int s_run_hex_encoding_test_case(
     memset(allocation.buffer, 0xdd, allocation.capacity);
 
     ASSERT_INT_EQUALS(test_str_size - 1, output_size, "Output size on string should be %d", test_str_size - 1);
-
-    output.capacity = output_size;
-    if (output.capacity == 0) {
-        output.buffer = NULL;
-    }
-    output.len = 0;
+    aws_byte_buf_reset(&output, false);
 
     struct aws_byte_cursor expected_buf = aws_byte_cursor_from_array(expected, expected_size - 1);
     ASSERT_SUCCESS(aws_hex_decode(&expected_buf, &output), "decode call should have succeeded");
@@ -314,7 +308,6 @@ static int s_run_base64_encoding_test_case(
     memset(allocation.buffer, 0xdd, allocation.capacity);
 
     struct aws_byte_buf output = aws_byte_buf_from_empty_array(allocation.buffer + 1, output_size);
-    output.len = 0;
 
     ASSERT_SUCCESS(aws_base64_encode(&to_encode, &output), "encode call should have succeeded");
 
@@ -349,7 +342,6 @@ static int s_run_base64_encoding_test_case(
     memset(allocation.buffer, 0xdd, allocation.capacity);
 
     output = aws_byte_buf_from_empty_array(allocation.buffer + 1, output_size);
-    output.len = 0;
 
     struct aws_byte_cursor expected_buf = aws_byte_cursor_from_array(expected, expected_size - 1);
     ASSERT_SUCCESS(aws_base64_decode(&expected_buf, &output), "decode call should have succeeded");


### PR DESCRIPTION
*Description of changes:*
There are cases where the user wants to reuse the same buffer (we see this in some c-common tests, for example). Instead of either having to
1. poke inside the buf internals
1. call secure_zero, which has the added cost of a memset.

this gives the user an API function that does the right thing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
