### PR TITLE
Redefine AWS_PRECONDITION and add an explanation to all preconditions

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
@@ -28,16 +28,20 @@ void aws_array_list_back_harness() {
     __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
     ensure_array_list_has_allocated_data_member(&list);
     __CPROVER_assume(aws_array_list_is_valid(&list));
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
+    /* assume preconditions */
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+    __CPROVER_assume(val && AWS_MEM_IS_WRITABLE(val, list.item_size));
+
     /* perform operation under verification */
-    size_t malloc_size;
-    __CPROVER_assume(malloc_size <= list.item_size);
-    void *val = can_fail_malloc(malloc_size);
     if (aws_array_list_back(&list, val) == AWS_OP_SUCCESS) {
         /* In the case aws_array_list_back is successful, we can ensure the list isn't empty */
         assert(list.data != NULL);

--- a/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
@@ -27,16 +27,20 @@ void aws_array_list_front_harness() {
     __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
     ensure_array_list_has_allocated_data_member(&list);
     __CPROVER_assume(aws_array_list_is_valid(&list));
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
+    /* assume preconditions */
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+    __CPROVER_assume(val && AWS_MEM_IS_WRITABLE(val, list.item_size));
+
     /* perform operation under verification */
-    size_t malloc_size;
-    __CPROVER_assume(malloc_size <= list.item_size);
-    void *val = can_fail_malloc(malloc_size);
     if (!aws_array_list_front(&list, val)) {
         /* In the case aws_array_list_front is successful, we can ensure the list isn't empty */
         assert(list.data);

--- a/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
@@ -27,17 +27,21 @@ void aws_array_list_get_at_harness() {
     __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
     ensure_array_list_has_allocated_data_member(&list);
     __CPROVER_assume(aws_array_list_is_valid(&list));
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
+    size_t index;
 
     /* save current state of the data structure */
     struct aws_array_list old = list;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
+    /* assume preconditions */
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+    __CPROVER_assume(val && AWS_MEM_IS_WRITABLE(val, list.item_size));
+
     /* perform operation under verification */
-    size_t malloc_size;
-    __CPROVER_assume(malloc_size <= list.item_size);
-    void *val = can_fail_malloc(malloc_size);
-    size_t index;
     if (!aws_array_list_get_at(&list, val, index)) {
         /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
          * and index is within bounds.

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
@@ -27,15 +27,19 @@ void aws_array_list_get_at_ptr_harness() {
     __CPROVER_assume(aws_array_list_is_bounded(&list, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
     ensure_array_list_has_allocated_data_member(&list);
     __CPROVER_assume(aws_array_list_is_valid(&list));
+    void **val = can_fail_malloc(sizeof(void *));
+    size_t index;
 
     /* save current state of the data structure */
     struct aws_array_list old = list;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
+    /* assume preconditions */
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+    __CPROVER_assume(val);
+
     /* perform operation under verification */
-    void **val = can_fail_malloc(sizeof(void *));
-    size_t index;
     if (!aws_array_list_get_at_ptr(&list, val, index)) {
         /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
          * and index is within bounds.

--- a/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
@@ -28,16 +28,20 @@ void aws_array_list_push_back_harness() {
     ensure_array_list_has_allocated_data_member(&list);
     __CPROVER_assume(aws_array_list_is_valid(&list));
     __CPROVER_assume(list.data != NULL);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
 
     /* save current state of the data structure */
     struct aws_array_list old = list;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
+    /* assume preconditions */
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+    __CPROVER_assume(val && AWS_MEM_IS_READABLE(val, list.item_size));
+
     /* perform operation under verification and assertions */
-    size_t malloc_size;
-    __CPROVER_assume(malloc_size <= list.item_size);
-    void *val = can_fail_malloc(malloc_size);
     if (!aws_array_list_push_back(&list, val)) {
         assert(list.length == old.length + 1);
     } else {

--- a/.cbmc-batch/jobs/aws_array_list_set_at/aws_array_list_set_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/aws_array_list_set_at_harness.c
@@ -28,17 +28,21 @@ void aws_array_list_set_at_harness() {
     ensure_array_list_has_allocated_data_member(&list);
     __CPROVER_assume(aws_array_list_is_valid(&list));
     __CPROVER_assume(list.data != NULL);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
+    size_t index;
 
     /* save current state of the data structure */
     struct aws_array_list old = list;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
+    /* assume preconditions */
+    __CPROVER_assume(aws_array_list_is_valid(&list));
+    __CPROVER_assume(val && AWS_MEM_IS_READABLE(val, list.item_size));
+
     /* perform operation under verification and assertions */
-    size_t malloc_size;
-    __CPROVER_assume(malloc_size <= list.item_size);
-    void *val = can_fail_malloc(malloc_size);
-    size_t index;
     if (!aws_array_list_set_at(&list, val, index)) {
         if (index > old.length)
             assert(list.length == index + 1);

--- a/.cbmc-batch/jobs/aws_byte_buf_advance/aws_byte_buf_advance_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_advance/aws_byte_buf_advance_harness.c
@@ -40,7 +40,7 @@ void aws_byte_buf_advance_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    if (aws_byte_buf_advance((nondet_bool() ? &buf : NULL), (nondet_bool() ? &output : NULL), len)) {
+    if (aws_byte_buf_advance(&buf, &output, len)) {
         assert(buf.len == old.len + len);
         assert(buf.capacity == old.capacity);
         assert(buf.allocator == old.allocator);

--- a/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
@@ -19,7 +19,7 @@
 void aws_byte_buf_from_array_harness() {
     /* parameters */
     size_t length;
-    uint8_t *array = can_fail_malloc(length);
+    uint8_t *array = bounded_malloc(length);
 
     /* operation under verification */
     struct aws_byte_buf buf = aws_byte_buf_from_array(array, length);

--- a/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write/aws_byte_buf_write_harness.c
@@ -20,7 +20,7 @@ void aws_byte_buf_write_harness() {
     /* parameters */
     struct aws_byte_buf buf;
     size_t len;
-    uint8_t *array = can_fail_malloc(len);
+    uint8_t *array = bounded_malloc(len);
 
     /* assumptions */
     ensure_byte_buf_has_allocated_buffer_member(&buf);
@@ -31,7 +31,7 @@ void aws_byte_buf_write_harness() {
     struct store_byte_from_buffer old_byte_from_buf;
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
-    if (aws_byte_buf_write((nondet_bool() ? &buf : NULL), array, len)) {
+    if (aws_byte_buf_write(&buf, array, len)) {
         assert(buf.len == old.len + len);
         assert(old.capacity == buf.capacity);
         assert(old.allocator == buf.allocator);

--- a/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/aws_byte_buf_write_from_whole_cursor_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_write_from_whole_cursor/aws_byte_buf_write_from_whole_cursor_harness.c
@@ -28,6 +28,7 @@ void aws_byte_buf_write_from_whole_cursor_harness() {
     __CPROVER_assume(aws_byte_cursor_is_bounded(&src, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&src);
     __CPROVER_assume(aws_byte_cursor_is_valid(&src));
+    __CPROVER_assume(AWS_MEM_IS_WRITABLE(src.ptr, src.len));
 
     /* save current state of the parameters */
     struct aws_byte_buf buf_old = buf;

--- a/.cbmc-batch/jobs/aws_byte_cursor_eq/aws_byte_cursor_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_eq/aws_byte_cursor_eq_harness.c
@@ -43,7 +43,7 @@ void aws_byte_cursor_eq_harness() {
     save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_cursor_eq((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL))) {
+    if (aws_byte_cursor_eq(&lhs, &rhs)) {
         assert(lhs.len == rhs.len);
         if (lhs.len > 0) {
             assert_bytes_match(lhs.ptr, rhs.ptr, lhs.len);

--- a/.cbmc-batch/jobs/aws_byte_cursor_eq_byte_buf/aws_byte_cursor_eq_byte_buf_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_eq_byte_buf/aws_byte_cursor_eq_byte_buf_harness.c
@@ -39,7 +39,7 @@ void aws_byte_cursor_eq_byte_buf_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    if (aws_byte_cursor_eq_byte_buf((nondet_bool() ? &cur : NULL), (nondet_bool() ? &buf : NULL))) {
+    if (aws_byte_cursor_eq_byte_buf(&cur, &buf)) {
         assert(cur.len == buf.len);
         if (cur.len > 0) {
             assert_bytes_match(cur.ptr, buf.buffer, cur.len);

--- a/.cbmc-batch/jobs/aws_byte_cursor_eq_byte_buf_ignore_case/aws_byte_cursor_eq_byte_buf_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_eq_byte_buf_ignore_case/aws_byte_cursor_eq_byte_buf_ignore_case_harness.c
@@ -39,7 +39,7 @@ void aws_byte_cursor_eq_byte_buf_ignore_case_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    if (aws_byte_cursor_eq_byte_buf_ignore_case((nondet_bool() ? &cur : NULL), (nondet_bool() ? &buf : NULL))) {
+    if (aws_byte_cursor_eq_byte_buf_ignore_case(&cur, &buf)) {
         assert(cur.len == buf.len);
     }
 

--- a/.cbmc-batch/jobs/aws_byte_cursor_eq_c_str/aws_byte_cursor_eq_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_eq_c_str/aws_byte_cursor_eq_c_str_harness.c
@@ -20,7 +20,7 @@
 void aws_byte_cursor_eq_c_str_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
-    const char *c_str = nondet_bool() ? NULL : make_arbitrary_c_str(MAX_BUFFER_SIZE);
+    const char *c_str = make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* assumptions */
     __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
@@ -36,7 +36,7 @@ void aws_byte_cursor_eq_c_str_harness() {
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 
     /* operation under verification */
-    if (aws_byte_cursor_eq_c_str((nondet_bool() ? NULL : &cur), c_str)) {
+    if (aws_byte_cursor_eq_c_str(&cur, c_str)) {
         assert(cur.len == str_len);
         if (cur.len > 0) {
             assert_bytes_match(cur.ptr, (uint8_t *)c_str, cur.len);

--- a/.cbmc-batch/jobs/aws_byte_cursor_eq_c_str_ignore_case/aws_byte_cursor_eq_c_str_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_eq_c_str_ignore_case/aws_byte_cursor_eq_c_str_ignore_case_harness.c
@@ -20,7 +20,7 @@
 void aws_byte_cursor_eq_c_str_ignore_case_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
-    const char *c_str = nondet_bool() ? NULL : make_arbitrary_c_str(MAX_BUFFER_SIZE);
+    const char *c_str = make_arbitrary_c_str(MAX_BUFFER_SIZE);
 
     /* assumptions */
     __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
@@ -36,7 +36,7 @@ void aws_byte_cursor_eq_c_str_ignore_case_harness() {
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 
     /* operation under verification */
-    if (aws_byte_cursor_eq_c_str_ignore_case((nondet_bool() ? NULL : &cur), c_str)) {
+    if (aws_byte_cursor_eq_c_str_ignore_case(&cur, c_str)) {
         assert(cur.len == str_len);
     }
 

--- a/.cbmc-batch/jobs/aws_byte_cursor_eq_ignore_case/aws_byte_cursor_eq_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_eq_ignore_case/aws_byte_cursor_eq_ignore_case_harness.c
@@ -43,7 +43,7 @@ void aws_byte_cursor_eq_ignore_case_harness() {
     save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_cursor_eq_ignore_case((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL))) {
+    if (aws_byte_cursor_eq_ignore_case(&lhs, &rhs)) {
         assert(lhs.len == rhs.len);
     }
 

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
@@ -19,7 +19,7 @@
 void aws_byte_cursor_from_array_harness() {
     /* parameters */
     size_t length;
-    uint8_t *array = can_fail_malloc(length);
+    uint8_t *array = bounded_malloc(length);
 
     /* operation under verification */
     struct aws_byte_cursor cur = aws_byte_cursor_from_array(array, length);

--- a/.cbmc-batch/jobs/aws_byte_cursor_from_buf/aws_byte_cursor_from_buf_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_from_buf/aws_byte_cursor_from_buf_harness.c
@@ -31,7 +31,7 @@ void aws_byte_cursor_from_buf_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    struct aws_byte_cursor cur = aws_byte_cursor_from_buf(nondet_bool() ? &buf : NULL);
+    struct aws_byte_cursor cur = aws_byte_cursor_from_buf(&buf);
 
     /* assertions */
     assert(aws_byte_buf_is_valid(&buf));

--- a/.cbmc-batch/jobs/aws_hash_iter_done/aws_hash_iter_done_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_iter_done/aws_hash_iter_done_harness.c
@@ -36,7 +36,7 @@ void aws_hash_iter_done_harness() {
     bool rval = aws_hash_iter_done(&iter);
 
     assert(aws_hash_iter_is_valid(&iter));
-    AWS_POSTCONDITION(rval == (iter.status == AWS_HASH_ITER_STATUS_DONE));
+    assert(rval == (iter.status == AWS_HASH_ITER_STATUS_DONE));
     assert(iter.status == old_status);
     assert(aws_hash_table_is_valid(&map));
     check_hash_table_unchanged(&map, &old_byte);

--- a/.cbmc-batch/jobs/aws_hash_table_eq/aws_hash_table_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_eq/aws_hash_table_eq_harness.c
@@ -36,6 +36,10 @@ void aws_hash_table_eq_harness() {
     struct store_byte_from_buffer old_byte_b;
     save_byte_from_hash_table(&map_b, &old_byte_b);
 
+    /* assume the preconditions */
+    __CPROVER_assume(aws_hash_table_is_valid(&map_a));
+    __CPROVER_assume(aws_hash_table_is_valid(&map_b));
+
     bool rval = aws_hash_table_eq(&map_a, &map_b, uninterpreted_equals_assert_inputs_nonnull);
 
     assert(aws_hash_table_is_valid(&map_a));

--- a/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
@@ -34,7 +34,12 @@ void aws_hash_table_find_harness() {
 
     void *key;
     struct aws_hash_element *p_elem;
-    int rval = aws_hash_table_find(&map, key, nondet_bool() ? &p_elem : NULL);
+
+    /* Preconditions */
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+    __CPROVER_assume(AWS_OBJECT_PTR_IS_WRITABLE(&p_elem));
+
+    int rval = aws_hash_table_find(&map, key, &p_elem);
     assert(rval == AWS_OP_SUCCESS);
     if (p_elem) {
         assert(AWS_OBJECT_PTR_IS_READABLE(p_elem));

--- a/.cbmc-batch/jobs/aws_hash_table_foreach/aws_hash_table_foreach_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_foreach/aws_hash_table_foreach_harness.c
@@ -20,7 +20,7 @@
 #include <proof_helpers/utils.h>
 
 int hash_table_foreach_proof_callback(void *context, struct aws_hash_element *pElement) {
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(pElement));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(pElement), "Input pointer [pElement] must be writable.");
     return nondet_int();
 }
 

--- a/.cbmc-batch/jobs/aws_hash_table_remove/aws_hash_table_remove_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_remove/aws_hash_table_remove_harness.c
@@ -32,7 +32,7 @@ void aws_hash_table_remove_harness() {
     size_t empty_slot_idx;
     __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
     void *key;
-    struct aws_hash_element *p_elem;
+    struct aws_hash_element p_elem;
     bool get_p_elem;
     bool track_was_present;
     int was_present;
@@ -55,8 +55,8 @@ void aws_hash_table_remove_harness() {
                 map.p_impl->entry_count == old_state.entry_count - 1);
         }
 
-        if (get_p_elem) {
-            assert(uninterpreted_equals(p_elem->key, key));
+        if (get_p_elem && track_was_present && was_present == 1) {
+            assert(uninterpreted_equals(p_elem.key, key));
         }
     } else {
         assert(map.p_impl->entry_count == old_state.entry_count);

--- a/.cbmc-batch/jobs/aws_hash_table_remove/aws_hash_table_remove_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_remove/aws_hash_table_remove_harness.c
@@ -39,6 +39,11 @@ void aws_hash_table_remove_harness() {
 
     struct hash_table_state old_state = *map.p_impl;
 
+    /* assume the preconditions */
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+    __CPROVER_assume(AWS_OBJECT_PTR_IS_WRITABLE(&p_elem));
+    __CPROVER_assume(AWS_OBJECT_PTR_IS_WRITABLE(&was_present));
+
     int rval = aws_hash_table_remove(&map, key, get_p_elem ? &p_elem : NULL, track_was_present ? &was_present : NULL);
     assert(aws_hash_table_is_valid(&map));
     if (rval == AWS_OP_SUCCESS) {

--- a/.cbmc-batch/stubs/aws_hash_iter_overrides.c
+++ b/.cbmc-batch/stubs/aws_hash_iter_overrides.c
@@ -13,7 +13,7 @@
  * times */
 struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     /* Leave it as non-det as possible */
-    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
     struct aws_hash_iter rval;
     rval.limit = map->p_impl->size;
     __CPROVER_assume(rval.slot <= rval.limit);
@@ -22,7 +22,9 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
 }
 
 bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
+    AWS_PRECONDITION(
+        iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
+        "Input aws_hash_iter [iter] status should either be done or ready to use.");
     bool rval = iter->slot == iter->limit;
     assert(rval == (iter->status == AWS_HASH_ITER_STATUS_DONE));
     return rval;

--- a/.cbmc-batch/stubs/aws_hash_table_find_override.c
+++ b/.cbmc-batch/stubs/aws_hash_table_find_override.c
@@ -11,8 +11,8 @@
 bool __CPROVER_file_local_hash_table_c_s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b);
 
 int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struct aws_hash_element **p_elem) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map));
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(p_elem));
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(p_elem), "Input pointer [p_elem] must be writable.");
 
     const struct hash_table_state *const state = map->p_impl;
     size_t i;
@@ -25,6 +25,6 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
         __CPROVER_assume(__CPROVER_file_local_hash_table_c_s_hash_keys_eq(state, key, entry->element.key));
         *p_elem = &entry->element;
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
     return AWS_OP_SUCCESS;
 }

--- a/.cbmc-batch/stubs/s_emplace_item_override.c
+++ b/.cbmc-batch/stubs/s_emplace_item_override.c
@@ -26,10 +26,10 @@ struct hash_table_entry *__CPROVER_file_local_hash_table_c_s_emplace_item(
     struct hash_table_state *state,
     struct hash_table_entry entry,
     size_t probe_idx) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state));
+    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
 
     if (entry.hash_code == 0) {
-        AWS_POSTCONDITION(hash_table_state_is_valid(state));
+        AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
         return NULL;
     }
 
@@ -39,6 +39,6 @@ struct hash_table_entry *__CPROVER_file_local_hash_table_c_s_emplace_item(
     state->slots[index] = entry;
     size_t empty_slot_idx;
     __CPROVER_assume(hash_table_state_has_an_empty_slot(state, &empty_slot_idx));
-    AWS_POSTCONDITION(hash_table_state_is_valid(state));
+    AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
     return &state->slots[index];
 }

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -91,7 +91,7 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (list->alloc && list->data) {
         aws_mem_release(list->alloc, list->data);
     }
@@ -106,7 +106,7 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
 
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
@@ -122,7 +122,7 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
 
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
@@ -136,7 +136,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -149,7 +149,7 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t n) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (n >= aws_array_list_length(list)) {
         aws_array_list_clear(list);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -171,7 +171,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
 
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
@@ -187,7 +187,7 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
 
         AWS_FATAL_ASSERT(list->data);
@@ -206,7 +206,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (list->data) {
 #ifdef DEBUG_BUILD
         memset(list->data, AWS_ARRAY_LIST_DEBUG_FILL, list->current_size);
@@ -224,8 +224,8 @@ void aws_array_list_swap_contents(
     AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
     AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
     AWS_FATAL_ASSERT(list_a != list_b);
-    AWS_PRECONDITION(aws_array_list_is_valid(list_a), "Input array_list [list_a] must be valid.");
-    AWS_PRECONDITION(aws_array_list_is_valid(list_b), "Input array_list [list_b] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list_a), "Input aws_array_list [list_a] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list_b), "Input aws_array_list [list_b] must be valid.");
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
@@ -237,7 +237,7 @@ void aws_array_list_swap_contents(
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t capacity = list->current_size / list->item_size;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return capacity;
@@ -250,7 +250,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * list.
      */
     AWS_FATAL_ASSERT(!list->length || list->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t len = list->length;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return len;
@@ -258,7 +258,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
@@ -271,7 +271,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     AWS_PRECONDITION(val, "Input pointer [val] mustn't be NULL.");
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
@@ -284,7 +284,7 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
 
 AWS_STATIC_IMPL
 int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list, size_t index, size_t *necessary_size) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -301,7 +301,7 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point readable memory of [list->item_size] bytes.");
     
     if (aws_array_list_ensure_capacity(list, index)) {
@@ -330,7 +330,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
 
 AWS_STATIC_IMPL
 void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (list->data) {
         qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -52,7 +52,7 @@ int aws_array_list_init_dynamic(
     }
     AWS_FATAL_ASSERT(list->current_size == 0 || list->data);
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return AWS_OP_SUCCESS;
 }
 
@@ -74,7 +74,7 @@ void aws_array_list_init_static(
     list->item_size = item_size;
     list->length = 0;
     list->data = raw_array;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }
 
 AWS_STATIC_IMPL
@@ -91,7 +91,7 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (list->alloc && list->data) {
         aws_mem_release(list->alloc, list->data);
     }
@@ -101,58 +101,58 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
     list->length = 0;
     list->data = NULL;
     list->alloc = NULL;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
 
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return aws_raise_error(AWS_ERROR_LIST_EXCEEDS_MAX_SIZE);
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return err_code;
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
 AWS_STATIC_IMPL
 void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t n) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (n >= aws_array_list_length(list)) {
         aws_array_list_clear(list);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return;
     }
 
@@ -166,28 +166,28 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
         memset((uint8_t *)list->data + remaining_bytes, AWS_ARRAY_LIST_DEBUG_FILL, popping_bytes);
 #endif
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
         memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
 
         AWS_FATAL_ASSERT(list->data);
@@ -196,24 +196,24 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
 
         memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
 AWS_STATIC_IMPL
 void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (list->data) {
 #ifdef DEBUG_BUILD
         memset(list->data, AWS_ARRAY_LIST_DEBUG_FILL, list->current_size);
 #endif
         list->length = 0;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }
 
 AWS_STATIC_IMPL
@@ -224,22 +224,22 @@ void aws_array_list_swap_contents(
     AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
     AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
     AWS_FATAL_ASSERT(list_a != list_b);
-    AWS_PRECONDITION(aws_array_list_is_valid(list_a), "Input aws_array_list [list_a] must be valid.");
-    AWS_PRECONDITION(aws_array_list_is_valid(list_b), "Input aws_array_list [list_b] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list_a));
+    AWS_PRECONDITION(aws_array_list_is_valid(list_b));
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
     *list_b = tmp;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list_a), "Output aws_array_list [list_a] must be valid.");
-    AWS_POSTCONDITION(aws_array_list_is_valid(list_b), "Output aws_array_list [list_b] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list_a));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list_b));
 }
 
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t capacity = list->current_size / list->item_size;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return capacity;
 }
 
@@ -250,62 +250,62 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * list.
      */
     AWS_FATAL_ASSERT(!list->length || list->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t len = list->length;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return len;
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
-    AWS_PRECONDITION(val, "Input pointer [val] mustn't be NULL.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val != NULL);
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list, size_t index, size_t *necessary_size) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
 
     if (aws_mul_size_checked(index_inc, list->item_size, necessary_size)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return AWS_OP_SUCCESS;
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point readable memory of [list->item_size] bytes.");
     
     if (aws_array_list_ensure_capacity(list, index)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
 
@@ -319,20 +319,20 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
      */
     if (index >= aws_array_list_length(list)) {
         if (aws_add_size_checked(index, 1, &list->length)) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return AWS_OP_SUCCESS;
 }
 
 AWS_STATIC_IMPL
 void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (list->data) {
         qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -91,7 +91,7 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->alloc && list->data) {
         aws_mem_release(list->alloc, list->data);
     }
@@ -106,8 +106,9 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
+
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
@@ -121,8 +122,8 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
 
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -135,7 +136,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -148,7 +149,7 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t n) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (n >= aws_array_list_length(list)) {
         aws_array_list_clear(list);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -170,8 +171,8 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
 
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -186,7 +187,7 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
 
 AWS_STATIC_IMPL
 int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
 
         AWS_FATAL_ASSERT(list->data);
@@ -205,7 +206,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->data) {
 #ifdef DEBUG_BUILD
         memset(list->data, AWS_ARRAY_LIST_DEBUG_FILL, list->current_size);
@@ -223,8 +224,8 @@ void aws_array_list_swap_contents(
     AWS_FATAL_ASSERT(list_a->alloc == list_b->alloc);
     AWS_FATAL_ASSERT(list_a->item_size == list_b->item_size);
     AWS_FATAL_ASSERT(list_a != list_b);
-    AWS_PRECONDITION(aws_array_list_is_valid(list_a));
-    AWS_PRECONDITION(aws_array_list_is_valid(list_b));
+    AWS_PRECONDITION(aws_array_list_is_valid(list_a), "Input array_list [list_a] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list_b), "Input array_list [list_b] must be valid.");
 
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
@@ -236,7 +237,7 @@ void aws_array_list_swap_contents(
 AWS_STATIC_IMPL
 size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t capacity = list->current_size / list->item_size;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return capacity;
@@ -249,7 +250,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * list.
      */
     AWS_FATAL_ASSERT(!list->length || list->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t len = list->length;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return len;
@@ -257,8 +258,8 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -270,8 +271,8 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
 
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val);
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(val, "Input pointer [val] mustn't be NULL.");
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -283,7 +284,7 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
 
 AWS_STATIC_IMPL
 int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list, size_t index, size_t *necessary_size) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -300,8 +301,8 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point readable memory of [list->item_size] bytes.");
     
     if (aws_array_list_ensure_capacity(list, index)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -329,7 +330,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
 
 AWS_STATIC_IMPL
 void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->data) {
         qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -52,7 +52,7 @@ int aws_array_list_init_dynamic(
     }
     AWS_FATAL_ASSERT(list->current_size == 0 || list->data);
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -74,7 +74,7 @@ void aws_array_list_init_static(
     list->item_size = item_size;
     list->length = 0;
     list->data = raw_array;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
 }
 
 AWS_STATIC_IMPL
@@ -101,7 +101,7 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
     list->length = 0;
     list->data = NULL;
     list->alloc = NULL;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
 }
 
 AWS_STATIC_IMPL
@@ -112,11 +112,11 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return aws_raise_error(AWS_ERROR_LIST_EXCEEDS_MAX_SIZE);
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return err_code;
 }
 
@@ -126,11 +126,11 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -139,11 +139,11 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -152,7 +152,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (n >= aws_array_list_length(list)) {
         aws_array_list_clear(list);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return;
     }
 
@@ -166,7 +166,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
         memset((uint8_t *)list->data + remaining_bytes, AWS_ARRAY_LIST_DEBUG_FILL, popping_bytes);
 #endif
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
 }
 
 AWS_STATIC_IMPL
@@ -177,11 +177,11 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
         memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -196,11 +196,11 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
 
         memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_LIST_EMPTY);
 }
 
@@ -213,7 +213,7 @@ void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list) {
 #endif
         list->length = 0;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
 }
 
 AWS_STATIC_IMPL
@@ -230,8 +230,8 @@ void aws_array_list_swap_contents(
     struct aws_array_list tmp = *list_a;
     *list_a = *list_b;
     *list_b = tmp;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list_a));
-    AWS_POSTCONDITION(aws_array_list_is_valid(list_b));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list_a), "Output aws_array_list [list_a] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list_b), "Output aws_array_list [list_b] must be valid.");
 }
 
 AWS_STATIC_IMPL
@@ -239,7 +239,7 @@ size_t aws_array_list_capacity(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(list->item_size);
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t capacity = list->current_size / list->item_size;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return capacity;
 }
 
@@ -252,7 +252,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
     AWS_FATAL_ASSERT(!list->length || list->data);
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t len = list->length;
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return len;
 }
 
@@ -262,10 +262,10 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
     AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
 }
 
@@ -275,10 +275,10 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
     AWS_PRECONDITION(val, "Input pointer [val] mustn't be NULL.");
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
 }
 
@@ -287,15 +287,15 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t index_inc;
     if (aws_add_size_checked(index, 1, &index_inc)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_ERR;
     }
 
     if (aws_mul_size_checked(index_inc, list->item_size, necessary_size)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_ERR;
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -305,7 +305,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
     AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point readable memory of [list->item_size] bytes.");
     
     if (aws_array_list_ensure_capacity(list, index)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_ERR;
     }
 
@@ -319,12 +319,12 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
      */
     if (index >= aws_array_list_length(list)) {
         if (aws_add_size_checked(index, 1, &list->length)) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list));
+            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
             return AWS_OP_ERR;
         }
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -334,5 +334,5 @@ void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_lis
     if (list->data) {
         qsort(list->data, aws_array_list_length(list), list->item_size, compare_fn);
     }
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
 }

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -485,7 +485,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
 }
 
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len) {
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len));
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len), "Input array [bytes] must be writable up to [len] bytes.");
     struct aws_byte_buf buf;
     buf.buffer = (len > 0) ? (uint8_t *)bytes : NULL;
     buf.len = len;
@@ -496,7 +496,8 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, s
 }
 
 AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity) {
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, capacity));
+    AWS_PRECONDITION(
+        AWS_MEM_IS_WRITABLE(bytes, capacity), "Input array [bytes] must be writable up to [capacity] bytes.");
     struct aws_byte_buf buf;
     buf.buffer = (capacity > 0) ? (uint8_t *)bytes : NULL;
     buf.len = 0;

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -480,7 +480,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
     buf.capacity = buf.len;
     buf.buffer = (buf.capacity == 0) ? NULL : (uint8_t *)c_str;
     buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf), "Output aws_byte_buf [buf] must be valid.");
     return buf;
 }
 
@@ -491,7 +491,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, s
     buf.len = len;
     buf.capacity = len;
     buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf), "Output aws_byte_buf [buf] must be valid.");
     return buf;
 }
 
@@ -503,7 +503,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *by
     buf.len = 0;
     buf.capacity = capacity;
     buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf), "Output aws_byte_buf [buf] must be valid.");
     return buf;
 }
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -480,7 +480,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
     buf.capacity = buf.len;
     buf.buffer = (buf.capacity == 0) ? NULL : (uint8_t *)c_str;
     buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;
 }
 
@@ -491,7 +491,7 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, s
     buf.len = len;
     buf.capacity = len;
     buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;
 }
 
@@ -503,16 +503,16 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *by
     buf.len = 0;
     buf.capacity = capacity;
     buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
     return buf;
 }
 
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     struct aws_byte_cursor cur;
     cur.ptr = buf->buffer;
     cur.len = buf->len;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur), "Output aws_byte_cursor [cur] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
     return cur;
 }
 
@@ -520,7 +520,7 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_
     struct aws_byte_cursor cur;
     cur.ptr = (uint8_t *)c_str;
     cur.len = (cur.ptr) ? strlen(c_str) : 0;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur), "Output aws_byte_cursor [cur] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
     return cur;
 }
 
@@ -529,7 +529,7 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *co
     struct aws_byte_cursor cur;
     cur.ptr = (uint8_t *)bytes;
     cur.len = len;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur), "Output aws_byte_cursor [cur] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
     return cur;
 }
 
