### PR TITLE
Adds proof harness for aws_byte_buf_advance function

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_buf_advance/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_advance/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+MAX_BUFFER_SIZE=40
+
+# This bound allows us to reach 100% coverage rate
+UNWINDSET += memset_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memset_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_buf_advance_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_buf_advance/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_buf_advance/Makefile
@@ -14,6 +14,7 @@
 ###########
 include ../Makefile.aws_byte_buf
 
+# Required to cover the size of aws_byte_buf structure
 MAX_BUFFER_SIZE=40
 
 # This bound allows us to reach 100% coverage rate

--- a/.cbmc-batch/jobs/aws_byte_buf_advance/aws_byte_buf_advance_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_advance/aws_byte_buf_advance_harness.c
@@ -26,9 +26,13 @@ void aws_byte_buf_advance_harness() {
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    __CPROVER_assume(aws_byte_buf_is_bounded(&output, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&output);
-    __CPROVER_assume(aws_byte_buf_is_valid(&output));
+    if (nondet_bool()) {
+        output = buf;
+    } else {
+        __CPROVER_assume(aws_byte_buf_is_bounded(&output, MAX_BUFFER_SIZE));
+        ensure_byte_buf_has_allocated_buffer_member(&output);
+        __CPROVER_assume(aws_byte_buf_is_valid(&output));
+    }
 
     /* save current state of the parameters */
     struct aws_byte_buf old = buf;
@@ -36,7 +40,7 @@ void aws_byte_buf_advance_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    if (aws_byte_buf_advance(&buf, &output, len)) {
+    if (aws_byte_buf_advance((nondet_bool() ? &buf : NULL), (nondet_bool() ? &output : NULL), len)) {
         assert(buf.len == old.len + len);
         assert(buf.capacity == old.capacity);
         assert(buf.allocator == old.allocator);

--- a/.cbmc-batch/jobs/aws_byte_buf_advance/aws_byte_buf_advance_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_advance/aws_byte_buf_advance_harness.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_advance_harness() {
+    /* parameters */
+    struct aws_byte_buf buf;
+    struct aws_byte_buf output;
+    size_t len;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+    __CPROVER_assume(aws_byte_buf_is_bounded(&output, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&output);
+    __CPROVER_assume(aws_byte_buf_is_valid(&output));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    if (aws_byte_buf_advance(&buf, &output, len)) {
+        assert(buf.len == old.len + len);
+        assert(buf.capacity == old.capacity);
+        assert(buf.allocator == old.allocator);
+        if (old.len > 0) {
+            assert_byte_from_buffer_matches(buf.buffer, &old_byte_from_buf);
+        }
+        assert(output.len == 0);
+        assert(output.capacity == len);
+        assert(output.allocator == NULL);
+    } else {
+        assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+        assert(output.len == 0);
+        assert(output.capacity == 0);
+        assert(output.allocator == NULL);
+        assert(output.buffer == NULL);
+    }
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(aws_byte_buf_is_valid(&output));
+}

--- a/.cbmc-batch/jobs/aws_byte_buf_advance/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_buf_advance/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_impl.0:41;--object-bits;8"
+goto: aws_byte_buf_advance_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -777,9 +777,9 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_be64(struct aws_byte_cursor *cur, uint
  * false.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_advance(
-    struct aws_byte_buf *AWS_RESTRICT buffer,
-    struct aws_byte_buf *AWS_RESTRICT output,
-    size_t len) {
+    struct aws_byte_buf *const AWS_RESTRICT buffer,
+    struct aws_byte_buf *const AWS_RESTRICT output,
+    const size_t len) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
     if (buffer->capacity - buffer->len >= len) {
         *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -780,13 +780,16 @@ AWS_STATIC_IMPL bool aws_byte_buf_advance(
     struct aws_byte_buf *AWS_RESTRICT buffer,
     struct aws_byte_buf *AWS_RESTRICT output,
     size_t len) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
     if (buffer->capacity - buffer->len >= len) {
         *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
         buffer->len += len;
         output->len = 0;
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
         return true;
     } else {
         AWS_ZERO_STRUCT(*output);
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
         return false;
     }
 }

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -233,11 +233,10 @@ static int s_test_buffer_advance(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
 
     uint8_t arr[16];
-    struct aws_byte_buf src_buf = aws_byte_buf_from_array(arr, sizeof(arr));
+    struct aws_byte_buf src_buf = aws_byte_buf_from_empty_array(arr, sizeof(arr));
 
-    struct aws_byte_buf dst_buf;
+    struct aws_byte_buf dst_buf = {.len = 0};
 
-    src_buf.len = 0;
     ASSERT_TRUE(aws_byte_buf_advance(&src_buf, &dst_buf, 4));
     ASSERT_NULL(dst_buf.allocator);
     ASSERT_INT_EQUALS(src_buf.len, 4);

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -235,7 +235,7 @@ static int s_test_buffer_advance(struct aws_allocator *allocator, void *ctx) {
     uint8_t arr[16];
     struct aws_byte_buf src_buf = aws_byte_buf_from_empty_array(arr, sizeof(arr));
 
-    struct aws_byte_buf dst_buf = {.len = 0};
+    struct aws_byte_buf dst_buf = {0};
 
     ASSERT_TRUE(aws_byte_buf_advance(&src_buf, &dst_buf, 4));
     ASSERT_NULL(dst_buf.allocator);


### PR DESCRIPTION
*Description of changes:*
1. Updates implementation of `aws_byte_buf_advance` function with pre- and post-conditions;
2. Adds a proof harness for `aws_byte_buf_advance` function;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
