### PR TITLE
 Adds proof harnesses for aws_byte_cursor_from_* functions 

### DIFF
--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -18,6 +18,7 @@
 #include <aws/common/array_list.h>
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
@@ -19,10 +19,7 @@
 void aws_byte_buf_from_array_harness() {
     /* parameters */
     size_t length;
-    uint8_t *array;
-
-    /* assumptions */
-    ASSUME_VALID_MEMORY_COUNT(array, length);
+    uint8_t *array = can_fail_malloc(length);
 
     /* operation under verification */
     struct aws_byte_buf buf = aws_byte_buf_from_array(array, length);

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_array/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_array/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_from_array_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_cursor_from_array_harness() {
+    /* parameters */
+    size_t length;
+    uint8_t *array;
+
+    /* assumptions */
+    __CPROVER_assume(length < MAX_MALLOC); /* we need bound length to avoid suspious integer overflows */
+    if (nondet_bool()) {
+        ASSUME_VALID_MEMORY_COUNT(array, length);
+    } else {
+        if (nondet_bool()) {
+            __CPROVER_assume(array == NULL);
+        } else {
+            ASSUME_VALID_MEMORY_COUNT(array, nondet_size_t());
+        }
+    }
+
+    /* operation under verification */
+    struct aws_byte_cursor cur = aws_byte_cursor_from_array(array, length);
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    assert(cur.len == length);
+    if (cur.ptr) {
+        assert_bytes_match(cur.ptr, array, cur.len);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
@@ -19,19 +19,7 @@
 void aws_byte_cursor_from_array_harness() {
     /* parameters */
     size_t length;
-    uint8_t *array;
-
-    /* assumptions */
-    __CPROVER_assume(length < MAX_MALLOC); /* we need bound length to avoid suspious integer overflows */
-    if (nondet_bool()) {
-        ASSUME_VALID_MEMORY_COUNT(array, length);
-    } else {
-        if (nondet_bool()) {
-            __CPROVER_assume(array == NULL);
-        } else {
-            ASSUME_VALID_MEMORY_COUNT(array, nondet_size_t());
-        }
-    }
+    uint8_t *array = can_fail_malloc(length);
 
     /* operation under verification */
     struct aws_byte_cursor cur = aws_byte_cursor_from_array(array, length);

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_array/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_array/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_from_array_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_buf/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_buf/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_from_buf_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_buf/aws_byte_cursor_from_buf_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_buf/aws_byte_cursor_from_buf_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_cursor_from_buf_harness() {
+    /* parameter */
+    struct aws_byte_buf buf;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* save current state of the parameters */
+    struct aws_byte_buf old = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    struct aws_byte_cursor cur = aws_byte_cursor_from_buf(&buf);
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(aws_byte_cursor_is_valid(&cur));
+    assert_byte_buf_equivalence(&buf, &old, &old_byte_from_buf);
+    assert(cur.len == buf.len);
+    if (cur.ptr) {
+        assert_bytes_match(cur.ptr, buf.buffer, buf.len);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_buf/aws_byte_cursor_from_buf_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_buf/aws_byte_cursor_from_buf_harness.c
@@ -31,7 +31,7 @@ void aws_byte_cursor_from_buf_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    struct aws_byte_cursor cur = aws_byte_cursor_from_buf(&buf);
+    struct aws_byte_cursor cur = aws_byte_cursor_from_buf(nondet_bool() ? &buf : NULL);
 
     /* assertions */
     assert(aws_byte_buf_is_valid(&buf));

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_buf/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_buf/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_from_buf_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += strlen.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_from_c_str_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/aws_byte_cursor_from_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/aws_byte_cursor_from_c_str_harness.c
@@ -25,7 +25,7 @@ void aws_byte_cursor_from_c_str_harness() {
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));
-    if (cur.ptr) {
+    if (cur.ptr) { /* if ptr is NULL len shoud be 0, otherwise equal to c_str */
         assert(cur.len == strlen(c_str));
         assert_bytes_match(cur.ptr, (uint8_t *)c_str, cur.len);
     } else {

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/aws_byte_cursor_from_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/aws_byte_cursor_from_c_str_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_cursor_from_c_str_harness() {
+    /* parameters */
+    const char *c_str = nondet_bool() ? NULL : make_arbitrary_c_str(MAX_BUFFER_SIZE);
+
+    /* operation under verification */
+    struct aws_byte_cursor cur = aws_byte_cursor_from_c_str(c_str);
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    if (cur.ptr) {
+        assert(cur.len == strlen(c_str));
+        assert_bytes_match(cur.ptr, (uint8_t *)c_str, cur.len);
+    } else {
+        assert(cur.len == 0);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_c_str/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strlen.0:11;--object-bits;8"
+goto: aws_byte_cursor_from_c_str_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -20,7 +20,7 @@ void assert_bytes_match(const uint8_t *const a, const uint8_t *const b, const si
     assert(!a == !b);
     if (len > 0 && a != NULL && b != NULL) {
         size_t i;
-        __CPROVER_assume(i < len);
+        __CPROVER_assume(i < len && len < MAX_MALLOC); /* prevent spurious pointer overflows */
         assert(a[i] == b[i]);
     }
 }

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -506,24 +506,29 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *by
     return buf;
 }
 
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *buf) {
+AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     struct aws_byte_cursor cur;
     cur.ptr = buf->buffer;
     cur.len = buf->len;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
     return cur;
 }
 
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str) {
-    struct aws_byte_cursor cursor;
-    cursor.ptr = (uint8_t *)c_str;
-    cursor.len = strlen(c_str);
-    return cursor;
+    struct aws_byte_cursor cur;
+    cur.ptr = (uint8_t *)c_str;
+    cur.len = (cur.ptr) ? strlen(c_str) : 0;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    return cur;
 }
 
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *bytes, size_t len) {
+AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len) {
+    AWS_PRECONDITION(len == 0 || AWS_MEM_IS_READABLE(bytes, len));
     struct aws_byte_cursor cur;
     cur.ptr = (uint8_t *)bytes;
     cur.len = len;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
     return cur;
 }
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -71,7 +71,7 @@ bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf) {
 
 bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor) {
     return cursor &&
-           ((cursor->len == 0) || (cursor->len > 0 && cursor->ptr && AWS_MEM_IS_WRITABLE(cursor->ptr, cursor->len)));
+           ((cursor->len == 0) || (cursor->len > 0 && cursor->ptr && AWS_MEM_IS_READABLE(cursor->ptr, cursor->len)));
 }
 
 void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents) {


### PR DESCRIPTION
*Description of changes:*
1. Updates implementation of `aws_byte_cursor_from_*` functions with pre- and post-conditions;
2. Adds proof harnesses for `aws_byte_cursor_from_*` functions;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
