### PR TITLE
Adds proof harnesses for aws_byte_buf_eq* functions

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_eq/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcmp.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_eq_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_eq/aws_byte_buf_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq/aws_byte_buf_eq_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_buf_eq_harness() {
+    /* parameters */
+    struct aws_byte_buf lhs;
+    struct aws_byte_buf rhs;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&lhs, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&lhs);
+    __CPROVER_assume(aws_byte_buf_is_valid(&lhs));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&rhs, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&rhs);
+    __CPROVER_assume(aws_byte_buf_is_valid(&rhs));
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old_lhs = lhs;
+    struct store_byte_from_buffer old_byte_from_lhs;
+    save_byte_from_array(lhs.buffer, lhs.len, &old_byte_from_lhs);
+    struct aws_byte_buf old_rhs = rhs;
+    struct store_byte_from_buffer old_byte_from_rhs;
+    save_byte_from_array(rhs.buffer, rhs.len, &old_byte_from_rhs);
+
+    /* operation under verification */
+    if (aws_byte_buf_eq(&lhs, &rhs)) {
+        assert(lhs.len == rhs.len);
+        if (lhs.len > 0) {
+            assert_bytes_match(lhs.buffer, rhs.buffer, lhs.len);
+        }
+    }
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&lhs));
+    assert(aws_byte_buf_is_valid(&rhs));
+    assert_byte_buf_equivalence(&lhs, &old_lhs, &old_byte_from_lhs);
+    assert_byte_buf_equivalence(&rhs, &old_rhs, &old_byte_from_rhs);
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_eq/aws_byte_buf_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq/aws_byte_buf_eq_harness.c
@@ -26,9 +26,13 @@ void aws_byte_buf_eq_harness() {
     __CPROVER_assume(aws_byte_buf_is_bounded(&lhs, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&lhs);
     __CPROVER_assume(aws_byte_buf_is_valid(&lhs));
-    __CPROVER_assume(aws_byte_buf_is_bounded(&rhs, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&rhs);
-    __CPROVER_assume(aws_byte_buf_is_valid(&rhs));
+    if (nondet_bool()) {
+        rhs = lhs;
+    } else {
+        __CPROVER_assume(aws_byte_buf_is_bounded(&rhs, MAX_BUFFER_SIZE));
+        ensure_byte_buf_has_allocated_buffer_member(&rhs);
+        __CPROVER_assume(aws_byte_buf_is_valid(&rhs));
+    }
 
     /* save current state of the data structure */
     struct aws_byte_buf old_lhs = lhs;
@@ -39,7 +43,7 @@ void aws_byte_buf_eq_harness() {
     save_byte_from_array(rhs.buffer, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_buf_eq(&lhs, &rhs)) {
+    if (aws_byte_buf_eq((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL))) {
         assert(lhs.len == rhs.len);
         if (lhs.len > 0) {
             assert_bytes_match(lhs.buffer, rhs.buffer, lhs.len);

--- a/.cbmc-batch/jobs/aws_byte_buf_eq/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwindset;memcmp.0:11;--unwind;1"
+goto: aws_byte_buf_eq_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_array_eq_c_str.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET += strlen.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_eq_c_str_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/aws_byte_buf_eq_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/aws_byte_buf_eq_c_str_harness.c
@@ -20,24 +20,23 @@
 void aws_byte_buf_eq_c_str_harness() {
     /* parameters */
     struct aws_byte_buf buf;
-    const char *c_str;
+    const char *c_str = nondet_bool() ? NULL : make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* assumptions */
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    c_str = make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* save current state of the parameters */
     struct aws_byte_buf old = buf;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(buf.buffer, buf.len, &old_byte);
-    size_t str_len = strlen(c_str);
+    size_t str_len = (c_str) ? strlen(c_str) : 0;
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 
     /* operation under verification */
-    if (aws_byte_buf_eq_c_str(&buf, c_str)) {
+    if (aws_byte_buf_eq_c_str((nondet_bool() ? NULL : &buf), c_str)) {
         assert(buf.len == str_len);
         if (buf.len > 0) {
             assert_bytes_match(buf.buffer, (uint8_t *)c_str, buf.len);

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/aws_byte_buf_eq_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/aws_byte_buf_eq_c_str_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_buf_eq_c_str_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    const char *c_str;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    c_str = make_arbitrary_c_str(MAX_BUFFER_SIZE);
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte);
+    size_t str_len = strlen(c_str);
+    struct store_byte_from_buffer old_byte_from_str;
+    save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
+
+    /* operation under verification */
+    if (aws_byte_buf_eq_c_str(&buf, c_str)) {
+        assert(buf.len == str_len);
+        if (buf.len > 0) {
+            assert_bytes_match(buf.buffer, (uint8_t *)c_str, buf.len);
+        }
+    }
+
+    /* asserts both parameters remain unchanged */
+    assert(aws_byte_buf_is_valid(&buf));
+    assert_byte_buf_equivalence(&buf, &old, &old_byte);
+    if (str_len > 0) {
+        assert_byte_from_buffer_matches((uint8_t *)c_str, &old_byte_from_str);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwindset;aws_array_eq_c_str.0:11,strlen.0:11;--unwind;1"
+goto: aws_byte_buf_eq_c_str_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_array_eq_c_str_ignore_case.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET += strlen.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_eq_c_str_ignore_case_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/aws_byte_buf_eq_c_str_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/aws_byte_buf_eq_c_str_ignore_case_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_eq_c_str_ignore_case_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    const char *c_str;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    c_str = make_arbitrary_c_str(MAX_BUFFER_SIZE);
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte);
+    size_t str_len = strlen(c_str);
+    struct store_byte_from_buffer old_byte_from_str;
+    save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
+
+    /* operation under verification */
+    if (aws_byte_buf_eq_c_str_ignore_case(&buf, c_str)) {
+        assert(buf.len == str_len);
+    }
+
+    /* asserts both parameters remain unchanged */
+    assert(aws_byte_buf_is_valid(&buf));
+    assert_byte_buf_equivalence(&buf, &old, &old_byte);
+    if (str_len > 0) {
+        assert_byte_from_buffer_matches((uint8_t *)c_str, &old_byte_from_str);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/aws_byte_buf_eq_c_str_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/aws_byte_buf_eq_c_str_ignore_case_harness.c
@@ -19,24 +19,23 @@
 void aws_byte_buf_eq_c_str_ignore_case_harness() {
     /* parameters */
     struct aws_byte_buf buf;
-    const char *c_str;
+    const char *c_str = nondet_bool() ? NULL : make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* assumptions */
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    c_str = make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* save current state of the parameters */
     struct aws_byte_buf old = buf;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(buf.buffer, buf.len, &old_byte);
-    size_t str_len = strlen(c_str);
+    size_t str_len = (c_str) ? strlen(c_str) : 0;
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 
     /* operation under verification */
-    if (aws_byte_buf_eq_c_str_ignore_case(&buf, c_str)) {
+    if (aws_byte_buf_eq_c_str_ignore_case((nondet_bool() ? NULL : &buf), c_str)) {
         assert(buf.len == str_len);
     }
 

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_c_str_ignore_case/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwindset;aws_array_eq_c_str_ignore_case.0:11,strlen.0:11;--unwind;1"
+goto: aws_byte_buf_eq_c_str_ignore_case_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcmp.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET += aws_array_eq_ignore_case.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_eq_ignore_case_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/aws_byte_buf_eq_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/aws_byte_buf_eq_ignore_case_harness.c
@@ -26,9 +26,13 @@ void aws_byte_buf_eq_ignore_case_harness() {
     __CPROVER_assume(aws_byte_buf_is_bounded(&lhs, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&lhs);
     __CPROVER_assume(aws_byte_buf_is_valid(&lhs));
-    __CPROVER_assume(aws_byte_buf_is_bounded(&rhs, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&rhs);
-    __CPROVER_assume(aws_byte_buf_is_valid(&rhs));
+    if (nondet_bool()) {
+        rhs = lhs;
+    } else {
+        __CPROVER_assume(aws_byte_buf_is_bounded(&rhs, MAX_BUFFER_SIZE));
+        ensure_byte_buf_has_allocated_buffer_member(&rhs);
+        __CPROVER_assume(aws_byte_buf_is_valid(&rhs));
+    }
 
     /* save current state of the data structure */
     struct aws_byte_buf old_lhs = lhs;
@@ -39,7 +43,7 @@ void aws_byte_buf_eq_ignore_case_harness() {
     save_byte_from_array(rhs.buffer, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_buf_eq_ignore_case(&lhs, &rhs)) {
+    if (aws_byte_buf_eq_ignore_case((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL))) {
         assert(lhs.len == rhs.len);
     }
 

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/aws_byte_buf_eq_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/aws_byte_buf_eq_ignore_case_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_buf_eq_ignore_case_harness() {
+    /* parameters */
+    struct aws_byte_buf lhs;
+    struct aws_byte_buf rhs;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&lhs, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&lhs);
+    __CPROVER_assume(aws_byte_buf_is_valid(&lhs));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&rhs, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&rhs);
+    __CPROVER_assume(aws_byte_buf_is_valid(&rhs));
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old_lhs = lhs;
+    struct store_byte_from_buffer old_byte_from_lhs;
+    save_byte_from_array(lhs.buffer, lhs.len, &old_byte_from_lhs);
+    struct aws_byte_buf old_rhs = rhs;
+    struct store_byte_from_buffer old_byte_from_rhs;
+    save_byte_from_array(rhs.buffer, rhs.len, &old_byte_from_rhs);
+
+    /* operation under verification */
+    if (aws_byte_buf_eq_ignore_case(&lhs, &rhs)) {
+        assert(lhs.len == rhs.len);
+    }
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&lhs));
+    assert(aws_byte_buf_is_valid(&rhs));
+    assert_byte_buf_equivalence(&lhs, &old_lhs, &old_byte_from_lhs);
+    assert_byte_buf_equivalence(&rhs, &old_rhs, &old_byte_from_rhs);
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_eq_ignore_case/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwindset;memcmp.0:11,aws_array_eq_ignore_case.0:11;--unwind;1"
+goto: aws_byte_buf_eq_ignore_case_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -74,15 +74,12 @@ void assert_byte_buf_equivalence(
     const struct aws_byte_buf *const lhs,
     const struct aws_byte_buf *const rhs,
     const struct store_byte_from_buffer *const rhs_byte) {
-<<<<<<< HEAD
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
     } else {
         assert(lhs && rhs); /* if only one is null, they differ */
     }
-=======
->>>>>>> Adds assert_byte_buf_equivalence function to proof helpers
     assert(lhs->len == rhs->len);
     assert(lhs->capacity == rhs->capacity);
     assert(lhs->allocator == rhs->allocator);

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -74,12 +74,15 @@ void assert_byte_buf_equivalence(
     const struct aws_byte_buf *const lhs,
     const struct aws_byte_buf *const rhs,
     const struct store_byte_from_buffer *const rhs_byte) {
+<<<<<<< HEAD
     /* In order to be equivalent, either both are NULL or both are non-NULL */
     if (lhs == rhs) {
         return;
     } else {
         assert(lhs && rhs); /* if only one is null, they differ */
     }
+=======
+>>>>>>> Adds assert_byte_buf_equivalence function to proof helpers
     assert(lhs->len == rhs->len);
     assert(lhs->capacity == rhs->capacity);
     assert(lhs->allocator == rhs->allocator);

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -184,7 +184,7 @@ void aws_byte_buf_secure_zero(struct aws_byte_buf *buf);
  * Return whether their contents are equivalent.
  */
 AWS_COMMON_API
-bool aws_byte_buf_eq(const struct aws_byte_buf *a, const struct aws_byte_buf *b);
+bool aws_byte_buf_eq(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b);
 
 /**
  * Perform a case-insensitive string comparison of two aws_byte_buf structures.
@@ -193,7 +193,7 @@ bool aws_byte_buf_eq(const struct aws_byte_buf *a, const struct aws_byte_buf *b)
  * Data is assumed to be ASCII text, UTF-8 will work fine too.
  */
 AWS_COMMON_API
-bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *a, const struct aws_byte_buf *b);
+bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b);
 
 /**
  * Compare an aws_byte_buf and a null-terminated string.
@@ -201,7 +201,7 @@ bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *a, const struct aws_
  * The buffer should NOT contain a null-terminator, or the comparison will always return false.
  */
 AWS_COMMON_API
-bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *buf, const char *c_str);
+bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *const c_str);
 
 /**
  * Perform a case-insensitive string comparison of an aws_byte_buf and a null-terminated string.
@@ -211,7 +211,7 @@ bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *buf, const char *c_str);
  * Data is assumed to be ASCII text, UTF-8 will work fine too.
  */
 AWS_COMMON_API
-bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *buf, const char *c_str);
+bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *const buf, const char *const c_str);
 
 /**
  * No copies, no buffer allocations. Iterates over input_str, and returns the next substring between split_on instances.

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -108,24 +108,32 @@ void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
 }
 
-bool aws_byte_buf_eq(const struct aws_byte_buf *a, const struct aws_byte_buf *b) {
-    AWS_ASSERT(a && b);
-    return aws_array_eq(a->buffer, a->len, b->buffer, b->len);
+bool aws_byte_buf_eq(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    bool rval = aws_array_eq(a->buffer, a->len, b->buffer, b->len);
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    return rval;
 }
 
-bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *a, const struct aws_byte_buf *b) {
-    AWS_ASSERT(a && b);
-    return aws_array_eq_ignore_case(a->buffer, a->len, b->buffer, b->len);
+bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    bool rval = aws_array_eq_ignore_case(a->buffer, a->len, b->buffer, b->len);
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    return rval;
 }
 
-bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *buf, const char *c_str) {
-    AWS_ASSERT(buf && c_str);
-    return aws_array_eq_c_str(buf->buffer, buf->len, c_str);
+bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *const c_str) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && c_str);
+    bool rval = aws_array_eq_c_str(buf->buffer, buf->len, c_str);
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    return rval;
 }
 
-bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *buf, const char *c_str) {
-    AWS_ASSERT(buf && c_str);
-    return aws_array_eq_c_str_ignore_case(buf->buffer, buf->len, c_str);
+bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *const buf, const char *const c_str) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && c_str);
+    bool rval = aws_array_eq_c_str_ignore_case(buf->buffer, buf->len, c_str);
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    return rval;
 }
 
 int aws_byte_buf_init_copy_from_cursor(

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -161,7 +161,6 @@ static int s_test_buffer_eq_fn(struct aws_allocator *allocator, void *ctx) {
     struct aws_byte_buf b2 = aws_byte_buf_from_c_str("testb");
 
     b1.capacity = 5;
-    b1_equal.capacity = 2;
     b1_equal.allocator = allocator;
 
     ASSERT_TRUE(aws_byte_buf_eq(&b1, &b1_equal));


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*
1. Updates implementation of `aws_byte_buf_eq*` functions with pre- and post-conditions;
2. Adds proof harnesses for `aws_byte_buf_eq*` functions;
3. Fix test case `test_buffer_eq`;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