@@ -612,7 +612,7 @@ AWS_STATIC_IMPL size_t aws_nospec_mask(size_t index, size_t bound) {
  * a buffer overflow, and return NULL without changing *buf.
  */
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cursor, const size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
     struct aws_byte_cursor rv;
     if (cursor->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || len > cursor->len) {
         rv.ptr = NULL;
@@ -624,8 +624,8 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_c
         cursor->ptr += len;
         cursor->len -= len;
     }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv), "Output aws_byte_cursor [rv] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
     return rv;
 }
 
@@ -642,7 +642,7 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_c
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
     struct aws_byte_cursor *const cursor,
     size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
 
     struct aws_byte_cursor rv;
 
@@ -671,8 +671,8 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
         rv.len = 0;
     }
 
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv), "Output aws_byte_cursor [rv] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
     return rv;
 }
 
@@ -794,19 +794,19 @@ AWS_STATIC_IMPL bool aws_byte_buf_advance(
     struct aws_byte_buf *const AWS_RESTRICT buffer,
     struct aws_byte_buf *const AWS_RESTRICT output,
     const size_t len) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer), "Input aws_byte_buf [buffer] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input aws_byte_buf [output] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
     if (buffer->capacity - buffer->len >= len) {
         *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
         buffer->len += len;
         output->len = 0;
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(output), "Output aws_byte_buf [output] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(output));
         return true;
     } else {
         AWS_ZERO_STRUCT(*output);
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(output), "Output aws_byte_buf [output] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(output));
         return false;
     }
 }
