### PR TITLE
Adds proof harness for aws_byte_buf_clean_up_secure function

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up_secure/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up_secure/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+MAX_BUFFER_SIZE=40
+
+# This bound allows us to reach 100% coverage rate
+UNWINDSET += memset_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_clean_up_secure_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up_secure/aws_byte_buf_clean_up_secure_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up_secure/aws_byte_buf_clean_up_secure_harness.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_clean_up_secure_harness() {
+    /* data structure */
+    struct aws_byte_buf buf;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* operation under verification */
+    aws_byte_buf_clean_up_secure(&buf);
+
+    /* assertions */
+    assert(buf.allocator == NULL);
+    assert(buf.buffer == NULL);
+    assert(buf.len == 0);
+    assert(buf.capacity == 0);
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_clean_up_secure/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_clean_up_secure/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memset_impl.0:41;--unwind;1"
+goto: aws_byte_buf_clean_up_secure_harness.goto
+expected: "SUCCESSFUL"

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -96,8 +96,10 @@ void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     aws_byte_buf_secure_zero(buf);
     aws_byte_buf_clean_up(buf);
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
 }
 
 bool aws_byte_buf_eq(const struct aws_byte_buf *a, const struct aws_byte_buf *b) {


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*
1. Updates implementation of `aws_byte_buf_clean_up_secure` function with pre- and post-conditions;
2. Adds a proof harness for `aws_byte_buf_clean_up_secure` function;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
