### PR TITLE
Adds proof harness for aws_byte_buf_write function

### DIFF
--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -18,6 +18,7 @@
 #include <aws/common/array_list.h>
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
@@ -26,7 +26,7 @@ DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 
-ENTRY = aws_byte_buf_init_copy_harness
+ENTRY = aws_byte_buf_write_harness
 ###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
@@ -14,15 +14,12 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
-
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
@@ -20,11 +20,9 @@ void aws_byte_buf_write_harness() {
     /* parameters */
     struct aws_byte_buf buf;
     size_t len;
-    __CPROVER_assume(len <= MAX_BUFFER_SIZE);
     uint8_t *array = can_fail_malloc(len);
 
     /* assumptions */
-    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 

--- a/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    size_t len;
+    uint8_t *array;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    __CPROVER_assume(len <= MAX_BUFFER_SIZE);
+    array = nondet_bool() ? NULL : bounded_malloc(len);
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* Nondeterministically use len or SIZE_MAX to check whether aws_byte_buf_write handles overflow */
+    if (aws_byte_buf_write(&buf, array, nondet_bool() ? len : SIZE_MAX)) {
+        assert(buf.len == old.len + len);
+        assert(old.capacity == buf.capacity);
+        assert(old.allocator == buf.allocator);
+        if (len > 0 && buf.len > 0) {
+            assert_bytes_match(buf.buffer + old.len, array, len);
+        }
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_byte_buf_write_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -802,14 +802,17 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
     struct aws_byte_buf *AWS_RESTRICT buf,
     const uint8_t *AWS_RESTRICT src,
     size_t len) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && AWS_MEM_IS_WRITABLE(src, len));
 
     if (buf->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || buf->len + len > buf->capacity) {
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
         return false;
     }
 
     memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return true;
 }
 

--- a/tests/cursor_test.c
+++ b/tests/cursor_test.c
@@ -223,7 +223,7 @@ static int s_byte_cursor_limit_tests_fn(struct aws_allocator *allocator, void *c
     ASSERT_UINT_EQUALS(0, arr[1]);
 
     cur.len = 0;
-    buffer.capacity = 0;
+    aws_byte_buf_clean_up(&buffer);
     ASSERT_FALSE(aws_byte_cursor_read_u8(&cur, &u8));
     ASSERT_UINT_EQUALS(0, u8);
     ASSERT_FALSE(aws_byte_buf_write_u8(&buffer, 0));


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*
1. Updates implementation of `aws_byte_buf_write` function with pre- and post-conditions;
2. Adds a proof harness for `aws_byte_buf_write` function;
3. Updates the `byte_cursor_limit_tests` test to use a valid `aws_byte_buf` structure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