@@ -822,18 +822,18 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
     struct aws_byte_buf *AWS_RESTRICT buf,
     const uint8_t *AWS_RESTRICT src,
     size_t len) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(src, len), "Input array [src] must be readable up to [len] bytes.");
 
     if (buf->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || buf->len + len > buf->capacity) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
         return false;
     }
 
     memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return true;
 }
 
@@ -847,8 +847,8 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
 AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
     struct aws_byte_buf *AWS_RESTRICT buf,
     struct aws_byte_buf src) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(&src), "Input aws_byte_buf [src] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(&src));
     return aws_byte_buf_write(buf, src.buffer, src.len);
 }
 
@@ -862,8 +862,8 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
 AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
     struct aws_byte_buf *AWS_RESTRICT buf,
     struct aws_byte_cursor src) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(&src), "Input aws_byte_cursor [src] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&src));
     return aws_byte_buf_write(buf, src.ptr, src.len);
 }
 
@@ -877,7 +877,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
  cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf, uint8_t c) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     return aws_byte_buf_write(buf, &c, 1);
 }
 
@@ -889,7 +889,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     x = aws_hton16(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 2);
 }
@@ -902,7 +902,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t 
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     x = aws_hton32(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
 }
@@ -915,7 +915,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t 
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     x = aws_hton64(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
 }

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -508,11 +508,11 @@ AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *by
 }
 
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     struct aws_byte_cursor cur;
     cur.ptr = buf->buffer;
     cur.len = buf->len;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur), "Output aws_byte_cursor [cur] must be valid.");
     return cur;
 }
 
@@ -520,16 +520,16 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_
     struct aws_byte_cursor cur;
     cur.ptr = (uint8_t *)c_str;
     cur.len = (cur.ptr) ? strlen(c_str) : 0;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur), "Output aws_byte_cursor [cur] must be valid.");
     return cur;
 }
 
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len) {
-    AWS_PRECONDITION(len == 0 || AWS_MEM_IS_READABLE(bytes, len));
+    AWS_PRECONDITION(len == 0 || AWS_MEM_IS_READABLE(bytes, len), "Input array [bytes] must be readable up to [len].");
     struct aws_byte_cursor cur;
     cur.ptr = (uint8_t *)bytes;
     cur.len = len;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur), "Output aws_byte_cursor [cur] must be valid.");
     return cur;
 }
 
@@ -612,7 +612,7 @@ AWS_STATIC_IMPL size_t aws_nospec_mask(size_t index, size_t bound) {
  * a buffer overflow, and return NULL without changing *buf.
  */
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cursor, const size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
     struct aws_byte_cursor rv;
     if (cursor->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || len > cursor->len) {
         rv.ptr = NULL;
@@ -624,8 +624,8 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_c
         cursor->ptr += len;
         cursor->len -= len;
     }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv), "Output aws_byte_cursor [rv] must be valid.");
     return rv;
 }
 
@@ -642,7 +642,7 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_c
 AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
     struct aws_byte_cursor *const cursor,
     size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
 
     struct aws_byte_cursor rv;
 
@@ -671,8 +671,8 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
         rv.len = 0;
     }
 
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv), "Output aws_byte_cursor [rv] must be valid.");
     return rv;
 }
 
@@ -794,16 +794,19 @@ AWS_STATIC_IMPL bool aws_byte_buf_advance(
     struct aws_byte_buf *const AWS_RESTRICT buffer,
     struct aws_byte_buf *const AWS_RESTRICT output,
     const size_t len) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer), "Input aws_byte_buf [buffer] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input aws_byte_buf [output] must be valid.");
     if (buffer->capacity - buffer->len >= len) {
         *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
         buffer->len += len;
         output->len = 0;
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(output), "Output aws_byte_buf [output] must be valid.");
         return true;
     } else {
         AWS_ZERO_STRUCT(*output);
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer) && aws_byte_buf_is_valid(output));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(output), "Output aws_byte_buf [output] must be valid.");
         return false;
     }
 }
@@ -819,17 +822,18 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
     struct aws_byte_buf *AWS_RESTRICT buf,
     const uint8_t *AWS_RESTRICT src,
     size_t len) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && AWS_MEM_IS_WRITABLE(src, len));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(src, len), "Input array [src] must be readable up to [len] bytes.");
 
     if (buf->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || buf->len + len > buf->capacity) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
         return false;
     }
 
     memcpy(buf->buffer + buf->len, src, len);
     buf->len += len;
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
     return true;
 }
 
@@ -843,7 +847,8 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
 AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
     struct aws_byte_buf *AWS_RESTRICT buf,
     struct aws_byte_buf src) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && aws_byte_buf_is_valid(&src));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(&src), "Input aws_byte_buf [src] must be valid.");
     return aws_byte_buf_write(buf, src.buffer, src.len);
 }
 
@@ -857,7 +862,8 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
 AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
     struct aws_byte_buf *AWS_RESTRICT buf,
     struct aws_byte_cursor src) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && aws_byte_cursor_is_valid(&src));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&src), "Input aws_byte_cursor [src] must be valid.");
     return aws_byte_buf_write(buf, src.ptr, src.len);
 }
 
@@ -871,7 +877,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
  cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf, uint8_t c) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     return aws_byte_buf_write(buf, &c, 1);
 }
 
@@ -883,7 +889,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     x = aws_hton16(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 2);
 }
@@ -896,7 +902,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t 
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     x = aws_hton32(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
 }
