### PR TITLE
Adds proof harnesses for aws_byte_buf_write* functions

### DIFF
--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -18,6 +18,7 @@
 #include <aws/common/array_list.h>
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -73,9 +73,19 @@ void assert_array_list_equivalence(
  * it is necessary to select a non-deterministic byte from the rhs aws_byte_buf structure
  * (use save_byte_from_array function), so it can properly assert all bytes match.
  */
-void assert_byte_buf_equivalence(
+void assert_byte_cursor_equivalence(
     const struct aws_byte_buf *const lhs,
     const struct aws_byte_buf *const rhs,
+    const struct store_byte_from_buffer *const rhs_byte);
+
+/**
+ * Asserts two aws_byte_cursor structures are equivalent. Prior to using this function,
+ * it is necessary to select a non-deterministic byte from the rhs aws_byte_cursor structure
+ * (use save_byte_from_array function), so it can properly assert all bytes match.
+ */
+void assert_byte_buf_equivalence(
+    const struct aws_byte_cursor *const lhs,
+    const struct aws_byte_cursor *const rhs,
     const struct store_byte_from_buffer *const rhs_byte);
 
 /**

--- a/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
@@ -26,7 +26,7 @@ DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 
-ENTRY = aws_byte_buf_init_copy_harness
+ENTRY = aws_byte_buf_write_harness
 ###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/Makefile
@@ -14,15 +14,12 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
-
 CBMCFLAGS +=
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
@@ -20,11 +20,9 @@ void aws_byte_buf_write_harness() {
     /* parameters */
     struct aws_byte_buf buf;
     size_t len;
-    __CPROVER_assume(len <= MAX_BUFFER_SIZE);
     uint8_t *array = can_fail_malloc(len);
 
     /* assumptions */
-    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 

--- a/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    size_t len;
+    uint8_t *array;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    __CPROVER_assume(len <= MAX_BUFFER_SIZE);
+    array = nondet_bool() ? NULL : bounded_malloc(len);
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* Nondeterministically use len or SIZE_MAX to check whether aws_byte_buf_write handles overflow */
+    if (aws_byte_buf_write(&buf, array, nondet_bool() ? len : SIZE_MAX)) {
+        assert(buf.len == old.len + len);
+        assert(old.capacity == buf.capacity);
+        assert(old.allocator == buf.allocator);
+        if (len > 0 && buf.len > 0) {
+            assert_bytes_match(buf.buffer + old.len, array, len);
+        }
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_byte_buf_write_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be16/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be16/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_write_be16_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be16/aws_byte_buf_write_be16_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be16/aws_byte_buf_write_be16_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_be16_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    uint16_t x;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    if (aws_byte_buf_write_be16(&buf, x)) {
+        assert(buf.len == old.len + 2);
+        assert(old.capacity == buf.capacity);
+        assert(old.allocator == buf.allocator);
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be16/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_be16_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be32/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be32/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_write_be32_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be32/aws_byte_buf_write_be32_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be32/aws_byte_buf_write_be32_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_be32_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    uint32_t x;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    if (aws_byte_buf_write_be32(&buf, x)) {
+        assert(buf.len == old.len + 4);
+        assert(old.capacity == buf.capacity);
+        assert(old.allocator == buf.allocator);
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be32/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be32/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_be32_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be64/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be64/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_write_be64_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be64/aws_byte_buf_write_be64_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be64/aws_byte_buf_write_be64_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_be64_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    uint64_t x;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    if (aws_byte_buf_write_be64(&buf, x)) {
+        assert(buf.len == old.len + 8);
+        assert(old.capacity == buf.capacity);
+        assert(old.allocator == buf.allocator);
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write_be64/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_be64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_be64_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_buffer/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_buffer/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_write_from_whole_buffer_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_buffer/aws_byte_buf_write_from_whole_buffer_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_buffer/aws_byte_buf_write_from_whole_buffer_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_from_whole_buffer_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    struct aws_byte_buf src;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&src, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&src);
+    __CPROVER_assume(aws_byte_buf_is_valid(&src));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf buf_old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+    struct aws_byte_buf src_old = src;
+    struct store_byte_from_buffer old_byte_from_src;
+    save_byte_from_array(src.buffer, src.len, &old_byte_from_src);
+
+    /* operation under verification */
+    if (aws_byte_buf_write_from_whole_buffer(&buf, src)) {
+        assert(buf.len == buf_old.len + src.len);
+        assert(buf_old.capacity == buf.capacity);
+        assert(buf_old.allocator == buf.allocator);
+        if (src.len > 0 && buf.len > 0) {
+            assert_bytes_match(buf.buffer + buf_old.len, src.buffer, src.len);
+        }
+    } else {
+        assert_byte_buf_equivalence(&buf, &buf_old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(aws_byte_buf_is_valid(&src));
+    assert_byte_buf_equivalence(&src, &src_old, &old_byte_from_src);
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_buffer/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_buffer/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_from_whole_buffer_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_write_from_whole_cursor_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/aws_byte_buf_write_from_whole_cursor_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/aws_byte_buf_write_from_whole_cursor_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_from_whole_cursor_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    struct aws_byte_cursor src;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&src, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&src);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&src));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf buf_old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+    struct aws_byte_cursor src_old = src;
+    struct store_byte_from_buffer old_byte_from_src;
+    save_byte_from_array(src.ptr, src.len, &old_byte_from_src);
+
+    /* operation under verification */
+    if (aws_byte_buf_write_from_whole_cursor(&buf, src)) {
+        assert(buf.len == buf_old.len + src.len);
+        assert(buf_old.capacity == buf.capacity);
+        assert(buf_old.allocator == buf.allocator);
+        if (src.len > 0 && buf.len > 0) {
+            assert_bytes_match(buf.buffer + buf_old.len, src.ptr, src.len);
+        }
+    } else {
+        assert_byte_buf_equivalence(&buf, &buf_old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(aws_byte_cursor_is_valid(&src));
+    assert_byte_cursor_equivalence(&src, &src_old, &old_byte_from_src);
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_from_whole_cursor_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_buf_write_u8/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_u8/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_write_u8_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_write_u8/aws_byte_buf_write_u8_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_u8/aws_byte_buf_write_u8_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_write_u8_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    uint8_t x;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    if (aws_byte_buf_write_u8(&buf, x)) {
+        assert(buf.len == old.len + 1);
+        assert(old.capacity == buf.capacity);
+        assert(old.allocator == buf.allocator);
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    }
+
+    assert(aws_byte_buf_is_valid(&buf));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_write_u8/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_u8/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:11;--object-bits;8"
+goto: aws_byte_buf_write_u8_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -88,6 +88,19 @@ void assert_byte_buf_equivalence(
     }
 }
 
+void assert_byte_cursor_equivalence(
+    const struct aws_byte_cursor *const lhs,
+    const struct aws_byte_cursor *const rhs,
+    const struct store_byte_from_buffer *const rhs_byte) {
+    assert(!lhs == !rhs);
+    if (lhs && rhs) {
+        assert(lhs->len == rhs->len);
+        if (lhs->len > 0) {
+            assert_byte_from_buffer_matches(lhs->ptr, rhs_byte);
+        }
+    }
+}
+
 void save_byte_from_hash_table(const struct aws_hash_table *map, struct store_byte_from_buffer *storage) {
     struct hash_table_state *state = map->p_impl;
     size_t size_in_bytes;

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -802,14 +802,17 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
     struct aws_byte_buf *AWS_RESTRICT buf,
     const uint8_t *AWS_RESTRICT src,
     size_t len) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && AWS_MEM_IS_WRITABLE(src, len));
 
     if (buf->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || buf->len + len > buf->capacity) {
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
         return false;
     }
 
     memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return true;
 }
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -826,6 +826,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
 AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
     struct aws_byte_buf *AWS_RESTRICT buf,
     struct aws_byte_buf src) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && aws_byte_buf_is_valid(&src));
     return aws_byte_buf_write(buf, src.buffer, src.len);
 }
 
