### PR TITLE
Updates implementation of aws_byte_buf_from_c_str function

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += strlen.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_from_c_str_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_from_c_str_harness() {
+    size_t len;
+    char *c_str;
+
+    if (nondet_bool()) {
+        c_str = NULL;
+    } else {
+        /* Assume the length of the string is bounded by some max length */
+        __CPROVER_assume(len <= MAX_BUFFER_SIZE);
+        ASSUME_VALID_MEMORY_COUNT(c_str, len);
+
+        /* Need *c_str to be a '\0'-terminated C string, so assume an arbitrary character is 0 */
+        int index;
+        __CPROVER_assume(index >= 0 && index < len);
+        c_str[index] = 0;
+    }
+
+    /* operation under verification */
+    struct aws_byte_buf buf = aws_byte_buf_from_c_str(c_str);
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(buf.allocator == NULL);
+    if (buf.buffer) {
+        assert(buf.len == strlen(c_str));
+        assert(buf.capacity == buf.len + 1);
+        assert_bytes_match(buf.buffer, (uint8_t *)c_str, buf.len);
+    } else {
+        assert(buf.len == 0);
+        assert(buf.capacity == 0);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
@@ -17,21 +17,8 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 void aws_byte_buf_from_c_str_harness() {
-    size_t len;
-    char *c_str;
-
-    if (nondet_bool()) {
-        c_str = NULL;
-    } else {
-        /* Assume the length of the string is bounded by some max length */
-        __CPROVER_assume(len <= MAX_BUFFER_SIZE);
-        ASSUME_VALID_MEMORY_COUNT(c_str, len);
-
-        /* Need *c_str to be a '\0'-terminated C string, so assume an arbitrary character is 0 */
-        int index;
-        __CPROVER_assume(index >= 0 && index < len);
-        c_str[index] = 0;
-    }
+    /* parameter */
+    const char *c_str = nondet_bool() ? NULL : make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* operation under verification */
     struct aws_byte_buf buf = aws_byte_buf_from_c_str(c_str);
@@ -44,6 +31,9 @@ void aws_byte_buf_from_c_str_harness() {
         assert(buf.capacity == buf.len);
         assert_bytes_match(buf.buffer, (uint8_t *)c_str, buf.len);
     } else {
+        if (c_str) {
+            assert(strlen(c_str) == 0);
+        }
         assert(buf.len == 0);
         assert(buf.capacity == 0);
     }

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
@@ -41,7 +41,7 @@ void aws_byte_buf_from_c_str_harness() {
     assert(buf.allocator == NULL);
     if (buf.buffer) {
         assert(buf.len == strlen(c_str));
-        assert(buf.capacity == buf.len + 1);
+        assert(buf.capacity == buf.len);
         assert_bytes_match(buf.buffer, (uint8_t *)c_str, buf.len);
     } else {
         assert(buf.len == 0);

--- a/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_c_str/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;strlen.0:11;--unwind;1"
+goto: aws_byte_buf_from_c_str_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -451,9 +451,16 @@ AWS_EXTERN_C_END
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
     struct aws_byte_buf buf;
     buf.buffer = (uint8_t *)c_str;
-    buf.len = strlen(c_str);
-    buf.capacity = buf.len;
+    if (!buf.buffer) {
+        buf.len = 0;
+        buf.capacity = 0;
+    } else {
+        buf.len = strlen(c_str);
+        /* considering the byte for the terminating null character */
+        buf.capacity = buf.len + 1;
+    }
     buf.allocator = NULL;
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;
 }
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -450,15 +450,9 @@ AWS_EXTERN_C_END
  */
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
     struct aws_byte_buf buf;
-    buf.buffer = (uint8_t *)c_str;
-    if (!buf.buffer) {
-        buf.len = 0;
-        buf.capacity = 0;
-    } else {
-        buf.len = strlen(c_str);
-        /* considering the byte for the terminating null character */
-        buf.capacity = buf.len + 1;
-    }
+    buf.len = (!c_str) ? 0 : strlen(c_str);
+    buf.capacity = buf.len;
+    buf.buffer = (buf.capacity == 0) ? NULL : (uint8_t *)c_str;
     buf.allocator = NULL;
     AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -210,7 +210,8 @@ static int s_test_buffer_init_copy_fn(struct aws_allocator *allocator, void *ctx
 
     ASSERT_SUCCESS(aws_byte_buf_init_copy(&dest, allocator, &src));
     ASSERT_TRUE(aws_byte_buf_eq(&src, &dest));
-    ASSERT_INT_EQUALS(src.len, dest.capacity);
+    ASSERT_INT_EQUALS(src.len, strlen("test_string"));
+    ASSERT_INT_EQUALS(src.capacity, sizeof("test_string"));
     ASSERT_PTR_EQUALS(allocator, dest.allocator);
     aws_byte_buf_clean_up(&dest);
     return 0;

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -210,8 +210,7 @@ static int s_test_buffer_init_copy_fn(struct aws_allocator *allocator, void *ctx
 
     ASSERT_SUCCESS(aws_byte_buf_init_copy(&dest, allocator, &src));
     ASSERT_TRUE(aws_byte_buf_eq(&src, &dest));
-    ASSERT_INT_EQUALS(src.len, strlen("test_string"));
-    ASSERT_INT_EQUALS(src.capacity, sizeof("test_string"));
+    ASSERT_INT_EQUALS(src.len, dest.capacity);
     ASSERT_PTR_EQUALS(allocator, dest.allocator);
     aws_byte_buf_clean_up(&dest);
     return 0;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

1. Updates implementation of `aws_byte_buf_from_c_str` function;
2. Adds a proof harness for `aws_byte_buf_from_c_str` function;
3. Updates the `test_buffer_init_copy` test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