@@ -909,7 +915,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t 
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     x = aws_hton64(x);
     return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
 }

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -88,7 +88,7 @@ AWS_STATIC_IMPL uint32_t aws_ntoh32(uint32_t x) {
  * Convert 24 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
-    AWS_PRECONDITION(x <= 0xFFFFFF);
+    AWS_PRECONDITION(x <= 0xFFFFFF, "");
     if (aws_is_big_endian()) {
         return x;
     } else {
@@ -100,7 +100,7 @@ AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
  * Convert 24 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_ntoh24(uint32_t x) {
-    AWS_PRECONDITION((x) <= 0xFFFFFFF);
+    AWS_PRECONDITION((x) <= 0xFFFFFFF, "");
     if (aws_is_big_endian()) {
         return x;
     } else {

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -88,7 +88,7 @@ AWS_STATIC_IMPL uint32_t aws_ntoh32(uint32_t x) {
  * Convert 24 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
-    AWS_PRECONDITION(x <= 0xFFFFFF, "");
+    AWS_PRECONDITION(x <= 0xFFFFFF, "Input [x] must be representable with at most 3 bytes.");
     if (aws_is_big_endian()) {
         return x;
     } else {
@@ -100,7 +100,7 @@ AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
  * Convert 24 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_ntoh24(uint32_t x) {
-    AWS_PRECONDITION((x) <= 0xFFFFFFF, "");
+    AWS_PRECONDITION((x) <= 0xFFFFFFF, "Input [x] must be representable with at most 3 bytes.");
     if (aws_is_big_endian()) {
         return x;
     } else {

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -120,9 +120,9 @@
  */
 #ifdef CBMC
 #define AWS_PRECONDITION_2(cond, explanation) __CPROVER_precondition((cond), (explanation))
-#define AWS_PRECONDITION_1(cond, explanation) __CPROVER_precondition((cond), #cond " check failed")
+#define AWS_PRECONDITION_1(cond) __CPROVER_precondition((cond), #cond " check failed")
 #define AWS_POSTCONDITION_2(cond, explanation) __CPROVER_assert((cond), (explanation))
-#define AWS_POSTCONDITION_1(cond, explanation) __CPROVER_assert((cond), #cond " check failed")
+#define AWS_POSTCONDITION_1(cond) __CPROVER_assert((cond), #cond " check failed")
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -118,12 +118,12 @@
  */
 #ifdef CBMC
 #define AWS_PRECONDITION(cond, explanation) __CPROVER_precondition((cond), (explanation))
-#define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
+#define AWS_POSTCONDITION(cond, explanation) __CPROVER_assert((cond), (explanation))
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else
 #define AWS_PRECONDITION(cond, expl) AWS_ASSERT(cond)
-#define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
+#define AWS_POSTCONDITION(cond, expl) AWS_ASSERT(cond)
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */
 #define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -109,6 +109,8 @@
 
 #include <aws/common/assert.inl>
 
+#define GET_MACRO(_1,_2,NAME,...) NAME
+
 /**
  * Define function contracts.
  * When the code is being verified using CBMC these contracts are formally verified;
@@ -117,18 +119,25 @@
  * Violations of the function contracts are undefined behaviour.
  */
 #ifdef CBMC
-#define AWS_PRECONDITION(cond, explanation) __CPROVER_precondition((cond), (explanation))
-#define AWS_POSTCONDITION(cond, explanation) __CPROVER_assert((cond), (explanation))
+#define AWS_PRECONDITION_2(cond, explanation) __CPROVER_precondition((cond), (explanation))
+#define AWS_PRECONDITION_1(cond, explanation) __CPROVER_precondition((cond), "")
+#define AWS_POSTCONDITION_2(cond, explanation) __CPROVER_assert((cond), (explanation))
+#define AWS_POSTCONDITION_1(cond, explanation) __CPROVER_assert((cond), "")
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else
-#define AWS_PRECONDITION(cond, expl) AWS_ASSERT(cond)
-#define AWS_POSTCONDITION(cond, expl) AWS_ASSERT(cond)
+#define AWS_PRECONDITION_2(cond, expl) AWS_ASSERT(cond)
+#define AWS_PRECONDITION_1(cond) AWS_ASSERT(cond)
+#define AWS_POSTCONDITION_2(cond, expl) AWS_ASSERT(cond)
+#define AWS_POSTCONDITION_1(cond) AWS_ASSERT(cond)
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */
 #define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
 #define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 #endif
+
+#define AWS_PRECONDITION(...) GET_MACRO(__VA_ARGS__, AWS_PRECONDITION_2, AWS_PRECONDITION_1)(__VA_ARGS__)
+#define AWS_POSTCONDITION(...) GET_MACRO(__VA_ARGS__, AWS_POSTCONDITION_2, AWS_POSTCONDITION_1)(__VA_ARGS__)
 
 #define AWS_OBJECT_PTR_IS_READABLE(ptr) AWS_MEM_IS_READABLE((ptr), sizeof(*ptr))
 #define AWS_OBJECT_PTR_IS_WRITABLE(ptr) AWS_MEM_IS_WRITABLE((ptr), sizeof(*ptr))

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -120,9 +120,9 @@
  */
 #ifdef CBMC
 #define AWS_PRECONDITION_2(cond, explanation) __CPROVER_precondition((cond), (explanation))
-#define AWS_PRECONDITION_1(cond, explanation) __CPROVER_precondition((cond), "")
+#define AWS_PRECONDITION_1(cond, explanation) __CPROVER_precondition((cond), #cond " check failed")
 #define AWS_POSTCONDITION_2(cond, explanation) __CPROVER_assert((cond), (explanation))
-#define AWS_POSTCONDITION_1(cond, explanation) __CPROVER_assert((cond), "")
+#define AWS_POSTCONDITION_1(cond, explanation) __CPROVER_assert((cond), #cond " check failed")
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -136,8 +136,9 @@
 #define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 #endif
 
-#define AWS_PRECONDITION(...) GET_MACRO(__VA_ARGS__, AWS_PRECONDITION_2, AWS_PRECONDITION_1)(__VA_ARGS__)
-#define AWS_POSTCONDITION(...) GET_MACRO(__VA_ARGS__, AWS_POSTCONDITION_2, AWS_POSTCONDITION_1)(__VA_ARGS__)
+// The UNUSED is used to silence the complains of GCC for zero arguments in variadic macro
+#define AWS_PRECONDITION(...) GET_MACRO(__VA_ARGS__, AWS_PRECONDITION_2, AWS_PRECONDITION_1, UNUSED)(__VA_ARGS__)
+#define AWS_POSTCONDITION(...) GET_MACRO(__VA_ARGS__, AWS_POSTCONDITION_2, AWS_POSTCONDITION_1, UNUSED)(__VA_ARGS__)
 
 #define AWS_OBJECT_PTR_IS_READABLE(ptr) AWS_MEM_IS_READABLE((ptr), sizeof(*ptr))
 #define AWS_OBJECT_PTR_IS_WRITABLE(ptr) AWS_MEM_IS_WRITABLE((ptr), sizeof(*ptr))

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -117,7 +117,7 @@
  * Violations of the function contracts are undefined behaviour.
  */
 #ifdef CBMC
-#define AWS_PRECONDITION(cond, explanation) __CPROVER_precondition((cond), ("Precondition: " explanation))
+#define AWS_PRECONDITION(cond, explanation) __CPROVER_precondition((cond), (explanation))
 #define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -117,12 +117,12 @@
  * Violations of the function contracts are undefined behaviour.
  */
 #ifdef CBMC
-#define AWS_PRECONDITION(cond) __CPROVER_assume(cond)
+#define AWS_PRECONDITION(cond, explanation) __CPROVER_precondition((cond), ("Precondition: " explanation))
 #define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
 #define AWS_MEM_IS_READABLE(base, len) __CPROVER_r_ok((base), (len))
 #define AWS_MEM_IS_WRITABLE(base, len) __CPROVER_w_ok((base), (len))
 #else
-#define AWS_PRECONDITION(cond) AWS_ASSERT(cond)
+#define AWS_PRECONDITION(cond, expl) AWS_ASSERT(cond)
 #define AWS_POSTCONDITION(cond) AWS_ASSERT(cond)
 /* the C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid */

--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -55,8 +55,8 @@ struct hash_table_state {
 #endif
 
 /**
- * Best-effort check of hash_table_state data-structure invarients
- * Some invarients, such as that the number of entries is actually the
+ * Best-effort check of hash_table_state data-structure invariants
+ * Some invariants, such as that the number of entries is actually the
  * same as the entry_count field, would require a loop to check
  */
 AWS_STATIC_IMPL
@@ -81,8 +81,8 @@ bool hash_table_state_is_valid(const struct hash_table_state *map) {
 }
 
 /**
- * Best-effort check of hash_table_state data-structure invarients
- * Some invarients, such as that the number of entries is actually the
+ * Best-effort check of hash_table_state data-structure invariants
+ * Some invariants, such as that the number of entries is actually the
  * same as the entry_count field, would require a loop to check
  */
 AWS_STATIC_IMPL

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -18,7 +18,7 @@
 #include <stdlib.h> /* qsort */
 
 int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
@@ -53,8 +53,8 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
     AWS_FATAL_ASSERT(from->item_size == to->item_size);
     AWS_FATAL_ASSERT(from->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(from));
-    AWS_PRECONDITION(aws_array_list_is_valid(to));
+    AWS_PRECONDITION(aws_array_list_is_valid(from), "Input array_list [from] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(to), "Input array_list [to] must be valid.");
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -99,7 +99,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 }
 
 int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -185,7 +185,7 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
-    AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
 
     if (a == b) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -22,7 +22,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list));
+            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
             return AWS_OP_ERR;
         }
 
@@ -32,7 +32,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             if (ideal_size > 0) {
                 raw_data = aws_mem_acquire(list->alloc, ideal_size);
                 if (!raw_data) {
-                    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+                    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
                     return AWS_OP_ERR;
                 }
 
@@ -42,11 +42,11 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             list->data = raw_data;
             list->current_size = ideal_size;
         }
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return aws_raise_error(AWS_ERROR_LIST_STATIC_MODE_CANT_SHRINK);
 }
 
@@ -58,8 +58,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(from));
-        AWS_POSTCONDITION(aws_array_list_is_valid(to));
+        AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
         return AWS_OP_ERR;
     }
 
@@ -68,8 +68,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
             memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
-        AWS_POSTCONDITION(aws_array_list_is_valid(from));
-        AWS_POSTCONDITION(aws_array_list_is_valid(to));
+        AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
         return AWS_OP_SUCCESS;
     }
     /* if to is in dynamic mode, we can just reallocate it and copy */
@@ -77,8 +77,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         void *tmp = aws_mem_acquire(to->alloc, copy_size);
 
         if (!tmp) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(from));
-            AWS_POSTCONDITION(aws_array_list_is_valid(to));
+            AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
             return AWS_OP_ERR;
         }
 
@@ -90,8 +90,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         to->data = tmp;
         to->length = from->length;
         to->current_size = copy_size;
-        AWS_POSTCONDITION(aws_array_list_is_valid(from));
-        AWS_POSTCONDITION(aws_array_list_is_valid(to));
+        AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
@@ -102,13 +102,13 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return AWS_OP_ERR;
     }
 
     if (list->current_size < necessary_size) {
         if (!list->alloc) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list));
+            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
             return aws_raise_error(AWS_ERROR_INVALID_INDEX);
         }
 
@@ -129,14 +129,14 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
              * most certainly out of addressable memory. But since we're simply
              * going to fail fast and say, sorry can't do it, we'll just tell
              * the user they can't grow the list anymore. */
-            AWS_POSTCONDITION(aws_array_list_is_valid(list));
+            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
             return aws_raise_error(AWS_ERROR_LIST_EXCEEDS_MAX_SIZE);
         }
 
         void *temp = aws_mem_acquire(list->alloc, new_size);
 
         if (!temp) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list));
+            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
             return AWS_OP_ERR;
         }
 
@@ -155,7 +155,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
         list->current_size = new_size;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -188,7 +188,7 @@ void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, siz
     AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
 
     if (a == b) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list));
+        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
         return;
     }
 
@@ -196,5 +196,5 @@ void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, siz
     aws_array_list_get_at_ptr(list, &item1, a);
     aws_array_list_get_at_ptr(list, &item2, b);
     aws_array_list_mem_swap(item1, item2, list->item_size);
-    AWS_POSTCONDITION(aws_array_list_is_valid(list));
+    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
 }

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -18,11 +18,11 @@
 #include <stdlib.h> /* qsort */
 
 int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
 
@@ -32,7 +32,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             if (ideal_size > 0) {
                 raw_data = aws_mem_acquire(list->alloc, ideal_size);
                 if (!raw_data) {
-                    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+                    AWS_POSTCONDITION(aws_array_list_is_valid(list));
                     return AWS_OP_ERR;
                 }
 
@@ -42,24 +42,24 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             list->data = raw_data;
             list->current_size = ideal_size;
         }
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_LIST_STATIC_MODE_CANT_SHRINK);
 }
 
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
     AWS_FATAL_ASSERT(from->item_size == to->item_size);
     AWS_FATAL_ASSERT(from->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(from), "Input aws_array_list [from] must be valid.");
-    AWS_PRECONDITION(aws_array_list_is_valid(to), "Input aws_array_list [to] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(from));
+    AWS_PRECONDITION(aws_array_list_is_valid(to));
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
-        AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(from));
+        AWS_POSTCONDITION(aws_array_list_is_valid(to));
         return AWS_OP_ERR;
     }
 
@@ -68,8 +68,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
             memcpy(to->data, from->data, copy_size);
         }
         to->length = from->length;
-        AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
-        AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(from));
+        AWS_POSTCONDITION(aws_array_list_is_valid(to));
         return AWS_OP_SUCCESS;
     }
     /* if to is in dynamic mode, we can just reallocate it and copy */
@@ -77,8 +77,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         void *tmp = aws_mem_acquire(to->alloc, copy_size);
 
         if (!tmp) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
-            AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(from));
+            AWS_POSTCONDITION(aws_array_list_is_valid(to));
             return AWS_OP_ERR;
         }
 
@@ -90,8 +90,8 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         to->data = tmp;
         to->length = from->length;
         to->current_size = copy_size;
-        AWS_POSTCONDITION(aws_array_list_is_valid(from), "Output aws_array_list [from] must be valid.");
-        AWS_POSTCONDITION(aws_array_list_is_valid(to), "Output aws_array_list [to] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(from));
+        AWS_POSTCONDITION(aws_array_list_is_valid(to));
         return AWS_OP_SUCCESS;
     }
 
@@ -99,16 +99,16 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 }
 
 int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
     }
 
     if (list->current_size < necessary_size) {
         if (!list->alloc) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return aws_raise_error(AWS_ERROR_INVALID_INDEX);
         }
 
@@ -129,14 +129,14 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
              * most certainly out of addressable memory. But since we're simply
              * going to fail fast and say, sorry can't do it, we'll just tell
              * the user they can't grow the list anymore. */
-            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return aws_raise_error(AWS_ERROR_LIST_EXCEEDS_MAX_SIZE);
         }
 
         void *temp = aws_mem_acquire(list->alloc, new_size);
 
         if (!temp) {
-            AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+            AWS_POSTCONDITION(aws_array_list_is_valid(list));
             return AWS_OP_ERR;
         }
 
@@ -155,7 +155,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
         list->current_size = new_size;
     }
 
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return AWS_OP_SUCCESS;
 }
 
@@ -185,10 +185,10 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list));
 
     if (a == b) {
-        AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+        AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return;
     }
 
@@ -196,5 +196,5 @@ void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, siz
     aws_array_list_get_at_ptr(list, &item1, a);
     aws_array_list_get_at_ptr(list, &item2, b);
     aws_array_list_mem_swap(item1, item2, list->item_size);
-    AWS_POSTCONDITION(aws_array_list_is_valid(list), "Output aws_array_list [list] must be valid.");
+    AWS_POSTCONDITION(aws_array_list_is_valid(list));
 }

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -18,7 +18,7 @@
 #include <stdlib.h> /* qsort */
 
 int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     if (list->alloc) {
         size_t ideal_size;
         if (aws_mul_size_checked(list->length, list->item_size, &ideal_size)) {
@@ -53,8 +53,8 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
     AWS_FATAL_ASSERT(from->item_size == to->item_size);
     AWS_FATAL_ASSERT(from->data);
-    AWS_PRECONDITION(aws_array_list_is_valid(from), "Input array_list [from] must be valid.");
-    AWS_PRECONDITION(aws_array_list_is_valid(to), "Input array_list [to] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(from), "Input aws_array_list [from] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(to), "Input aws_array_list [to] must be valid.");
 
     size_t copy_size;
     if (aws_mul_size_checked(from->length, from->item_size, &copy_size)) {
@@ -99,7 +99,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
 }
 
 int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index) {
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -185,7 +185,7 @@ static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT
 void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b) {
     AWS_FATAL_ASSERT(a < list->length);
     AWS_FATAL_ASSERT(b < list->length);
-    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input array_list [list] must be valid.");
+    AWS_PRECONDITION(aws_array_list_is_valid(list), "Input aws_array_list [list] must be valid.");
 
     if (a == b) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -278,16 +278,16 @@ int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...) {
 }
 
 bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
     bool rv = aws_array_eq(a->ptr, a->len, b->ptr, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
     return rv;
 }
 
 bool aws_byte_cursor_eq_ignore_case(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
     bool rv = aws_array_eq_ignore_case(a->ptr, a->len, b->ptr, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
     return rv;
 }
 
@@ -431,32 +431,32 @@ uint64_t aws_hash_byte_cursor_ptr_ignore_case(const void *item) {
 }
 
 bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
     bool rv = aws_array_eq(a->ptr, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
     return rv;
 }
 
 bool aws_byte_cursor_eq_byte_buf_ignore_case(
     const struct aws_byte_cursor *const a,
     const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
     bool rv = aws_array_eq_ignore_case(a->ptr, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
     return rv;
 }
 
 bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor) && c_str);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor) && c_str, "");
     bool rv = aws_array_eq_c_str(cursor->ptr, cursor->len, c_str);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "");
     return rv;
 }
 
 bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cursor, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor) && c_str);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor) && c_str, "");
     bool rv = aws_array_eq_c_str_ignore_case(cursor->ptr, cursor->len, c_str);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "");
     return rv;
 }
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -36,7 +36,7 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
     buf->len = 0;
     buf->capacity = capacity;
     buf->allocator = allocator;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -48,7 +48,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (!src->buffer) {
         AWS_ZERO_STRUCT(*dest);
         dest->allocator = allocator;
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest), "Output aws_byte_buf [dest] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
@@ -60,7 +60,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         return AWS_OP_ERR;
     }
     memcpy(dest->buffer, src->buffer, src->len);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest), "Output aws_byte_buf [dest] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -98,41 +98,47 @@ void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
         aws_secure_zero(buf->buffer, buf->capacity);
     }
     buf->len = 0;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
 }
 
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     aws_byte_buf_secure_zero(buf);
     aws_byte_buf_clean_up(buf);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
 }
 
 bool aws_byte_buf_eq(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a), "Input aws_byte_buf [a] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
     bool rval = aws_array_eq(a->buffer, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(a), "Output aws_byte_buf [a] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
     return rval;
 }
 
 bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a), "Input aws_byte_buf [a] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
     bool rval = aws_array_eq_ignore_case(a->buffer, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(a), "Output aws_byte_buf [a] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
     return rval;
 }
 
 bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && c_str);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rval = aws_array_eq_c_str(buf->buffer, buf->len, c_str);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
     return rval;
 }
 
 bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *const buf, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf) && c_str);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rval = aws_array_eq_c_str_ignore_case(buf->buffer, buf->len, c_str);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
     return rval;
 }
 