@@ -839,6 +840,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
 AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
     struct aws_byte_buf *AWS_RESTRICT buf,
     struct aws_byte_cursor src) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && aws_byte_cursor_is_valid(&src));
     return aws_byte_buf_write(buf, src.ptr, src.len);
 }
 
@@ -852,6 +854,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
  cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf, uint8_t c) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     return aws_byte_buf_write(buf, &c, 1);
 }
 
@@ -863,6 +866,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     x = aws_hton16(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 2);
 }
@@ -875,6 +879,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t 
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     x = aws_hton32(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
 }
@@ -887,6 +892,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t 
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     x = aws_hton64(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
 }

--- a/tests/cursor_test.c
+++ b/tests/cursor_test.c
@@ -231,7 +231,7 @@ static int s_byte_cursor_limit_tests_fn(struct aws_allocator *allocator, void *c
 
     ASSERT_TRUE(aws_byte_cursor_read(&cur, arr, 0));
     ASSERT_TRUE(aws_byte_buf_write(&buffer, arr, 0));
-    arrbuf.capacity = 0;
+    aws_byte_buf_clean_up(&arrbuf);
     ASSERT_TRUE(aws_byte_cursor_read_and_fill_buffer(&cur, &arrbuf));
     ASSERT_TRUE(aws_byte_buf_write_from_whole_buffer(&buffer, arrbuf));
     ASSERT_UINT_EQUALS(0, arr[0]);

--- a/tests/cursor_test.c
+++ b/tests/cursor_test.c
@@ -223,7 +223,7 @@ static int s_byte_cursor_limit_tests_fn(struct aws_allocator *allocator, void *c
     ASSERT_UINT_EQUALS(0, arr[1]);
 
     cur.len = 0;
-    buffer.capacity = 0;
+    aws_byte_buf_clean_up(&buffer);
     ASSERT_FALSE(aws_byte_cursor_read_u8(&cur, &u8));
     ASSERT_UINT_EQUALS(0, u8);
     ASSERT_FALSE(aws_byte_buf_write_u8(&buffer, 0));


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*
1. Updates implementation of `aws_byte_buf_write*` functions with pre- and post-conditions;
2. Adds proof harnesses for `aws_byte_buf_write*` functions;
3. Fix test case `byte_cursor_limit_tests`;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
