### PR TITLE
Calloc is now fixed in CBMC, so use it. 

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -86,6 +86,7 @@ DEFAULT_REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
 ################################################################
 
 REMOVE_FUNCTION_BODY ?= $(DEFAULT_REMOVE_FUNCTION_BODY)
+REMOVE_FUNCTION_BODY += $(ADDITIONAL_REMOVE_FUNCTION_BODY)
 
 # Here, whenever there is a change in any of ANSI-C source
 # dependency files, make will take action. However, to make

--- a/.cbmc-batch/jobs/aws_hash_table_init-bounded/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_init-bounded/Makefile
@@ -12,25 +12,21 @@
 # limitations under the License.
 
 ###########
-# Sufficient for coverage for bounded inputs
-# Additional coverage is given using the -unbounded version of this proof
-# 4 - 1 min
-# 8 - 2 min
-# 12 - 6 min
-MAX_TABLE_SIZE ?= 8
+# Using the new calloc model, get full coverage in about 5s on unbounded sizes!
+MAX_TABLE_SIZE ?= SIZE_MAX
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
-
-#The hash table struct itself is 80 bytes, which is 10 iters 
-#A hash entry is 24 bytes, which is 10 iters. So we need 3 * MAX_TABLE_SIZE + 10 + 1
-UNWINDSET += memset_override_0_impl.0:$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 11)))
 
 DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memset_override_0.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body bounded_malloc
+ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body can_fail_malloc
+ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
+ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body s_can_fail_malloc_allocator
 
 ENTRY = aws_hash_table_init_bounded_harness
 ###########

--- a/.cbmc-batch/jobs/aws_hash_table_init-bounded/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_init-bounded/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memset_override_0_impl.0:35;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_hash_table_init_bounded_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -55,11 +55,8 @@ static void *s_can_fail_realloc_allocator(struct aws_allocator *allocator, void 
 static struct aws_allocator s_can_fail_allocator_static = {
     .mem_acquire = s_can_fail_malloc_allocator,
     .mem_release = s_can_fail_free_allocator,
-    .mem_realloc = nondet_bool() ? NULL : s_can_fail_realloc_allocator,
-    /* define .mem_calloc once the following issues are fixed in CBMC. Until then, use the fallback.
-     * https://github.com/diffblue/cbmc/issues/4603
-     * https://github.com/diffblue/cbmc/issues/4602
-     */
+    .mem_realloc = s_can_fail_realloc_allocator,
+    .mem_calloc = s_can_fail_calloc_allocator,
 };
 
 void *bounded_calloc(size_t num, size_t size) {


### PR DESCRIPTION
*Description of changes:*
* Use calloc from CBMC
* Fix up the aws_hash_table_init proof: now runs in seconds instead of minutes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