@@ -157,7 +163,7 @@ int aws_byte_buf_init_copy_from_cursor(
     if (src.len > 0) {
         memcpy(dest->buffer, src.ptr, src.len);
     }
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest), "Output aws_byte_buf [dest] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -309,8 +315,10 @@ bool aws_array_eq_ignore_case(
     const size_t len_a,
     const void *const array_b,
     const size_t len_b) {
-    AWS_PRECONDITION((len_a == 0) || AWS_MEM_IS_READABLE(array_a, len_a));
-    AWS_PRECONDITION((len_b == 0) || AWS_MEM_IS_READABLE(array_b, len_b));
+    AWS_PRECONDITION(
+        (len_a == 0) || AWS_MEM_IS_READABLE(array_a, len_a), "Input array [array_a] must be readable up to [len_a].");
+    AWS_PRECONDITION(
+        (len_b == 0) || AWS_MEM_IS_READABLE(array_b, len_b), "Input array [array_b] must be readable up to [len_b].");
 
     if (len_a != len_b) {
         return false;
@@ -328,8 +336,10 @@ bool aws_array_eq_ignore_case(
 }
 
 bool aws_array_eq(const void *const array_a, const size_t len_a, const void *const array_b, const size_t len_b) {
-    AWS_PRECONDITION((len_a == 0) || AWS_MEM_IS_READABLE(array_a, len_a));
-    AWS_PRECONDITION((len_b == 0) || AWS_MEM_IS_READABLE(array_b, len_b));
+    AWS_PRECONDITION(
+        (len_a == 0) || AWS_MEM_IS_READABLE(array_a, len_a), "Input array [array_a] must be readable up to [len_a].");
+    AWS_PRECONDITION(
+        (len_b == 0) || AWS_MEM_IS_READABLE(array_b, len_b), "Input array [array_b] must be readable up to [len_b].");
 
     if (len_a != len_b) {
         return false;
@@ -343,8 +353,10 @@ bool aws_array_eq(const void *const array_a, const size_t len_a, const void *con
 }
 
 bool aws_array_eq_c_str_ignore_case(const void *const array, const size_t array_len, const char *const c_str) {
-    AWS_PRECONDITION(array || (array_len == 0));
-    AWS_PRECONDITION(c_str);
+    AWS_PRECONDITION(
+        array || (array_len == 0),
+        "Either input pointer [array_a] mustn't be NULL or input [array_len] mustn't be zero.");
+    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
 
     /* Simpler implementation could have been:
      *   return aws_array_eq_ignore_case(array, array_len, c_str, strlen(c_str));
@@ -369,8 +381,10 @@ bool aws_array_eq_c_str_ignore_case(const void *const array, const size_t array_
 }
 
 bool aws_array_eq_c_str(const void *const array, const size_t array_len, const char *const c_str) {
-    AWS_PRECONDITION(array || (array_len == 0));
-    AWS_PRECONDITION(c_str);
+    AWS_PRECONDITION(
+        array || (array_len == 0),
+        "Either input pointer [array_a] mustn't be NULL or input [array_len] mustn't be zero.");
+    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
 
     /* Simpler implementation could have been:
      *   return aws_array_eq(array, array_len, c_str, strlen(c_str));
@@ -451,8 +465,8 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
     AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
 
     if (to->capacity - to->len < from->len) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
         return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
     }
 
@@ -464,8 +478,8 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
         to->len += from->len;
     }
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -479,8 +493,8 @@ int aws_byte_buf_append_with_lookup(
         AWS_MEM_IS_READABLE(lookup_table, 256), "Input array [lookup_table] must be at least 256 bytes long.");
 
     if (to->capacity - to->len < from->len) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
         return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
     }
 
@@ -492,8 +506,8 @@ int aws_byte_buf_append_with_lookup(
         return AWS_OP_ERR;
     }
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -512,8 +526,8 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
         size_t required_capacity = 0;
         if (aws_add_size_checked(to->capacity, missing_capacity, &required_capacity)) {
-            AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-            AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+            AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
             return AWS_OP_ERR;
         }
 
@@ -543,13 +557,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
                 new_capacity = required_capacity;
                 new_buffer = aws_mem_acquire(to->allocator, new_capacity);
                 if (new_buffer == NULL) {
-                    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-                    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+                    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+                    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
                     return AWS_OP_ERR;
                 }
             } else {
-                AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-                AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+                AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+                AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
                 return AWS_OP_ERR;
             }
         }
@@ -587,8 +601,8 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
     to->len += from->len;
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -598,18 +612,18 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
     }
 
     if (requested_capacity <= buffer->capacity) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
     if (aws_mem_realloc(buffer->allocator, (void **)&buffer->buffer, buffer->capacity, requested_capacity)) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
         return AWS_OP_ERR;
     }
 
     buffer->capacity = requested_capacity;
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -620,7 +634,7 @@ int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional
 
     size_t requested_capacity = 0;
     if (AWS_UNLIKELY(aws_add_size_checked(buffer->len, additional_length, &requested_capacity))) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
         return AWS_OP_ERR;
     }
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -278,16 +278,20 @@ int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...) {
 }
 
 bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(b), "Input aws_byte_cursor [b] must be valid.");
     bool rv = aws_array_eq(a->ptr, a->len, b->ptr, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(b), "Output aws_byte_cursor [b] must be valid.");
     return rv;
 }
 
 bool aws_byte_cursor_eq_ignore_case(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(b), "Input aws_byte_cursor [b] must be valid.");
     bool rv = aws_array_eq_ignore_case(a->ptr, a->len, b->ptr, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_cursor_is_valid(b), "");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(b), "Output aws_byte_cursor [b] must be valid.");
     return rv;
 }
 
@@ -431,32 +435,38 @@ uint64_t aws_hash_byte_cursor_ptr_ignore_case(const void *item) {
 }
 
 bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
     bool rv = aws_array_eq(a->ptr, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
     return rv;
 }
 
 bool aws_byte_cursor_eq_byte_buf_ignore_case(
     const struct aws_byte_cursor *const a,
     const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
     bool rv = aws_array_eq_ignore_case(a->ptr, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a) && aws_byte_buf_is_valid(b), "");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
     return rv;
 }
 
 bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor) && c_str, "");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
+    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rv = aws_array_eq_c_str(cursor->ptr, cursor->len, c_str);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
     return rv;
 }
 
 bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cursor, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor) && c_str, "");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
+    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rv = aws_array_eq_c_str_ignore_case(cursor->ptr, cursor->len, c_str);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
     return rv;
 }
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -82,7 +82,7 @@ void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents) {
 }
 
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
     if (buf->allocator && buf->buffer) {
         aws_mem_release(buf->allocator, (void *)buf->buffer);
     }
@@ -93,7 +93,7 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
     if (buf->buffer) {
         aws_secure_zero(buf->buffer, buf->capacity);
     }
@@ -102,7 +102,7 @@ void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
     aws_byte_buf_secure_zero(buf);
     aws_byte_buf_clean_up(buf);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
@@ -447,8 +447,8 @@ bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cu
 }
 
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
 
     if (to->capacity - to->len < from->len) {
         AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
@@ -473,9 +473,10 @@ int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,
     const uint8_t *lookup_table) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
-    AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(
+        AWS_MEM_IS_READABLE(lookup_table, 256), "Input array [lookup_table] must be at least 256 bytes long.");
 
     if (to->capacity - to->len < from->len) {
         AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
@@ -497,8 +498,8 @@ int aws_byte_buf_append_with_lookup(
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
     if (!to->allocator) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -36,7 +36,7 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
     buf->len = 0;
     buf->capacity = capacity;
     buf->allocator = allocator;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return AWS_OP_SUCCESS;
 }
 
@@ -48,7 +48,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     if (!src->buffer) {
         AWS_ZERO_STRUCT(*dest);
         dest->allocator = allocator;
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest), "Output aws_byte_buf [dest] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
         return AWS_OP_SUCCESS;
     }
 
@@ -60,7 +60,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         return AWS_OP_ERR;
     }
     memcpy(dest->buffer, src->buffer, src->len);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest), "Output aws_byte_buf [dest] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
     return AWS_OP_SUCCESS;
 }
 
@@ -82,7 +82,7 @@ void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents) {
 }
 
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     if (buf->allocator && buf->buffer) {
         aws_mem_release(buf->allocator, (void *)buf->buffer);
     }
@@ -93,52 +93,52 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     if (buf->buffer) {
         aws_secure_zero(buf->buffer, buf->capacity);
     }
     buf->len = 0;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
 }
 
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     aws_byte_buf_secure_zero(buf);
     aws_byte_buf_clean_up(buf);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
 }
 
 bool aws_byte_buf_eq(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(a), "Input aws_byte_buf [a] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b));
     bool rval = aws_array_eq(a->buffer, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(a), "Output aws_byte_buf [a] must be valid.");
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(a));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b));
     return rval;
 }
 
 bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(a), "Input aws_byte_buf [a] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b));
     bool rval = aws_array_eq_ignore_case(a->buffer, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(a), "Output aws_byte_buf [a] must be valid.");
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(a));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b));
     return rval;
 }
 
 bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rval = aws_array_eq_c_str(buf->buffer, buf->len, c_str);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return rval;
 }
 
 bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *const buf, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
     AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rval = aws_array_eq_c_str_ignore_case(buf->buffer, buf->len, c_str);
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf), "Output aws_byte_buf [buf] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return rval;
 }
 
@@ -163,7 +163,7 @@ int aws_byte_buf_init_copy_from_cursor(
     if (src.len > 0) {
         memcpy(dest->buffer, src.ptr, src.len);
     }
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest), "Output aws_byte_buf [dest] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
     return AWS_OP_SUCCESS;
 }
 
@@ -278,20 +278,20 @@ int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...) {
 }
 
 bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(b), "Input aws_byte_cursor [b] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(b));
     bool rv = aws_array_eq(a->ptr, a->len, b->ptr, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(b), "Output aws_byte_cursor [b] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(b));
     return rv;
 }
 
 bool aws_byte_cursor_eq_ignore_case(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(b), "Input aws_byte_cursor [b] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(b));
     bool rv = aws_array_eq_ignore_case(a->ptr, a->len, b->ptr, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(b), "Output aws_byte_cursor [b] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(b));
     return rv;
 }
 
@@ -435,48 +435,48 @@ uint64_t aws_hash_byte_cursor_ptr_ignore_case(const void *item) {
 }
 
 bool aws_byte_cursor_eq_byte_buf(const struct aws_byte_cursor *const a, const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b));
     bool rv = aws_array_eq(a->ptr, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b));
     return rv;
 }
 
 bool aws_byte_cursor_eq_byte_buf_ignore_case(
     const struct aws_byte_cursor *const a,
     const struct aws_byte_buf *const b) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(a), "Input aws_byte_cursor [a] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(b), "Input aws_byte_buf [b] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(a));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b));
     bool rv = aws_array_eq_ignore_case(a->ptr, a->len, b->buffer, b->len);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a), "Output aws_byte_cursor [a] must be valid.");
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(b), "Output aws_byte_buf [b] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(a));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(b));
     return rv;
 }
 
 bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
     AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rv = aws_array_eq_c_str(cursor->ptr, cursor->len, c_str);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
     return rv;
 }
 
 bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cursor, const char *const c_str) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor), "Input aws_byte_cursor [cursor] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
     AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
     bool rv = aws_array_eq_c_str_ignore_case(cursor->ptr, cursor->len, c_str);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor), "Output aws_byte_cursor [cursor] must be valid.");
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
     return rv;
 }
 
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input aws_byte_buf [to] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
 
     if (to->capacity - to->len < from->len) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
         return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
     }
 
@@ -488,8 +488,8 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
         to->len += from->len;
     }
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
     return AWS_OP_SUCCESS;
 }
 
@@ -497,14 +497,14 @@ int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,
     const uint8_t *lookup_table) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input aws_byte_buf [to] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
     AWS_PRECONDITION(
         AWS_MEM_IS_READABLE(lookup_table, 256), "Input array [lookup_table] must be at least 256 bytes long.");
 
     if (to->capacity - to->len < from->len) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
         return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
     }
 
@@ -516,14 +516,14 @@ int aws_byte_buf_append_with_lookup(
         return AWS_OP_ERR;
     }
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
     return AWS_OP_SUCCESS;
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input aws_byte_buf [to] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
     if (!to->allocator) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
@@ -536,8 +536,8 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
         size_t required_capacity = 0;
         if (aws_add_size_checked(to->capacity, missing_capacity, &required_capacity)) {
-            AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-            AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+            AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
             return AWS_OP_ERR;
         }
 
@@ -567,13 +567,13 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
                 new_capacity = required_capacity;
                 new_buffer = aws_mem_acquire(to->allocator, new_capacity);
                 if (new_buffer == NULL) {
-                    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-                    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+                    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+                    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
                     return AWS_OP_ERR;
                 }
             } else {
-                AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-                AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+                AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+                AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
                 return AWS_OP_ERR;
             }
         }
@@ -611,8 +611,8 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
     to->len += from->len;
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(to), "Output aws_byte_buf [to] must be valid.");
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from), "Output aws_byte_cursor [from] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
     return AWS_OP_SUCCESS;
 }
 
@@ -622,18 +622,18 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
     }
 
     if (requested_capacity <= buffer->capacity) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
         return AWS_OP_SUCCESS;
     }
 
     if (aws_mem_realloc(buffer->allocator, (void **)&buffer->buffer, buffer->capacity, requested_capacity)) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
         return AWS_OP_ERR;
     }
 
     buffer->capacity = requested_capacity;
 
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
     return AWS_OP_SUCCESS;
 }
 
@@ -644,7 +644,7 @@ int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional
 
     size_t requested_capacity = 0;
     if (AWS_UNLIKELY(aws_add_size_checked(buffer->len, additional_length, &requested_capacity))) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer), "Output aws_byte_buf [buffer] must be valid.");
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
         return AWS_OP_ERR;
     }
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -82,7 +82,7 @@ void aws_byte_buf_reset(struct aws_byte_buf *buf, bool zero_contents) {
 }
 
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     if (buf->allocator && buf->buffer) {
         aws_mem_release(buf->allocator, (void *)buf->buffer);
     }
@@ -93,7 +93,7 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     if (buf->buffer) {
         aws_secure_zero(buf->buffer, buf->capacity);
     }
@@ -102,7 +102,7 @@ void aws_byte_buf_secure_zero(struct aws_byte_buf *buf) {
 }
 
 void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input byte_buf [buf] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf), "Input aws_byte_buf [buf] must be valid.");
     aws_byte_buf_secure_zero(buf);
     aws_byte_buf_clean_up(buf);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
@@ -447,8 +447,8 @@ bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cu
 }
 
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input aws_byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
 
     if (to->capacity - to->len < from->len) {
         AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
@@ -473,8 +473,8 @@ int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,
     const uint8_t *lookup_table) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input aws_byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
     AWS_PRECONDITION(
         AWS_MEM_IS_READABLE(lookup_table, 256), "Input array [lookup_table] must be at least 256 bytes long.");
 
@@ -498,8 +498,8 @@ int aws_byte_buf_append_with_lookup(
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input byte_buf [to] must be valid.");
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input byte_cursor [from] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to), "Input aws_byte_buf [to] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(from), "Input aws_byte_cursor [from] must be valid.");
     if (!to->allocator) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -128,7 +128,7 @@ bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *const a, const struc
 
 bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
+    AWS_PRECONDITION(c_str != NULL);
     bool rval = aws_array_eq_c_str(buf->buffer, buf->len, c_str);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return rval;
@@ -136,7 +136,7 @@ bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *con
 
 bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *const buf, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
+    AWS_PRECONDITION(c_str != NULL);
     bool rval = aws_array_eq_c_str_ignore_case(buf->buffer, buf->len, c_str);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return rval;
@@ -360,7 +360,7 @@ bool aws_array_eq_c_str_ignore_case(const void *const array, const size_t array_
     AWS_PRECONDITION(
         array || (array_len == 0),
         "Either input pointer [array_a] mustn't be NULL or input [array_len] mustn't be zero.");
-    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
+    AWS_PRECONDITION(c_str != NULL);
 
     /* Simpler implementation could have been:
      *   return aws_array_eq_ignore_case(array, array_len, c_str, strlen(c_str));
@@ -388,7 +388,7 @@ bool aws_array_eq_c_str(const void *const array, const size_t array_len, const c
     AWS_PRECONDITION(
         array || (array_len == 0),
         "Either input pointer [array_a] mustn't be NULL or input [array_len] mustn't be zero.");
-    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
+    AWS_PRECONDITION(c_str != NULL);
 
     /* Simpler implementation could have been:
      *   return aws_array_eq(array, array_len, c_str, strlen(c_str));
@@ -456,7 +456,7 @@ bool aws_byte_cursor_eq_byte_buf_ignore_case(
 
 bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
+    AWS_PRECONDITION(c_str != NULL);
     bool rv = aws_array_eq_c_str(cursor->ptr, cursor->len, c_str);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
     return rv;
@@ -464,7 +464,7 @@ bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const 
 
 bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cursor, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_PRECONDITION(c_str, "Input pointer [c_str] mustn't be NULL.");
+    AWS_PRECONDITION(c_str != NULL);
     bool rv = aws_array_eq_c_str_ignore_case(cursor->ptr, cursor->len, c_str);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
     return rv;

--- a/source/common.c
+++ b/source/common.c
@@ -74,7 +74,7 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
 }
 
 void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
-    AWS_PRECONDITION(allocator, "Input pointer [allocator] mustn't be NULL.");
+    AWS_PRECONDITION(allocator != NULL);
 
     /* Defensive check: never use calloc with size * num that would overflow
      * https://wiki.sei.cmu.edu/confluence/display/c/MEM07-C.+Ensure+that+the+arguments+to+calloc%28%29%2C+when+multiplied%2C+do+not+wrap
@@ -99,7 +99,7 @@ void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
         return NULL;
     }
     memset(mem, 0, required_bytes);
-    AWS_POSTCONDITION(mem != NULL, "Output pointer [mem] mustn't be NULL.");
+    AWS_POSTCONDITION(mem != NULL);
     return mem;
 }
 

--- a/source/common.c
+++ b/source/common.c
@@ -99,7 +99,7 @@ void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
         return NULL;
     }
     memset(mem, 0, required_bytes);
-    AWS_POSTCONDITION(mem != NULL);
+    AWS_POSTCONDITION(mem != NULL, "Output pointer [mem] mustn't be NULL.");
     return mem;
 }
 

--- a/source/common.c
+++ b/source/common.c
@@ -74,7 +74,7 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
 }
 
 void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
-    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(allocator, "Input pointer [allocator] mustn't be NULL.");
 
     /* Defensive check: never use calloc with size * num that would overflow
      * https://wiki.sei.cmu.edu/confluence/display/c/MEM07-C.+Ensure+that+the+arguments+to+calloc%28%29%2C+when+multiplied%2C+do+not+wrap

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -88,8 +88,8 @@ int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length) {
 }
 
 int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode), "Input aws_byte_cursor [to_encode] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input aws_byte_buf [output] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
 
     size_t encoded_len = 0;
 
@@ -174,8 +174,8 @@ int aws_hex_compute_decoded_len(size_t to_decode_len, size_t *decoded_len) {
 }
 
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode), "Input aws_byte_cursor [to_decode] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input aws_byte_buf [output] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
 
     size_t decoded_length = 0;
 

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -88,8 +88,8 @@ int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length) {
 }
 
 int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode), "Input byte_cursor [to_encode] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input byte_buf [output] must be valid.");
 
     size_t encoded_len = 0;
 
@@ -174,8 +174,8 @@ int aws_hex_compute_decoded_len(size_t to_decode_len, size_t *decoded_len) {
 }
 
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode), "Input byte_cursor [to_decode] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input byte_buf [output] must be valid.");
 
     size_t decoded_length = 0;
 

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -88,8 +88,8 @@ int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length) {
 }
 
 int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode), "Input byte_cursor [to_encode] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input byte_buf [output] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_encode), "Input aws_byte_cursor [to_encode] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input aws_byte_buf [output] must be valid.");
 
     size_t encoded_len = 0;
 
@@ -174,8 +174,8 @@ int aws_hex_compute_decoded_len(size_t to_decode_len, size_t *decoded_len) {
 }
 
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode), "Input byte_cursor [to_decode] must be valid.");
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input byte_buf [output] must be valid.");
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(to_decode), "Input aws_byte_cursor [to_decode] must be valid.");
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output), "Input aws_byte_buf [output] must be valid.");
 
     size_t decoded_length = 0;
 

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -83,9 +83,9 @@ static bool s_safe_eq_check(aws_hash_callback_eq_fn *equals_fn, const void *a, c
  * Check equality of two hash keys, with a reasonable semantics for null keys.
  */
 static bool s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state), "");
+    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
     bool rval = s_safe_eq_check(state->equals_fn, a, b);
-    AWS_POSTCONDITION(hash_table_state_is_valid(state), "");
+    AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
     return rval;
 }
 
@@ -417,7 +417,7 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
     } else {
         *p_elem = NULL;
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table_state [map] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -660,9 +660,9 @@ int aws_hash_table_remove(
     const void *key,
     struct aws_hash_element *p_value,
     int *was_present) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "");
-    AWS_PRECONDITION(p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value), "");
-    AWS_PRECONDITION(was_present == NULL || AWS_OBJECT_PTR_IS_WRITABLE(was_present), "");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
+    AWS_PRECONDITION(p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value), "Input pointer [p_value] must be NULL or writable.");
+    AWS_PRECONDITION(was_present == NULL || AWS_OBJECT_PTR_IS_WRITABLE(was_present), "Input pointer [was_present] must be NULL or writable.");
 
     struct hash_table_state *state = map->p_impl;
     uint64_t hash_code = s_hash_for(state, key);
