### PR TITLE
Adds proof harness for aws_nospec_mask function

### DIFF
--- a/.cbmc-batch/jobs/aws_nospec_mask/Makefile
+++ b/.cbmc-batch/jobs/aws_nospec_mask/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_nospec_mask_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_nospec_mask/aws_nospec_mask_harness.c
+++ b/.cbmc-batch/jobs/aws_nospec_mask/aws_nospec_mask_harness.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_nospec_mask_harness() {
+    /* parameters */
+    size_t index;
+    size_t bound;
+
+    /* operation under verification */
+    size_t rval = aws_nospec_mask(index, bound);
+
+    /* assertions */
+    if (rval == 0) {
+        assert((index >= bound) || (bound > (SIZE_MAX / 2)) || (index > (SIZE_MAX / 2)));
+    } else {
+        assert(rval == UINTPTR_MAX);
+        assert(!((index >= bound) || (bound > (SIZE_MAX / 2)) || (index > (SIZE_MAX / 2))));
+    }
+}

--- a/.cbmc-batch/jobs/aws_nospec_mask/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_nospec_mask/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
+goto: aws_nospec_mask_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -501,6 +501,8 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *by
     return cur;
 }
 
+#pragma CPROVER check push
+#pragma CPROVER check disable "unsigned-overflow"
 /**
  * If index >= bound, bound > (SIZE_MAX / 2), or index > (SIZE_MAX / 2), returns
  * 0. Otherwise, returns UINTPTR_MAX.  This function is designed to return the correct
@@ -565,6 +567,7 @@ AWS_STATIC_IMPL size_t aws_nospec_mask(size_t index, size_t bound) {
 
     return combined_mask;
 }
+#pragma CPROVER check pop
 
 /**
  * Tests if the given aws_byte_cursor has at least len bytes remaining. If so,


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*
1. Updates implementation of `aws_nospec_mask` function with pre- and post-conditions;
2. Adds a proof harness for `aws_nospec_mask` function;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
