### PR TITLE
CBMC harness for aws_hash_table_find(), and related fixups.

### DIFF
--- a/.cbmc-batch/.gitignore
+++ b/.cbmc-batch/.gitignore
@@ -1,3 +1,4 @@
 html
 property.xml
 coverage.xml
+cbmc.txt

--- a/.cbmc-batch/.gitignore
+++ b/.cbmc-batch/.gitignore
@@ -1,0 +1,3 @@
+html
+property.xml
+coverage.xml

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -79,3 +79,29 @@ void check_hash_table_unchanged(const struct aws_hash_table *map, const struct s
  * Standard stub function to compare two items.
  */
 int nondet_compare(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to compare two items.
+ */
+int uninterpreted_compare(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to compare two items.
+ */
+bool nondet_equals(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to compare two items.
+ * Also enforces uninterpreted_hasher() to be equal for equal values.
+ */
+bool uninterpreted_equals(const void *const a, const void *const b);
+
+/**
+ * Standard stub function to hash one item.
+ */
+uint64_t nondet_hasher(const void *a);
+
+/**
+ * Standard stub function to hash one item.
+ */
+uint64_t uninterpreted_hasher(const void *a);

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -97,6 +97,11 @@ bool nondet_equals(const void *const a, const void *const b);
 bool uninterpreted_equals(const void *const a, const void *const b);
 
 /**
+ * uninterpreted_equals(), but with an extra assertion that a and b are both not null
+ */
+bool uninterpreted_equals_assert_inputs_nonnull(const void *const a, const void *const b);
+
+/**
  * Standard stub function to hash one item.
  */
 uint64_t nondet_hasher(const void *a);

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -96,7 +96,7 @@ $(ENTRY)0.goto: $(ENTRY).c $(DEPENDENCIES)
 	        2>&1 | tee $(ENTRY)1.log
 
 $(ENTRY)1.goto: $(ENTRY)0.goto
-ifeq ($(REMOVE_FNCTION_BODY), "")
+ifeq ($(REMOVE_FUNCTION_BODY), "")
 	cp $< $@
 	echo "Not removing function bodies" | tee $(ENTRY)1.log
 else

--- a/.cbmc-batch/jobs/aws_hash_table_find/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_find/Makefile
@@ -12,10 +12,9 @@
 # limitations under the License.
 
 ###########
-#4: 17 s
-#8: 31s
-#16: 1m30s
-#32: 10m
+#4: 25s
+#8: 1m
+#16: 5m45s
 MAX_TABLE_SIZE ?= 8
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
 

--- a/.cbmc-batch/jobs/aws_hash_table_find/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_find/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+#4: 17 s
+#8: 31s
+#16: 1m30s
+#32: 10m
+MAX_TABLE_SIZE ?= 8
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
+
+UNWINDSET += s_find_entry1.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ENTRY = aws_hash_table_find_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+uint64_t aws_hash_proof_hasher(const void *a) {
+    assert(a);
+    return nondet_uint64_t();
+}
+
+void aws_hash_table_find_harness() {
+
+    struct aws_hash_table map;
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+    map.p_impl->equals_fn = nondet_compare;
+    map.p_impl->hash_fn = aws_hash_proof_hasher;
+
+    size_t empty_slot_idx;
+    __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
+
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_hash_table(&map, &old_byte);
+
+    void *key;
+    struct aws_hash_element *p_elem;
+    int rval = aws_hash_table_find(&map, key, nondet_bool() ? &p_elem : NULL);
+    assert(rval == AWS_OP_SUCCESS);
+    if (p_elem) {
+        assert(AWS_OBJECT_PTR_IS_READABLE(p_elem));
+    }
+    assert(aws_hash_table_is_valid(&map));
+    check_hash_table_unchanged(&map, &old_byte);
+}

--- a/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
@@ -23,7 +23,7 @@ void aws_hash_table_find_harness() {
     struct aws_hash_table map;
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));
-    map.p_impl->equals_fn = uninterpreted_equals;
+    map.p_impl->equals_fn = uninterpreted_equals_assert_inputs_nonnull;
     map.p_impl->hash_fn = uninterpreted_hasher;
 
     size_t empty_slot_idx;
@@ -38,8 +38,7 @@ void aws_hash_table_find_harness() {
     assert(rval == AWS_OP_SUCCESS);
     if (p_elem) {
         assert(AWS_OBJECT_PTR_IS_READABLE(p_elem));
-        /* Avoid null error in the harness if key is null */
-        assert(key == p_elem->key || uninterpreted_equals(p_elem->key, key));
+        assert(p_elem->key == key || uninterpreted_equals(p_elem->key, key));
     }
     assert(aws_hash_table_is_valid(&map));
     check_hash_table_unchanged(&map, &old_byte);

--- a/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
@@ -19,18 +19,12 @@
 #include <proof_helpers/proof_allocators.h>
 #include <proof_helpers/utils.h>
 
-uint64_t aws_hash_proof_hasher(const void *a) {
-    assert(a);
-    return nondet_uint64_t();
-}
-
 void aws_hash_table_find_harness() {
-
     struct aws_hash_table map;
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));
-    map.p_impl->equals_fn = nondet_compare;
-    map.p_impl->hash_fn = aws_hash_proof_hasher;
+    map.p_impl->equals_fn = uninterpreted_equals;
+    map.p_impl->hash_fn = uninterpreted_hasher;
 
     size_t empty_slot_idx;
     __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
@@ -44,6 +38,8 @@ void aws_hash_table_find_harness() {
     assert(rval == AWS_OP_SUCCESS);
     if (p_elem) {
         assert(AWS_OBJECT_PTR_IS_READABLE(p_elem));
+        /* Avoid null error in the harness if key is null */
+        assert(key == p_elem->key || uninterpreted_equals(p_elem->key, key));
     }
     assert(aws_hash_table_is_valid(&map));
     check_hash_table_unchanged(&map, &old_byte);

--- a/.cbmc-batch/jobs/aws_hash_table_find/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_find/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;s_find_entry1.0:9;--object-bits;8"
+goto: aws_hash_table_find_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -87,7 +87,16 @@ int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
 int uninterpreted_compare(const void *const a, const void *const b) {
     assert(a != NULL);
     assert(b != NULL);
-    return __CPROVER_uninterpreted_compare(a, b);
+    int rval = __CPROVER_uninterpreted_compare(a, b);
+    /* Compare is reflexive */
+    __CPROVER_assume(IMPLIES(a == b, rval == 0));
+    /* Compare is anti-symmetric*/
+    __CPROVER_assume(__CPROVER_uninterpreted_compare(b, a) == -rval);
+    /* If two things are equal, their hashes are also equal */
+    if (rval == 0) {
+        __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
+    }
+    return rval;
 }
 
 bool nondet_equals(const void *const a, const void *const b) {
@@ -103,8 +112,6 @@ uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
  * transitivity because it doesn't cause any spurious proof failures on hash-table
  */
 bool uninterpreted_equals(const void *const a, const void *const b) {
-    assert(a != NULL);
-    assert(b != NULL);
     bool rval = __CPROVER_uninterpreted_equals(a, b);
     /* Equals is reflexive */
     __CPROVER_assume(IMPLIES(a == b, rval));
@@ -115,6 +122,12 @@ bool uninterpreted_equals(const void *const a, const void *const b) {
         __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
     }
     return rval;
+}
+
+bool uninterpreted_equals_assert_inputs_nonnull(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    return uninterpreted_equals(a, b);
 }
 
 uint64_t nondet_hasher(const void *a) {

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -80,6 +80,52 @@ void check_hash_table_unchanged(const struct aws_hash_table *map, const struct s
 int nondet_compare(const void *const a, const void *const b) {
     assert(a != NULL);
     assert(b != NULL);
-    int nondet;
-    return nondet;
+    return nondet_int();
+}
+
+int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
+int uninterpreted_compare(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    return __CPROVER_uninterpreted_compare(a, b);
+}
+
+bool nondet_equals(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    return nondet_bool();
+}
+
+bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
+uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
+/**
+ * Add assumptions that equality is reflexive and symmetric. Don't bother with
+ * transitivity because it doesn't cause any spurious proof failures on hash-table
+ */
+bool uninterpreted_equals(const void *const a, const void *const b) {
+    assert(a != NULL);
+    assert(b != NULL);
+    bool rval = __CPROVER_uninterpreted_equals(a, b);
+    /* Equals is reflexive */
+    __CPROVER_assume(IMPLIES(a == b, rval));
+    /* Equals is symmetric */
+    __CPROVER_assume(__CPROVER_uninterpreted_equals(b, a) == rval);
+    /* If two things are equal, their hashes are also equal */
+    if (rval) {
+        __CPROVER_assume(__CPROVER_uninterpreted_hasher(a) == __CPROVER_uninterpreted_hasher(b));
+    }
+    return rval;
+}
+
+uint64_t nondet_hasher(const void *a) {
+    assert(a != NULL);
+    return nondet_uint64_t();
+}
+
+/**
+ * Standard stub function to hash one item.
+ */
+uint64_t uninterpreted_hasher(const void *a) {
+    assert(a != NULL);
+    return __CPROVER_uninterpreted_hasher(a);
 }

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -130,7 +130,8 @@
 #define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 #endif
 
-
+#define AWS_OBJECT_PTR_IS_READABLE(ptr) AWS_MEM_IS_READABLE((ptr), sizeof(*ptr))
+#define AWS_OBJECT_PTR_IS_WRITABLE(ptr) AWS_MEM_IS_WRITABLE((ptr), sizeof(*ptr))
 
 #ifndef NO_STDBOOL
 #    include <stdbool.h>


### PR DESCRIPTION
* CBMC harness for aws_hash_table_find

* Update hash-table to avoid null dereference on equals and hash functions.

* Add pre and post conditions to relevant hash-table functions

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