@@ -677,7 +677,7 @@ int aws_hash_table_remove(
 
     if (rv != AWS_ERROR_SUCCESS) {
         *was_present = 0;
-        AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
+        AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
         return AWS_OP_SUCCESS;
     }
 
@@ -695,20 +695,20 @@ int aws_hash_table_remove(
     }
     s_remove_entry(state, entry);
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
 int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "");
-    AWS_PRECONDITION(p_value, "");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
+    AWS_PRECONDITION(p_value, "Input pointer [p_value] mustn't be NULL.");
 
     struct hash_table_state *state = map->p_impl;
     struct hash_table_entry *entry = AWS_CONTAINER_OF(p_value, struct hash_table_entry, element);
 
     s_remove_entry(state, entry);
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
     return AWS_OP_SUCCESS;
 }
 
@@ -736,13 +736,13 @@ bool aws_hash_table_eq(
     const struct aws_hash_table *a,
     const struct aws_hash_table *b,
     aws_hash_callback_eq_fn *value_eq) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(a), "");
-    AWS_PRECONDITION(aws_hash_table_is_valid(b), "");
-    AWS_PRECONDITION(value_eq != NULL, "");
+    AWS_PRECONDITION(aws_hash_table_is_valid(a), "Input hash_table [a] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(b), "Input hash_table [b] must be valid.");
+    AWS_PRECONDITION(value_eq != NULL, "Input pointer [value_eq] mustn't be NULL.");
 
     if (aws_hash_table_get_entry_count(a) != aws_hash_table_get_entry_count(b)) {
-        AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
-        AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
+        AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
+        AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
 
         return false;
     }
@@ -764,19 +764,19 @@ bool aws_hash_table_eq(
 
         if (!b_element) {
             /* Key is present in A only */
-            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
-            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
             return false;
         }
 
         if (!s_safe_eq_check(value_eq, a_entry->element.value, b_element->value)) {
-            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
-            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
             return false;
         }
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
-    AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
     return true;
 }
 

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -47,7 +47,7 @@ static void s_suppress_unused_lookup3_func_warnings(void) {
  * Ensures that no object ever hashes to 0, which is the sentinal value for an empty hash element.
  */
 static uint64_t s_hash_for(struct hash_table_state *state, const void *key) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
+    AWS_PRECONDITION(hash_table_state_is_valid(state));
     s_suppress_unused_lookup3_func_warnings();
 
     if (key == NULL) {
@@ -59,7 +59,7 @@ static uint64_t s_hash_for(struct hash_table_state *state, const void *key) {
     if (!hash_code) {
         hash_code = 1;
     }
-    AWS_POSTCONDITION(hash_code != 0, "Output uint64_t [hash_code] mustn't be zero.");
+    AWS_POSTCONDITION(hash_code != 0);
     return hash_code;
 }
 
@@ -83,17 +83,17 @@ static bool s_safe_eq_check(aws_hash_callback_eq_fn *equals_fn, const void *a, c
  * Check equality of two hash keys, with a reasonable semantics for null keys.
  */
 static bool s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
+    AWS_PRECONDITION(hash_table_state_is_valid(state));
     bool rval = s_safe_eq_check(state->equals_fn, a, b);
-    AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
+    AWS_POSTCONDITION(hash_table_state_is_valid(state));
     return rval;
 }
 
 static size_t s_index_for(struct hash_table_state *map, struct hash_table_entry *entry) {
-    AWS_PRECONDITION(hash_table_state_is_valid(map), "Input hash_table_state [map] must be valid.");
+    AWS_PRECONDITION(hash_table_state_is_valid(map));
     size_t index = entry - map->slots;
-    AWS_POSTCONDITION(index < map->size, "Output size_t [index] must be less than [map->size].");
-    AWS_POSTCONDITION(hash_table_state_is_valid(map), "Output hash_table_state [map] must be valid.");
+    AWS_POSTCONDITION(index < map->size);
+    AWS_POSTCONDITION(hash_table_state_is_valid(map));
     return index;
 }
 
@@ -232,10 +232,10 @@ int aws_hash_table_init(
     aws_hash_callback_eq_fn *equals_fn,
     aws_hash_callback_destroy_fn *destroy_key_fn,
     aws_hash_callback_destroy_fn *destroy_value_fn) {
-    AWS_PRECONDITION(map, "Input pointer [map] mustn't be NULL.");
-    AWS_PRECONDITION(alloc, "Input pointer [alloc] mustn't be NULL.");
-    AWS_PRECONDITION(hash_fn, "Input pointer [hash_fn] mustn't be NULL.");
-    AWS_PRECONDITION(equals_fn, "Input pointer [equals_fn] mustn't be NULL.");
+    AWS_PRECONDITION(map != NULL);
+    AWS_PRECONDITION(alloc != NULL);
+    AWS_PRECONDITION(hash_fn != NULL);
+    AWS_PRECONDITION(equals_fn != NULL);
 
     struct hash_table_state template;
     template.hash_fn = hash_fn;
@@ -256,12 +256,12 @@ int aws_hash_table_init(
         return AWS_OP_ERR;
     }
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output aws_hash_table [map] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
     return AWS_OP_SUCCESS;
 }
 
 void aws_hash_table_clean_up(struct aws_hash_table *map) {
-    AWS_PRECONDITION(map, "Input aws_hash_table pointer [map] mustn't be NULL.");
+    AWS_PRECONDITION(map != NULL);
     AWS_PRECONDITION(
         map->p_impl == NULL || aws_hash_table_is_valid(map),
         "Input aws_hash_table [map] must be valid or hash_table_state pointer [map->p_impl] must be NULL, in case "
@@ -277,7 +277,7 @@ void aws_hash_table_clean_up(struct aws_hash_table *map) {
     aws_mem_release(map->p_impl->alloc, map->p_impl);
 
     map->p_impl = NULL;
-    AWS_POSTCONDITION(map->p_impl == NULL, "Output hash_table_state [map->p_impl] must be NULL.");
+    AWS_POSTCONDITION(map->p_impl == NULL);
 }
 
 void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_table *AWS_RESTRICT b) {
@@ -288,14 +288,14 @@ void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_
 }
 
 void aws_hash_table_move(struct aws_hash_table *AWS_RESTRICT to, struct aws_hash_table *AWS_RESTRICT from) {
-    AWS_PRECONDITION(to, "Input pointer [to] mustn't be NULL.");
-    AWS_PRECONDITION(from, "Input pointer [from] mustn't be NULL.");
+    AWS_PRECONDITION(to != NULL);
+    AWS_PRECONDITION(from != NULL);
     AWS_PRECONDITION(to != from, "Input pointers [to] and [from] mustn't be aliased.");
-    AWS_PRECONDITION(aws_hash_table_is_valid(from), "Input aws_hash_table [from] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(from));
 
     *to = *from;
     AWS_ZERO_STRUCT(*from);
-    AWS_POSTCONDITION(aws_hash_table_is_valid(to), "Output aws_hash_table [to] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(to));
 }
 
 /* Tries to find where the requested key is or where it should go if put.
@@ -403,7 +403,7 @@ static int s_find_entry1(
 }
 
 int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struct aws_hash_element **p_elem) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input aws_hash_table [map] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
     AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(p_elem), "Input aws_hash_element pointer [p_elem] must be writable.");
 
     struct hash_table_state *state = map->p_impl;
@@ -417,7 +417,7 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
     } else {
         *p_elem = NULL;
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table_state [map] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
     return AWS_OP_SUCCESS;
 }
 
@@ -432,10 +432,10 @@ static struct hash_table_entry *s_emplace_item(
     struct hash_table_state *state,
     struct hash_table_entry entry,
     size_t probe_idx) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
+    AWS_PRECONDITION(hash_table_state_is_valid(state));
 
     if (entry.hash_code == 0) {
-        AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
+        AWS_POSTCONDITION(hash_table_state_is_valid(state));
         return NULL;
     }
 
@@ -471,7 +471,7 @@ static struct hash_table_entry *s_emplace_item(
         }
     }
 
-    AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
+    AWS_POSTCONDITION(hash_table_state_is_valid(state));
     AWS_POSTCONDITION(
         rval >= &state->slots[0] && rval < &state->slots[state->size],
         "Output hash_table_entry pointer [rval] must point in the slots of [state].");
@@ -614,8 +614,8 @@ int aws_hash_table_put(struct aws_hash_table *map, const void *key, void *value,
  * lower than the original entry's index)
  */
 static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_entry *entry) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state), "Input hash_table_state [state] must be valid.");
-    AWS_PRECONDITION(state->entry_count > 0, "Input hash_table_state [state] must contain at least one entry.");
+    AWS_PRECONDITION(hash_table_state_is_valid(state));
+    AWS_PRECONDITION(state->entry_count > 0);
     AWS_PRECONDITION(
         entry >= &state->slots[0] && entry < &state->slots[state->size],
         "Input hash_table_entry [entry] pointer must point in the available slots.");
@@ -650,8 +650,8 @@ static size_t s_remove_entry(struct hash_table_state *state, struct hash_table_e
 
     /* Clear the entry we shifted out of */
     AWS_ZERO_STRUCT(state->slots[index]);
-    AWS_POSTCONDITION(hash_table_state_is_valid(state), "Output hash_table_state [state] must be valid.");
-    AWS_POSTCONDITION(index <= state->size, "Output size_t [index] must be smaller than [state->size].");
+    AWS_POSTCONDITION(hash_table_state_is_valid(state));
+    AWS_POSTCONDITION(index <= state->size);
     return index;
 }
 
@@ -660,7 +660,7 @@ int aws_hash_table_remove(
     const void *key,
     struct aws_hash_element *p_value,
     int *was_present) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
     AWS_PRECONDITION(
         p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value), "Input pointer [p_value] must be NULL or writable.");
     AWS_PRECONDITION(
@@ -680,7 +680,7 @@ int aws_hash_table_remove(
 
     if (rv != AWS_ERROR_SUCCESS) {
         *was_present = 0;
-        AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
+        AWS_POSTCONDITION(aws_hash_table_is_valid(map));
         return AWS_OP_SUCCESS;
     }
 
@@ -698,20 +698,20 @@ int aws_hash_table_remove(
     }
     s_remove_entry(state, entry);
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
     return AWS_OP_SUCCESS;
 }
 
 int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
-    AWS_PRECONDITION(p_value, "Input pointer [p_value] mustn't be NULL.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+    AWS_PRECONDITION(p_value != NULL);
 
     struct hash_table_state *state = map->p_impl;
     struct hash_table_entry *entry = AWS_CONTAINER_OF(p_value, struct hash_table_entry, element);
 
     s_remove_entry(state, entry);
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
     return AWS_OP_SUCCESS;
 }
 
@@ -739,13 +739,13 @@ bool aws_hash_table_eq(
     const struct aws_hash_table *a,
     const struct aws_hash_table *b,
     aws_hash_callback_eq_fn *value_eq) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(a), "Input hash_table [a] must be valid.");
-    AWS_PRECONDITION(aws_hash_table_is_valid(b), "Input hash_table [b] must be valid.");
-    AWS_PRECONDITION(value_eq != NULL, "Input pointer [value_eq] mustn't be NULL.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(a));
+    AWS_PRECONDITION(aws_hash_table_is_valid(b));
+    AWS_PRECONDITION(value_eq != NULL);
 
     if (aws_hash_table_get_entry_count(a) != aws_hash_table_get_entry_count(b)) {
-        AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
-        AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
+        AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+        AWS_POSTCONDITION(aws_hash_table_is_valid(b));
 
         return false;
     }
@@ -767,19 +767,19 @@ bool aws_hash_table_eq(
 
         if (!b_element) {
             /* Key is present in A only */
-            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
-            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b));
             return false;
         }
 
         if (!s_safe_eq_check(value_eq, a_entry->element.value, b_element->value)) {
-            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
-            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b));
             return false;
         }
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(a), "Output hash_table [a] must be valid.");
-    AWS_POSTCONDITION(aws_hash_table_is_valid(b), "Output hash_table [b] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(b));
     return true;
 }
 
@@ -793,8 +793,8 @@ bool aws_hash_table_eq(
  * iterator which is "done".
  */
 static inline void s_get_next_element(struct aws_hash_iter *iter, size_t start_slot) {
-    AWS_PRECONDITION(iter != NULL, "Input pointer [iter] mustn't be NULL.");
-    AWS_PRECONDITION(aws_hash_table_is_valid(iter->map), "The aws_hash_table pointed by input [iter] must be valid.");
+    AWS_PRECONDITION(iter != NULL);
+    AWS_PRECONDITION(aws_hash_table_is_valid(iter->map));
     struct hash_table_state *state = iter->map->p_impl;
     size_t limit = iter->limit;
 
@@ -812,11 +812,11 @@ static inline void s_get_next_element(struct aws_hash_iter *iter, size_t start_s
     iter->element.value = NULL;
     iter->slot = iter->limit;
     iter->status = AWS_HASH_ITER_STATUS_DONE;
-    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter), "Output aws_hash_iter [iter] must be valid.");
+    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter));
 }
 
 struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input aws_hash_table [map] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
     AWS_ZERO_STRUCT(iter);
@@ -826,12 +826,12 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
     AWS_POSTCONDITION(
         iter.status == AWS_HASH_ITER_STATUS_DONE || iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
         "The status of output aws_hash_iter [iter] must either be DONE or READY_FOR_USE.");
-    AWS_POSTCONDITION(aws_hash_iter_is_valid(&iter), "Output aws_hash_iter [iter] must be valid.");
+    AWS_POSTCONDITION(aws_hash_iter_is_valid(&iter));
     return iter;
 }
 
 bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input aws_hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
     AWS_PRECONDITION(
         iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
         "Input aws_hash_iter [iter] must either be done, or ready to use.");
@@ -848,12 +848,12 @@ bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
     AWS_POSTCONDITION(
         rval == (iter->status == AWS_HASH_ITER_STATUS_DONE),
         "Output bool [rval] must be true if and only if the status of [iter] is DONE.");
-    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter), "Output aws_hash_iter [iter] must be valid.");
+    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter));
     return rval;
 }
 
 void aws_hash_iter_next(struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input aws_hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
     s_get_next_element(iter, iter->slot + 1);
@@ -861,13 +861,13 @@ void aws_hash_iter_next(struct aws_hash_iter *iter) {
     AWS_POSTCONDITION(
         iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
         "The status of output aws_hash_iter [iter] must either be DONE or READY_FOR_USE.");
-    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter), "Output aws_hash_iter [iter] must be valid.");
+    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter));
 }
 
 void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents) {
     AWS_PRECONDITION(
         iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE, "Input aws_hash_iter [iter] must be ready for use.");
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input aws_hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter));
     AWS_PRECONDITION(
         iter->map->p_impl->entry_count > 0,
         "The hash_table_state pointed by input [iter] must contain at least one entry.");
@@ -917,11 +917,11 @@ void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents) {
     AWS_POSTCONDITION(
         iter->status == AWS_HASH_ITER_STATUS_DELETE_CALLED,
         "The status of output aws_hash_iter [iter] must be DELETE_CALLED.");
-    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter), "Output aws_hash_iter [iter] must be valid.");
+    AWS_POSTCONDITION(aws_hash_iter_is_valid(iter));
 }
 
 void aws_hash_table_clear(struct aws_hash_table *map) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input aws_hash_table [map] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
     struct hash_table_state *state = map->p_impl;
 
     /* Check that we have at least one destructor before iterating over the table */
@@ -944,7 +944,7 @@ void aws_hash_table_clear(struct aws_hash_table *map) {
     memset(state->slots, 0, sizeof(*state->slots) * state->size);
 
     state->entry_count = 0;
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output aws_hash_table [map] must be valid.");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
 }
 
 uint64_t aws_hash_c_string(const void *item) {
@@ -988,25 +988,25 @@ uint64_t aws_hash_ptr(const void *item) {
 }
 
 bool aws_hash_callback_c_str_eq(const void *a, const void *b) {
-    AWS_PRECONDITION(aws_c_string_is_valid(a), "Input c_string [a] must be valid.");
-    AWS_PRECONDITION(aws_c_string_is_valid(b), "Input c_string [b] must be valid.");
+    AWS_PRECONDITION(aws_c_string_is_valid(a));
+    AWS_PRECONDITION(aws_c_string_is_valid(b));
     bool rval = !strcmp(a, b);
-    AWS_POSTCONDITION(aws_c_string_is_valid(a), "Output c_string [a] must be valid.");
-    AWS_POSTCONDITION(aws_c_string_is_valid(b), "Output c_string [b] must be valid.");
+    AWS_POSTCONDITION(aws_c_string_is_valid(a));
+    AWS_POSTCONDITION(aws_c_string_is_valid(b));
     return rval;
 }
 
 bool aws_hash_callback_string_eq(const void *a, const void *b) {
-    AWS_PRECONDITION(aws_string_is_valid(a), "Input [a] must be a valid string.");
-    AWS_PRECONDITION(aws_string_is_valid(b), "Input [b] must be a valid string.");
+    AWS_PRECONDITION(aws_string_is_valid(a));
+    AWS_PRECONDITION(aws_string_is_valid(b));
     bool rval = aws_string_eq(a, b);
-    AWS_POSTCONDITION(aws_string_is_valid(a), "Output string [a] must be valid.");
-    AWS_POSTCONDITION(aws_string_is_valid(b), "Output string [b] must be valid.");
+    AWS_POSTCONDITION(aws_string_is_valid(a));
+    AWS_POSTCONDITION(aws_string_is_valid(b));
     return rval;
 }
 
 void aws_hash_callback_string_destroy(void *a) {
-    AWS_PRECONDITION(aws_string_is_valid(a), "Input [a] must be a valid c_string.");
+    AWS_PRECONDITION(aws_string_is_valid(a));
     aws_string_destroy(a);
 }
 

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -403,7 +403,6 @@ static int s_find_entry1(
 }
 
 int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struct aws_hash_element **p_elem) {
-
     AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input aws_hash_table [map] must be valid.");
     AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(p_elem), "Input aws_hash_element pointer [p_elem] must be writable.");
 

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -278,7 +278,7 @@ void aws_hash_table_clean_up(struct aws_hash_table *map) {
 }
 
 void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_table *AWS_RESTRICT b) {
-    AWS_PRECONDITION(a != b, "Input hash_tables [a] and [b] must be different.");
+    AWS_PRECONDITION(a != b, "Input aws_hash_tables [a] and [b] must be different.");
     struct aws_hash_table tmp = *a;
     *a = *b;
     *b = tmp;
@@ -288,7 +288,7 @@ void aws_hash_table_move(struct aws_hash_table *AWS_RESTRICT to, struct aws_hash
     AWS_PRECONDITION(to, "Input pointer [to] mustn't be NULL.");
     AWS_PRECONDITION(from, "Input pointer [from] mustn't be NULL.");
     AWS_PRECONDITION(to != from, "Input pointers [to] and [from] mustn't be aliased.");
-    AWS_PRECONDITION(aws_hash_table_is_valid(from), "Input hash_table [from] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(from), "Input aws_hash_table [from] must be valid.");
 
     *to = *from;
     AWS_ZERO_STRUCT(*from);
@@ -787,7 +787,7 @@ bool aws_hash_table_eq(
  */
 static inline void s_get_next_element(struct aws_hash_iter *iter, size_t start_slot) {
     AWS_PRECONDITION(iter != NULL, "Input pointer [iter] mustn't be NULL.");
-    AWS_PRECONDITION(aws_hash_table_is_valid(iter->map), "The hash_table pointed by input [iter] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(iter->map), "The aws_hash_table pointed by input [iter] must be valid.");
     struct hash_table_state *state = iter->map->p_impl;
     size_t limit = iter->limit;
 
@@ -809,7 +809,7 @@ static inline void s_get_next_element(struct aws_hash_iter *iter, size_t start_s
 }
 
 struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input aws_hash_table [map] must be valid.");
     struct hash_table_state *state = map->p_impl;
     struct aws_hash_iter iter;
     AWS_ZERO_STRUCT(iter);
@@ -822,10 +822,10 @@ struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
 }
 
 bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input aws_hash_iter [iter] must be valid.");
     AWS_PRECONDITION(
         iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
-        "Input hash_iter [iter] must either be done, or ready to use.");
+        "Input aws_hash_iter [iter] must either be done, or ready to use.");
     /*
      * SIZE_MAX is a valid (non-terminal) value for iter->slot in the event that
      * we delete slot 0. See comments in aws_hash_iter_delete.
@@ -840,7 +840,7 @@ bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
 }
 
 void aws_hash_iter_next(struct aws_hash_iter *iter) {
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input hash_iter [iter] must be valid.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input aws_hash_iter [iter] must be valid.");
 #pragma CPROVER check push
 #pragma CPROVER check disable "unsigned-overflow"
     s_get_next_element(iter, iter->slot + 1);
@@ -851,8 +851,8 @@ void aws_hash_iter_next(struct aws_hash_iter *iter) {
 
 void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents) {
     AWS_PRECONDITION(
-        iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE, "Input hash_iter [iter] must be ready for use.");
-    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input hash_iter [iter] must be valid.");
+        iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE, "Input aws_hash_iter [iter] must be ready for use.");
+    AWS_PRECONDITION(aws_hash_iter_is_valid(iter), "Input aws_hash_iter [iter] must be valid.");
     AWS_PRECONDITION(
         iter->map->p_impl->entry_count > 0,
         "The hash_table_state pointed by input [iter] must contain at least one entry.");

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -661,8 +661,11 @@ int aws_hash_table_remove(
     struct aws_hash_element *p_value,
     int *was_present) {
     AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
-    AWS_PRECONDITION(p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value), "Input pointer [p_value] must be NULL or writable.");
-    AWS_PRECONDITION(was_present == NULL || AWS_OBJECT_PTR_IS_WRITABLE(was_present), "Input pointer [was_present] must be NULL or writable.");
+    AWS_PRECONDITION(
+        p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value), "Input pointer [p_value] must be NULL or writable.");
+    AWS_PRECONDITION(
+        was_present == NULL || AWS_OBJECT_PTR_IS_WRITABLE(was_present),
+        "Input pointer [was_present] must be NULL or writable.");
 
     struct hash_table_state *state = map->p_impl;
     uint64_t hash_code = s_hash_for(state, key);

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -281,7 +281,7 @@ void aws_hash_table_clean_up(struct aws_hash_table *map) {
 }
 
 void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_table *AWS_RESTRICT b) {
-    AWS_PRECONDITION(a != b, "Input aws_hash_tables [a] and [b] must be different.");
+    AWS_PRECONDITION(a != b);
     struct aws_hash_table tmp = *a;
     *a = *b;
     *b = tmp;
@@ -290,7 +290,7 @@ void aws_hash_table_swap(struct aws_hash_table *AWS_RESTRICT a, struct aws_hash_
 void aws_hash_table_move(struct aws_hash_table *AWS_RESTRICT to, struct aws_hash_table *AWS_RESTRICT from) {
     AWS_PRECONDITION(to != NULL);
     AWS_PRECONDITION(from != NULL);
-    AWS_PRECONDITION(to != from, "Input pointers [to] and [from] mustn't be aliased.");
+    AWS_PRECONDITION(to != from);
     AWS_PRECONDITION(aws_hash_table_is_valid(from));
 
     *to = *from;

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -83,9 +83,9 @@ static bool s_safe_eq_check(aws_hash_callback_eq_fn *equals_fn, const void *a, c
  * Check equality of two hash keys, with a reasonable semantics for null keys.
  */
 static bool s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state));
+    AWS_PRECONDITION(hash_table_state_is_valid(state), "");
     bool rval = s_safe_eq_check(state->equals_fn, a, b);
-    AWS_POSTCONDITION(hash_table_state_is_valid(state));
+    AWS_POSTCONDITION(hash_table_state_is_valid(state), "");
     return rval;
 }
 
@@ -417,7 +417,7 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
     } else {
         *p_elem = NULL;
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
     return AWS_OP_SUCCESS;
 }
 
@@ -660,9 +660,9 @@ int aws_hash_table_remove(
     const void *key,
     struct aws_hash_element *p_value,
     int *was_present) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map));
-    AWS_PRECONDITION(p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value));
-    AWS_PRECONDITION(was_present == NULL || AWS_OBJECT_PTR_IS_WRITABLE(was_present));
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "");
+    AWS_PRECONDITION(p_value == NULL || AWS_OBJECT_PTR_IS_WRITABLE(p_value), "");
+    AWS_PRECONDITION(was_present == NULL || AWS_OBJECT_PTR_IS_WRITABLE(was_present), "");
 
     struct hash_table_state *state = map->p_impl;
     uint64_t hash_code = s_hash_for(state, key);
@@ -677,7 +677,7 @@ int aws_hash_table_remove(
 
     if (rv != AWS_ERROR_SUCCESS) {
         *was_present = 0;
-        AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+        AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
         return AWS_OP_SUCCESS;
     }
 
@@ -695,20 +695,20 @@ int aws_hash_table_remove(
     }
     s_remove_entry(state, entry);
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
     return AWS_OP_SUCCESS;
 }
 
 int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(map));
-    AWS_PRECONDITION(p_value);
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "");
+    AWS_PRECONDITION(p_value, "");
 
     struct hash_table_state *state = map->p_impl;
     struct hash_table_entry *entry = AWS_CONTAINER_OF(p_value, struct hash_table_entry, element);
 
     s_remove_entry(state, entry);
 
-    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "");
     return AWS_OP_SUCCESS;
 }
 
@@ -736,13 +736,13 @@ bool aws_hash_table_eq(
     const struct aws_hash_table *a,
     const struct aws_hash_table *b,
     aws_hash_callback_eq_fn *value_eq) {
-    AWS_PRECONDITION(aws_hash_table_is_valid(a));
-    AWS_PRECONDITION(aws_hash_table_is_valid(b));
-    AWS_PRECONDITION(value_eq != NULL);
+    AWS_PRECONDITION(aws_hash_table_is_valid(a), "");
+    AWS_PRECONDITION(aws_hash_table_is_valid(b), "");
+    AWS_PRECONDITION(value_eq != NULL, "");
 
     if (aws_hash_table_get_entry_count(a) != aws_hash_table_get_entry_count(b)) {
-        AWS_POSTCONDITION(aws_hash_table_is_valid(a));
-        AWS_POSTCONDITION(aws_hash_table_is_valid(b));
+        AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
+        AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
 
         return false;
     }
@@ -764,19 +764,19 @@ bool aws_hash_table_eq(
 
         if (!b_element) {
             /* Key is present in A only */
-            AWS_POSTCONDITION(aws_hash_table_is_valid(a));
-            AWS_POSTCONDITION(aws_hash_table_is_valid(b));
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
             return false;
         }
 
         if (!s_safe_eq_check(value_eq, a_entry->element.value, b_element->value)) {
-            AWS_POSTCONDITION(aws_hash_table_is_valid(a));
-            AWS_POSTCONDITION(aws_hash_table_is_valid(b));
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
             return false;
         }
     }
-    AWS_POSTCONDITION(aws_hash_table_is_valid(a));
-    AWS_POSTCONDITION(aws_hash_table_is_valid(b));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(a), "");
+    AWS_POSTCONDITION(aws_hash_table_is_valid(b), "");
     return true;
 }
 

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -22,11 +22,11 @@
 #define RIGHT_OF(index) (((index) << 1) + 2)
 
 static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
     AWS_PRECONDITION(
-        a < queue->container.length, "Input index [a] must be less than the length of the queue container.");
+        a < queue->container.length);
     AWS_PRECONDITION(
-        b < queue->container.length, "Input index [b] must be less than the length of the queue container.");
+        b < queue->container.length);
 
     aws_array_list_swap(&queue->container, a, b);
 
@@ -50,15 +50,15 @@ static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
             (*bp_b)->current_index = b;
         }
     }
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
 }
 
 /* Precondition: with the exception of the given root element, the container must be
  * in heap order */
 static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
     AWS_PRECONDITION(
-        root < queue->container.length, "Input index [root] must be less than the length of the queue container.");
+        root < queue->container.length);
 
     bool did_move = false;
 
@@ -98,15 +98,15 @@ static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
         }
     }
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
     return did_move;
 }
 
 /* Precondition: Elements prior to the specified index must be in heap order. */
 static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
     AWS_PRECONDITION(
-        index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
+        index < queue->container.length);
 
     bool did_move = false;
 
@@ -133,7 +133,7 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
         }
     }
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
     return did_move;
 }
 
@@ -142,15 +142,15 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
  * In particular, the parent of the current index is a predecessor of all children of the current index.
  */
 static void s_sift_either(struct aws_priority_queue *queue, size_t index) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
     AWS_PRECONDITION(
-        index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
+        index < queue->container.length);
 
     if (!index || !s_sift_up(queue, index)) {
         s_sift_down(queue, index);
     }
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
 }
 
 int aws_priority_queue_init_dynamic(
@@ -165,7 +165,7 @@ int aws_priority_queue_init_dynamic(
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == AWS_OP_SUCCESS) {
-        AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
+        AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
     }
     return ret;
 }
@@ -182,7 +182,7 @@ void aws_priority_queue_init_static(
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
 }
 
 bool aws_priority_queue_is_valid(const struct aws_priority_queue *const queue) {

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -22,9 +22,9 @@
 #define RIGHT_OF(index) (((index) << 1) + 2)
 
 static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(a < queue->container.length);
-    AWS_PRECONDITION(b < queue->container.length);
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(a < queue->container.length, "Input index [a] must be less than the length of the queue container.");
+    AWS_PRECONDITION(b < queue->container.length, "Input index [b] must be less than the length of the queue container.");
 
     aws_array_list_swap(&queue->container, a, b);
 
@@ -48,14 +48,14 @@ static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
             (*bp_b)->current_index = b;
         }
     }
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
 }
 
 /* Precondition: with the exception of the given root element, the container must be
  * in heap order */
 static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(root < queue->container.length);
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(root < queue->container.length, "Input index [root] must be less than the length of the queue container.");
 
     bool did_move = false;
 
@@ -95,14 +95,14 @@ static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
         }
     }
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
     return did_move;
 }
 
 /* Precondition: Elements prior to the specified index must be in heap order. */
 static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(index < queue->container.length);
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
 
     bool did_move = false;
 
@@ -129,7 +129,7 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
         }
     }
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
     return did_move;
 }
 
@@ -138,14 +138,14 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
  * In particular, the parent of the current index is a predecessor of all children of the current index.
  */
 static void s_sift_either(struct aws_priority_queue *queue, size_t index) {
-    AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(index < queue->container.length);
+    AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
+    AWS_PRECONDITION(index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
 
     if (!index || !s_sift_up(queue, index)) {
         s_sift_down(queue, index);
     }
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
 }
 
 int aws_priority_queue_init_dynamic(
@@ -160,7 +160,7 @@ int aws_priority_queue_init_dynamic(
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
     if (ret == AWS_OP_SUCCESS) {
-        AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
+        AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
     }
     return ret;
 }
@@ -177,7 +177,7 @@ void aws_priority_queue_init_static(
 
     aws_array_list_init_static(&queue->container, heap, item_count, item_size);
 
-    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
+    AWS_POSTCONDITION(aws_priority_queue_is_valid(queue), "Output aws_prority_queue [queue] must be valid.");
 }
 
 bool aws_priority_queue_is_valid(const struct aws_priority_queue *const queue) {

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -23,8 +23,10 @@
 
 static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
-    AWS_PRECONDITION(a < queue->container.length, "Input index [a] must be less than the length of the queue container.");
-    AWS_PRECONDITION(b < queue->container.length, "Input index [b] must be less than the length of the queue container.");
+    AWS_PRECONDITION(
+        a < queue->container.length, "Input index [a] must be less than the length of the queue container.");
+    AWS_PRECONDITION(
+        b < queue->container.length, "Input index [b] must be less than the length of the queue container.");
 
     aws_array_list_swap(&queue->container, a, b);
 
@@ -55,7 +57,8 @@ static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
  * in heap order */
 static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
-    AWS_PRECONDITION(root < queue->container.length, "Input index [root] must be less than the length of the queue container.");
+    AWS_PRECONDITION(
+        root < queue->container.length, "Input index [root] must be less than the length of the queue container.");
 
     bool did_move = false;
 
@@ -102,7 +105,8 @@ static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
 /* Precondition: Elements prior to the specified index must be in heap order. */
 static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
-    AWS_PRECONDITION(index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
+    AWS_PRECONDITION(
+        index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
 
     bool did_move = false;
 
@@ -139,7 +143,8 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
  */
 static void s_sift_either(struct aws_priority_queue *queue, size_t index) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue), "Input aws_prority_queue [queue] must be valid.");
-    AWS_PRECONDITION(index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
+    AWS_PRECONDITION(
+        index < queue->container.length, "Input index [index] must be less than the length of the queue container.");
 
     if (!index || !s_sift_up(queue, index)) {
         s_sift_down(queue, index);

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -23,10 +23,8 @@
 
 static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(
-        a < queue->container.length);
-    AWS_PRECONDITION(
-        b < queue->container.length);
+    AWS_PRECONDITION(a < queue->container.length);
+    AWS_PRECONDITION(b < queue->container.length);
 
     aws_array_list_swap(&queue->container, a, b);
 
@@ -57,8 +55,7 @@ static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
  * in heap order */
 static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(
-        root < queue->container.length);
+    AWS_PRECONDITION(root < queue->container.length);
 
     bool did_move = false;
 
@@ -105,8 +102,7 @@ static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
 /* Precondition: Elements prior to the specified index must be in heap order. */
 static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(
-        index < queue->container.length);
+    AWS_PRECONDITION(index < queue->container.length);
 
     bool did_move = false;
 
@@ -143,8 +139,7 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
  */
 static void s_sift_either(struct aws_priority_queue *queue, size_t index) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
-    AWS_PRECONDITION(
-        index < queue->container.length);
+    AWS_PRECONDITION(index < queue->container.length);
 
     if (!index || !s_sift_up(queue, index)) {
         s_sift_down(queue, index);


### PR DESCRIPTION
Redefine `AWS_PRECONDITION` using `__CPROVER_precondition` and add an explanation string to all preconditions in the library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
