### PR TITLE
Marking unused parameters with AWS_UNUSED_PARAM macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ and let the user figure it out.
 * There is only one valid character encoding-- UTF-8. Try not to ever need to care about character encodings, but
 where you do, the working assumption should always be UTF-8 unless it's something we don't get a choice in (e.g. a protocol
 explicitly mandates a character set).
+* If you are not using one or more parameters of a function within its body, use the `AWS_UNUSED_PARAM` macro to communicate explicit intent and avoid possible compilation warnings.
 * If you are adding/using a compiler specific keyword, macro, or intrinsic, hide it behind a platform independent macro
 definition. This mainly applies to header files. Obviously, if you are writing a file that will only be built on a certain
 platform, you have more liberty on this.

--- a/include/aws/common/atomics_msvc.inl
+++ b/include/aws/common/atomics_msvc.inl
@@ -89,7 +89,7 @@ static inline void aws_atomic_priv_check_order(enum aws_memory_order order) {
             abort();
     }
 #endif
-    (void)order;
+    AWS_UNUSED_PARAM(order);
 }
 
 enum aws_atomic_mode_priv { aws_atomic_priv_load, aws_atomic_priv_store };

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -51,7 +51,7 @@
             memset((void *)array, 0, sizeof(array));                                                                   \
         } while (0)
 #define AWS_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-
+#define AWS_UNUSED_PARAM(param) (void)(param)
 
 #define AWS_CACHE_LINE 64
 

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -51,7 +51,11 @@
             memset((void *)array, 0, sizeof(array));                                                                   \
         } while (0)
 #define AWS_ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-#define AWS_UNUSED_PARAM(param) (void)(param)
+
+/* Avoid collisions with same-named macro in the C++ library if/when wrapped */
+#ifndef AWS_UNUSED_PARAM
+#    define AWS_UNUSED_PARAM(param) (void)(param)
+#endif /* AWS_UNUSED_PARAM */
 
 #define AWS_CACHE_LINE 64
 

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -353,8 +353,8 @@ static LONG WINAPI s_test_print_stack_trace(struct _EXCEPTION_POINTERS *exceptio
 #elif defined(AWS_HAVE_EXECINFO)
 #    include <signal.h>
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data) {
-    (void)sig;
-    (void)user_data;
+    AWS_UNUSED_PARAM(sig);
+    AWS_UNUSED_PARAM(user_data);
 #    if !defined(AWS_HEADER_CHECKER)
     aws_backtrace_print(stderr, sig_info);
 #    endif

--- a/source/common.c
+++ b/source/common.c
@@ -34,23 +34,23 @@
 #endif
 
 static void *s_default_malloc(struct aws_allocator *allocator, size_t size) {
-    (void)allocator;
+    AWS_UNUSED_PARAM(allocator);
     return malloc(size);
 }
 
 static void s_default_free(struct aws_allocator *allocator, void *ptr) {
-    (void)allocator;
+    AWS_UNUSED_PARAM(allocator);
     free(ptr);
 }
 
 static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
-    (void)allocator;
-    (void)oldsize;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(oldsize);
     return realloc(ptr, newsize);
 }
 
 static void *s_default_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
-    (void)allocator;
+    AWS_UNUSED_PARAM(allocator);
     return calloc(num, size);
 }
 
@@ -198,7 +198,7 @@ static CFStringRef s_cf_allocator_description = CFSTR("CFAllocator wrapping aws_
 
 /* note we don't have a standard specification stating sizeof(size_t) == sizeof(void *) so we have some extra casts */
 static void *s_cf_allocator_allocate(CFIndex alloc_size, CFOptionFlags hint, void *info) {
-    (void)hint;
+    AWS_UNUSED_PARAM(hint);
 
     struct aws_allocator *allocator = info;
 
@@ -222,7 +222,7 @@ static void s_cf_allocator_deallocate(void *ptr, void *info) {
 }
 
 static void *s_cf_allocator_reallocate(void *ptr, CFIndex new_size, CFOptionFlags hint, void *info) {
-    (void)hint;
+    AWS_UNUSED_PARAM(hint);
 
     struct aws_allocator *allocator = info;
     AWS_ASSERT(allocator->mem_realloc);
@@ -242,14 +242,14 @@ static void *s_cf_allocator_reallocate(void *ptr, CFIndex new_size, CFOptionFlag
 }
 
 static CFStringRef s_cf_allocator_copy_description(const void *info) {
-    (void)info;
+    AWS_UNUSED_PARAM(info);
 
     return s_cf_allocator_description;
 }
 
 static CFIndex s_cf_allocator_preferred_size(CFIndex size, CFOptionFlags hint, void *info) {
-    (void)hint;
-    (void)info;
+    AWS_UNUSED_PARAM(hint);
+    AWS_UNUSED_PARAM(info);
 
     return size + sizeof(size_t);
 }

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -29,16 +29,16 @@ bool aws_common_private_has_avx2(void);
  * not be called - but we must provide them anyway to avoid link errors.
  */
 static inline size_t aws_common_private_base64_decode_sse41(const unsigned char *in, unsigned char *out, size_t len) {
-    (void)in;
-    (void)out;
-    (void)len;
+    AWS_UNUSED_PARAM(in);
+    AWS_UNUSED_PARAM(out);
+    AWS_UNUSED_PARAM(len);
     AWS_ASSERT(false);
     return (size_t)-1; /* unreachable */
 }
 static inline void aws_common_private_base64_encode_sse41(const unsigned char *in, unsigned char *out, size_t len) {
-    (void)in;
-    (void)out;
-    (void)len;
+    AWS_UNUSED_PARAM(in);
+    AWS_UNUSED_PARAM(out);
+    AWS_UNUSED_PARAM(len);
     AWS_ASSERT(false);
 }
 static inline bool aws_common_private_has_avx2(void) {

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -35,10 +35,10 @@ static void s_suppress_unused_lookup3_func_warnings(void) {
     /* We avoid making changes to lookup3 if we can avoid it, but since it has functions
      * we're not using, reference them somewhere to suppress the unused function warning.
      */
-    (void)hashword;
-    (void)hashword2;
-    (void)hashlittle;
-    (void)hashbig;
+    AWS_UNUSED_PARAM(hashword);
+    AWS_UNUSED_PARAM(hashword2);
+    AWS_UNUSED_PARAM(hashlittle);
+    AWS_UNUSED_PARAM(hashbig);
 }
 
 /**

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -128,7 +128,7 @@ int s_parse_symbol(const char *symbol, void *addr, struct aws_stack_frame_info *
     /* symbols look like: <exe-or-shared-lib>(<function>) [0x<addr>]
      *                or: <exe-or-shared-lib> [0x<addr>]
      */
-    (void)addr;
+    AWS_UNUSED_PARAM(addr);
     const char *open_paren = strstr(symbol, "(");
     const char *close_paren = strstr(symbol, ")");
     const char *exe_end = open_paren;

--- a/source/windows/clock.c
+++ b/source/windows/clock.c
@@ -26,9 +26,9 @@ static VOID WINAPI s_get_system_time_func_lazy_init(LPFILETIME filetime_p);
 static timefunc_t *volatile s_p_time_func = s_get_system_time_func_lazy_init;
 
 static BOOL CALLBACK s_get_system_time_init_once(PINIT_ONCE init_once, PVOID param, PVOID *context) {
-    (void)init_once;
-    (void)param;
-    (void)context;
+    AWS_UNUSED_PARAM(init_once);
+    AWS_UNUSED_PARAM(param);
+    AWS_UNUSED_PARAM(context);
 
     HMODULE hkernel32 = GetModuleHandleW(L"kernel32.dll");
     timefunc_t *time_func = (timefunc_t *)GetProcAddress(hkernel32, "GetSystemTimePreciseAsFileTime");

--- a/source/windows/condition_variable.c
+++ b/source/windows/condition_variable.c
@@ -32,7 +32,7 @@ int aws_condition_variable_init(struct aws_condition_variable *condition_variabl
 }
 
 void aws_condition_variable_clean_up(struct aws_condition_variable *condition_variable) {
-    (void)condition_variable;
+    AWS_UNUSED_PARAM(condition_variable);
     /* no op */
 }
 

--- a/source/windows/rw_lock.c
+++ b/source/windows/rw_lock.c
@@ -29,7 +29,7 @@ int aws_rw_lock_init(struct aws_rw_lock *lock) {
 
 void aws_rw_lock_clean_up(struct aws_rw_lock *lock) {
 
-    (void)lock;
+    AWS_UNUSED_PARAM(lock);
 }
 
 int aws_rw_lock_rlock(struct aws_rw_lock *lock) {

--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -45,8 +45,8 @@ struct callback_fn_wrapper {
 };
 
 BOOL WINAPI s_init_once_wrapper(PINIT_ONCE init_once, void *param, void **context) {
-    (void)context;
-    (void)init_once;
+    AWS_UNUSED_PARAM(context);
+    AWS_UNUSED_PARAM(init_once);
 
     struct callback_fn_wrapper *callback_fn_wrapper = param;
     callback_fn_wrapper->call_once();

--- a/tests/array_list_test.c
+++ b/tests/array_list_test.c
@@ -20,7 +20,7 @@
 
 static int s_array_list_order_push_back_pop_front_fn(struct aws_allocator *allocator, void *ctx) {
 
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -88,7 +88,7 @@ static int s_array_list_order_push_back_pop_front_fn(struct aws_allocator *alloc
 AWS_TEST_CASE(array_list_order_push_back_pop_front_test, s_array_list_order_push_back_pop_front_fn)
 
 static int s_array_list_order_push_back_pop_back_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -153,7 +153,7 @@ static int s_array_list_order_push_back_pop_back_fn(struct aws_allocator *alloca
 AWS_TEST_CASE(array_list_order_push_back_pop_back_test, s_array_list_order_push_back_pop_back_fn)
 
 static int s_array_list_pop_front_n_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -197,7 +197,7 @@ static int s_array_list_pop_front_n_fn(struct aws_allocator *allocator, void *ct
 AWS_TEST_CASE(array_list_pop_front_n_test, s_array_list_pop_front_n_fn)
 
 static int s_array_list_exponential_mem_model_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -267,7 +267,7 @@ static int s_array_list_exponential_mem_model_test_fn(struct aws_allocator *allo
 AWS_TEST_CASE(array_list_exponential_mem_model_test, s_array_list_exponential_mem_model_test_fn)
 
 static int s_array_list_exponential_mem_model_iteration_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -337,8 +337,8 @@ static int s_array_list_exponential_mem_model_iteration_test_fn(struct aws_alloc
 AWS_TEST_CASE(array_list_exponential_mem_model_iteration_test, s_array_list_exponential_mem_model_iteration_test_fn)
 
 static int s_array_list_set_at_overwrite_safety_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -362,7 +362,7 @@ static int s_array_list_set_at_overwrite_safety_fn(struct aws_allocator *allocat
 AWS_TEST_CASE(array_list_set_at_overwrite_safety, s_array_list_set_at_overwrite_safety_fn)
 
 static int s_array_list_iteration_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -408,7 +408,7 @@ static int s_array_list_iteration_test_fn(struct aws_allocator *allocator, void 
 AWS_TEST_CASE(array_list_iteration_test, s_array_list_iteration_test_fn)
 
 static int s_array_list_iteration_by_ptr_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -454,8 +454,8 @@ static int s_array_list_iteration_by_ptr_test_fn(struct aws_allocator *allocator
 AWS_TEST_CASE(array_list_iteration_by_ptr_test, s_array_list_iteration_by_ptr_test_fn)
 
 static int s_array_list_preallocated_iteration_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -511,8 +511,8 @@ static int s_array_list_preallocated_iteration_test_fn(struct aws_allocator *all
 AWS_TEST_CASE(array_list_preallocated_iteration_test, s_array_list_preallocated_iteration_test_fn)
 
 static int s_array_list_preallocated_push_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -542,7 +542,7 @@ static int s_array_list_preallocated_push_test_fn(struct aws_allocator *allocato
 AWS_TEST_CASE(array_list_preallocated_push_test, s_array_list_preallocated_push_test_fn)
 
 static int s_array_list_shrink_to_fit_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -586,8 +586,8 @@ static int s_array_list_shrink_to_fit_test_fn(struct aws_allocator *allocator, v
 AWS_TEST_CASE(array_list_shrink_to_fit_test, s_array_list_shrink_to_fit_test_fn)
 
 static int s_array_list_shrink_to_fit_static_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -624,7 +624,7 @@ static int s_array_list_shrink_to_fit_static_test_fn(struct aws_allocator *alloc
 AWS_TEST_CASE(array_list_shrink_to_fit_static_test, s_array_list_shrink_to_fit_static_test_fn)
 
 static int s_array_list_clear_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
 
@@ -663,7 +663,7 @@ static int s_array_list_clear_test_fn(struct aws_allocator *allocator, void *ctx
 AWS_TEST_CASE(array_list_clear_test, s_array_list_clear_test_fn)
 
 static int s_array_list_copy_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list_a;
     struct aws_array_list list_b;
@@ -708,7 +708,7 @@ static int s_array_list_copy_test_fn(struct aws_allocator *allocator, void *ctx)
 AWS_TEST_CASE(array_list_copy_test, s_array_list_copy_test_fn)
 
 static int s_array_list_swap_contents_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* build lists */
     struct aws_array_list list_a;
@@ -765,7 +765,7 @@ static int s_array_list_swap_contents_test_fn(struct aws_allocator *allocator, v
 AWS_TEST_CASE(array_list_swap_contents_test, s_array_list_swap_contents_test_fn)
 
 static int s_array_list_not_enough_space_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list_a;
     struct aws_array_list list_b;
@@ -805,7 +805,7 @@ static int s_array_list_not_enough_space_test_fn(struct aws_allocator *allocator
 AWS_TEST_CASE(array_list_not_enough_space_test, s_array_list_not_enough_space_test_fn)
 
 static int s_array_list_not_enough_space_test_failure_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list_a;
     struct aws_array_list list_b;
@@ -843,7 +843,7 @@ static int s_array_list_not_enough_space_test_failure_fn(struct aws_allocator *a
 AWS_TEST_CASE(array_list_not_enough_space_test_failure, s_array_list_not_enough_space_test_failure_fn)
 
 static int s_array_list_of_strings_sort_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     AWS_STATIC_STRING_FROM_LITERAL(empty, "");
     AWS_STATIC_STRING_FROM_LITERAL(foo, "foo");
@@ -890,7 +890,7 @@ static int s_array_list_of_strings_sort_fn(struct aws_allocator *allocator, void
 AWS_TEST_CASE(array_list_of_strings_sort, s_array_list_of_strings_sort_fn)
 
 static int s_array_list_empty_sort_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_array_list list;
     ASSERT_SUCCESS(

--- a/tests/assert_test.c
+++ b/tests/assert_test.c
@@ -209,9 +209,9 @@ int main(int argc, char **argv) {
     g_test_filename = argv[1];
 
     // Suppress unused function warnings
-    (void)s_mem_acquire_malloc;
-    (void)s_mem_release_free;
-    (void)s_aws_run_test_case;
+    AWS_UNUSED_PARAM(s_mem_acquire_malloc);
+    AWS_UNUSED_PARAM(s_mem_release_free);
+    AWS_UNUSED_PARAM(s_aws_run_test_case);
 
     // Sanity checks for our own test macros
 

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -39,8 +39,8 @@ static int t_semantics(struct aws_allocator *allocator, void *ctx) {
      * doesn't matter. We do however use a variety of memory orders to ensure that they
      * are accepted.
      */
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     /* These provide us with some unique test pointers */
     int dummy_1, dummy_2, dummy_3;
@@ -106,8 +106,8 @@ static int t_semantics_implicit(struct aws_allocator *allocator, void *ctx) {
     /*
      * This test verifies that the non-_explicit atomics work properly on a single thread.
      */
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     /* These provide us with some unique test pointers */
     int dummy_1, dummy_2, dummy_3;
@@ -166,8 +166,8 @@ static int t_semantics_implicit(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(atomics_static_init, t_static_init)
 static int t_static_init(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     /* Verify that we have the right sign extension behavior - we should see zero extension here */
     struct aws_atomic_var int_init = AWS_ATOMIC_INIT_INT((uint8_t)0x80);
@@ -267,7 +267,7 @@ static void free_races(struct aws_allocator *alloc) {
 }
 
 static bool are_races_done(void *ignored) {
-    (void)ignored;
+    AWS_UNUSED_PARAM(ignored);
 
     return done_racing >= n_participants;
 }
@@ -383,7 +383,7 @@ DEFINE_RACE(loads_reordered_with_older_stores, participant, race) {
 
 AWS_TEST_CASE(atomics_loads_reordered_with_older_stores, t_loads_reordered_with_older_stores)
 static int t_loads_reordered_with_older_stores(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_atomic_var template[2];
     size_t last_race;
@@ -438,7 +438,7 @@ DEFINE_RACE(acquire_to_release_one_direction, participant, race) {
 
 AWS_TEST_CASE(atomics_acquire_to_release_one_direction, t_acquire_to_release_one_direction)
 static int t_acquire_to_release_one_direction(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_atomic_var template[2];
     size_t last_race;
@@ -500,7 +500,7 @@ DEFINE_RACE(acquire_to_release_mixed, participant, race) {
 
 AWS_TEST_CASE(atomics_acquire_to_release_mixed, t_acquire_to_release_mixed)
 static int t_acquire_to_release_mixed(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_atomic_var template[2];
     size_t last_race;

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -20,7 +20,7 @@
 
 AWS_TEST_CASE(test_buffer_cat, s_test_buffer_cat_fn)
 static int s_test_buffer_cat_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf str1 = aws_byte_buf_from_c_str("testa");
     struct aws_byte_buf str2 = aws_byte_buf_from_c_str(";testb");
@@ -52,7 +52,7 @@ static int s_test_buffer_cat_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_buffer_cat_dest_too_small, s_test_buffer_cat_dest_too_small_fn)
 static int s_test_buffer_cat_dest_too_small_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf str1 = aws_byte_buf_from_c_str("testa");
     struct aws_byte_buf str2 = aws_byte_buf_from_c_str(";testb");
@@ -72,7 +72,7 @@ static int s_test_buffer_cat_dest_too_small_fn(struct aws_allocator *allocator, 
 
 AWS_TEST_CASE(test_buffer_cpy, s_test_buffer_cpy_fn)
 static int s_test_buffer_cpy_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf from_buf = aws_byte_buf_from_c_str("testa");
     struct aws_byte_cursor from = aws_byte_cursor_from_buf(&from_buf);
@@ -93,7 +93,7 @@ static int s_test_buffer_cpy_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_buffer_cpy_offsets, s_test_buffer_cpy_offsets_fn)
 static int s_test_buffer_cpy_offsets_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf from_buf = aws_byte_buf_from_c_str("testa");
     struct aws_byte_cursor from = aws_byte_cursor_from_buf(&from_buf);
@@ -117,7 +117,7 @@ static int s_test_buffer_cpy_offsets_fn(struct aws_allocator *allocator, void *c
 
 AWS_TEST_CASE(test_buffer_cpy_dest_too_small, s_test_buffer_cpy_dest_too_small_fn)
 static int s_test_buffer_cpy_dest_too_small_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf from_buf = aws_byte_buf_from_c_str("testa");
     struct aws_byte_cursor from = aws_byte_cursor_from_buf(&from_buf);
@@ -135,7 +135,7 @@ static int s_test_buffer_cpy_dest_too_small_fn(struct aws_allocator *allocator, 
 
 AWS_TEST_CASE(test_buffer_cpy_offsets_dest_too_small, s_test_buffer_cpy_offsets_dest_too_small_fn)
 static int s_test_buffer_cpy_offsets_dest_too_small_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf from_buf = aws_byte_buf_from_c_str("testa");
     struct aws_byte_cursor from = aws_byte_cursor_from_buf(&from_buf);
@@ -153,7 +153,7 @@ static int s_test_buffer_cpy_offsets_dest_too_small_fn(struct aws_allocator *all
 
 AWS_TEST_CASE(test_buffer_eq, s_test_buffer_eq_fn)
 static int s_test_buffer_eq_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf b1 = aws_byte_buf_from_c_str("testa");
     struct aws_byte_buf b1_equal = aws_byte_buf_from_c_str("testa");
@@ -173,8 +173,8 @@ static int s_test_buffer_eq_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_buffer_eq_same_content_different_len, s_test_buffer_eq_same_content_different_len_fn)
 static int s_test_buffer_eq_same_content_different_len_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf b1 = aws_byte_buf_from_c_str("testa");
     struct aws_byte_buf b2 = aws_byte_buf_from_c_str("testa");
@@ -187,8 +187,8 @@ static int s_test_buffer_eq_same_content_different_len_fn(struct aws_allocator *
 
 AWS_TEST_CASE(test_buffer_eq_null_internal_byte_buffer, s_test_buffer_eq_null_internal_byte_buffer_fn)
 static int s_test_buffer_eq_null_internal_byte_buffer_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf b1 = aws_byte_buf_from_array(NULL, 0);
     struct aws_byte_buf b2 = aws_byte_buf_from_array(NULL, 0);
@@ -203,7 +203,7 @@ static int s_test_buffer_eq_null_internal_byte_buffer_fn(struct aws_allocator *a
 
 AWS_TEST_CASE(test_buffer_init_copy, s_test_buffer_init_copy_fn)
 static int s_test_buffer_init_copy_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf src = aws_byte_buf_from_c_str("test_string");
     struct aws_byte_buf dest;
@@ -218,7 +218,7 @@ static int s_test_buffer_init_copy_fn(struct aws_allocator *allocator, void *ctx
 
 AWS_TEST_CASE(test_buffer_init_copy_null_buffer, s_test_buffer_init_copy_null_buffer_fn)
 static int s_test_buffer_init_copy_null_buffer_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf src;
     AWS_ZERO_STRUCT(src);
@@ -230,8 +230,8 @@ static int s_test_buffer_init_copy_null_buffer_fn(struct aws_allocator *allocato
 
 AWS_TEST_CASE(test_buffer_advance, s_test_buffer_advance)
 static int s_test_buffer_advance(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     uint8_t arr[16];
     struct aws_byte_buf src_buf = aws_byte_buf_from_array(arr, sizeof(arr));
@@ -264,8 +264,8 @@ static int s_test_buffer_advance(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_buffer_printf, s_test_buffer_printf)
 static int s_test_buffer_printf(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const char src[] = "abcdefg";
 
@@ -299,8 +299,8 @@ static int s_test_buffer_printf(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_array_eq, s_test_array_eq)
 static int s_test_array_eq(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     uint8_t a[] = {1, 2, 3};
     uint8_t b[] = {1, 2, 3};
@@ -329,8 +329,8 @@ static int s_test_array_eq(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_array_eq_ignore_case, s_test_array_eq_ignore_case)
 static int s_test_array_eq_ignore_case(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
     {
         uint8_t a[] = {'a', 'B', 'c', 'D', '1'};
         uint8_t b[] = {'a', 'b', 'C', 'D', '1'}; /* same as a */
@@ -392,8 +392,8 @@ static int s_test_array_eq_ignore_case(struct aws_allocator *allocator, void *ct
 
 AWS_TEST_CASE(test_array_eq_c_str, s_test_array_eq_c_str)
 static int s_test_array_eq_c_str(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     {
         uint8_t arr_a[] = {'a', 'b', 'c'};
@@ -432,8 +432,8 @@ static int s_test_array_eq_c_str(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_array_eq_c_str_ignore_case, s_test_array_eq_c_str_ignore_case)
 static int s_test_array_eq_c_str_ignore_case(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     {
         uint8_t arr_a[] = {'a', 'B', 'c'};
@@ -472,8 +472,8 @@ static int s_test_array_eq_c_str_ignore_case(struct aws_allocator *allocator, vo
 
 AWS_TEST_CASE(test_array_hash_ignore_case, s_test_array_hash_ignore_case)
 static int s_test_array_hash_ignore_case(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     {
         /* Check against known FNV-1A values */
@@ -553,7 +553,7 @@ static int s_do_append_dynamic_test(
 }
 
 static int s_test_byte_buf_append_dynamic(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /*
      * Throw a small sample of different growth request profiles at the function
@@ -570,7 +570,7 @@ AWS_TEST_CASE(test_byte_buf_append_dynamic, s_test_byte_buf_append_dynamic)
 AWS_STATIC_STRING_FROM_LITERAL(s_to_lower_test, "UPPerANdLowercASE");
 
 static int s_test_byte_buf_append_lookup_success(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf buffer;
     aws_byte_buf_init(&buffer, allocator, s_to_lower_test->len);
@@ -604,7 +604,7 @@ static int s_test_reset_body(struct aws_byte_buf *buffer) {
     return 0;
 }
 static int s_test_byte_buf_reset(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf buffer;
     aws_byte_buf_init(&buffer, allocator, s_to_lower_test->len);
@@ -633,7 +633,7 @@ static int s_test_byte_buf_reset(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(test_byte_buf_reset, s_test_byte_buf_reset)
 
 static int s_test_byte_buf_append_lookup_failure(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf buffer;
     aws_byte_buf_init(&buffer, allocator, 3);
@@ -654,8 +654,8 @@ AWS_STATIC_STRING_FROM_LITERAL(s_reserve_test_prefix, "Successful");
 AWS_STATIC_STRING_FROM_LITERAL(s_reserve_test_prefix_concatenated, "SuccessfulReserveTest");
 
 static int s_test_byte_buf_reserve(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_buf buffer;
     aws_byte_buf_init(&buffer, allocator, s_reserve_test_prefix->len);
@@ -678,8 +678,8 @@ static int s_test_byte_buf_reserve(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(test_byte_buf_reserve, s_test_byte_buf_reserve)
 
 static int s_test_byte_buf_reserve_relative(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_buf buffer;
     aws_byte_buf_init(&buffer, allocator, 1);
@@ -702,8 +702,8 @@ static int s_test_byte_buf_reserve_relative(struct aws_allocator *allocator, voi
 AWS_TEST_CASE(test_byte_buf_reserve_relative, s_test_byte_buf_reserve_relative)
 
 static int s_test_byte_cursor_compare_lexical(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("test");
     struct aws_byte_cursor test_cursor2 = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("test");
@@ -739,8 +739,8 @@ static int s_test_byte_cursor_compare_lexical(struct aws_allocator *allocator, v
 AWS_TEST_CASE(test_byte_cursor_compare_lexical, s_test_byte_cursor_compare_lexical)
 
 static int s_test_byte_cursor_compare_lookup(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor Test_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Test");
     struct aws_byte_cursor tesT_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("tesT");

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -18,8 +18,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t ans_x = 0x1122334455667788ULL;
     uint32_t ans_y = 0xaabbccdd;

--- a/tests/calloc_test.c
+++ b/tests/calloc_test.c
@@ -58,8 +58,8 @@ static int s_test_calloc_on_given_allocator(struct aws_allocator *allocator, boo
 
 AWS_TEST_CASE(test_calloc_override, s_test_calloc_override_fn)
 static int s_test_calloc_override_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct aws_allocator my_alloc = {
         .mem_calloc = s_calloc_stub,
         .mem_release = s_mem_release_stub,
@@ -69,8 +69,8 @@ static int s_test_calloc_override_fn(struct aws_allocator *allocator, void *ctx)
 
 AWS_TEST_CASE(test_calloc_fallback_from_default_allocator, s_test_calloc_fallback_from_default_allocator_fn)
 static int s_test_calloc_fallback_from_default_allocator_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_allocator my_alloc = *aws_default_allocator();
     my_alloc.mem_calloc = NULL;
@@ -79,8 +79,8 @@ static int s_test_calloc_fallback_from_default_allocator_fn(struct aws_allocator
 
 AWS_TEST_CASE(test_calloc_fallback_from_given, s_test_calloc_fallback_from_given_fn)
 static int s_test_calloc_fallback_from_given_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_allocator my_alloc = *allocator;
     my_alloc.mem_calloc = NULL;
@@ -89,13 +89,13 @@ static int s_test_calloc_fallback_from_given_fn(struct aws_allocator *allocator,
 
 AWS_TEST_CASE(test_calloc_from_default_allocator, s_test_calloc_from_default_allocator_fn)
 static int s_test_calloc_from_default_allocator_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     return s_test_calloc_on_given_allocator(aws_default_allocator(), false);
 }
 
 AWS_TEST_CASE(test_calloc_from_given_allocator, s_test_calloc_from_given_allocator_fn)
 static int s_test_calloc_from_given_allocator_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
     return s_test_calloc_on_given_allocator(allocator, false);
 }

--- a/tests/clock_test.c
+++ b/tests/clock_test.c
@@ -19,8 +19,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_high_res_clock_increments(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t ticks = 0, prev = 0;
 
@@ -40,8 +40,8 @@ static int s_test_high_res_clock_increments(struct aws_allocator *allocator, voi
 }
 
 static int s_test_sys_clock_increments(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t ticks = 0, prev = 0;
 
@@ -61,8 +61,8 @@ static int s_test_sys_clock_increments(struct aws_allocator *allocator, void *ct
 }
 
 static int s_test_sec_and_millis_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t secs = 10;
     ASSERT_UINT_EQUALS(10000, aws_timestamp_convert(secs, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_MILLIS, NULL));
@@ -72,8 +72,8 @@ static int s_test_sec_and_millis_conversion(struct aws_allocator *allocator, voi
 }
 
 static int s_test_sec_and_micros_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t secs = 10;
     ASSERT_UINT_EQUALS(10000000, aws_timestamp_convert(secs, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_MICROS, NULL));
@@ -83,8 +83,8 @@ static int s_test_sec_and_micros_conversion(struct aws_allocator *allocator, voi
 }
 
 static int s_test_sec_and_nanos_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t secs = 10;
     ASSERT_UINT_EQUALS(10000000000, aws_timestamp_convert(secs, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL));
@@ -94,8 +94,8 @@ static int s_test_sec_and_nanos_conversion(struct aws_allocator *allocator, void
 }
 
 static int s_test_milli_and_micros_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t ms = 10;
     ASSERT_UINT_EQUALS(10000, aws_timestamp_convert(ms, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_MICROS, NULL));
@@ -105,8 +105,8 @@ static int s_test_milli_and_micros_conversion(struct aws_allocator *allocator, v
 }
 
 static int s_test_milli_and_nanos_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t ms = 10;
     ASSERT_UINT_EQUALS(10000000, aws_timestamp_convert(ms, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL));
@@ -116,8 +116,8 @@ static int s_test_milli_and_nanos_conversion(struct aws_allocator *allocator, vo
 }
 
 static int s_test_micro_and_nanos_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t micros = 10;
     ASSERT_UINT_EQUALS(10000, aws_timestamp_convert(micros, AWS_TIMESTAMP_MICROS, AWS_TIMESTAMP_NANOS, NULL));
@@ -127,8 +127,8 @@ static int s_test_micro_and_nanos_conversion(struct aws_allocator *allocator, vo
 }
 
 static int s_test_precision_loss_remainders_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t nanos = 10123456789;
     uint64_t remainder = 0;
@@ -139,8 +139,8 @@ static int s_test_precision_loss_remainders_conversion(struct aws_allocator *all
 }
 
 static int s_test_overflow_conversion(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     ASSERT_UINT_EQUALS(
         UINT64_MAX, aws_timestamp_convert(100000000000ULL, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL));

--- a/tests/command_line_parser_test.c
+++ b/tests/command_line_parser_test.c
@@ -16,8 +16,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_short_argument_parse_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct aws_cli_option options[] = {
         {.name = NULL, .has_arg = AWS_CLI_OPTIONS_NO_ARGUMENT, .flag = NULL, .val = 'a'},
         {.name = "beeee", .has_arg = AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, .flag = NULL, .val = 'b'},
@@ -54,8 +54,8 @@ static int s_test_short_argument_parse_fn(struct aws_allocator *allocator, void 
 AWS_TEST_CASE(short_argument_parse, s_test_short_argument_parse_fn)
 
 static int s_test_long_argument_parse_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct aws_cli_option options[] = {
         {.name = "aaee", .has_arg = AWS_CLI_OPTIONS_NO_ARGUMENT, .flag = NULL, .val = 'a'},
         {.name = "beeee", .has_arg = AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, .flag = NULL, .val = 'b'},
@@ -93,8 +93,8 @@ static int s_test_long_argument_parse_fn(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(long_argument_parse, s_test_long_argument_parse_fn)
 
 static int s_test_unqualified_argument_parse_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct aws_cli_option options[] = {
         {.name = "aaee", .has_arg = AWS_CLI_OPTIONS_NO_ARGUMENT, .flag = NULL, .val = 'a'},
         {.name = "beeee", .has_arg = AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, .flag = NULL, .val = 'b'},
@@ -128,8 +128,8 @@ static int s_test_unqualified_argument_parse_fn(struct aws_allocator *allocator,
 AWS_TEST_CASE(unqualified_argument_parse, s_test_unqualified_argument_parse_fn)
 
 static int s_test_unknown_argument_parse_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct aws_cli_option options[] = {
         {.name = "aaee", .has_arg = AWS_CLI_OPTIONS_NO_ARGUMENT, .flag = NULL, .val = 'a'},
         {.name = "beeee", .has_arg = AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, .flag = NULL, .val = 'b'},

--- a/tests/condition_variable_test.c
+++ b/tests/condition_variable_test.c
@@ -71,7 +71,7 @@ static void s_conditional_thread_3_fn(void *arg) {
 }
 
 static int s_test_conditional_notify_one_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct condition_predicate_args predicate_args = {.call_count = 0};
 
@@ -109,7 +109,7 @@ static int s_test_conditional_notify_one_fn(struct aws_allocator *allocator, voi
 AWS_TEST_CASE(conditional_notify_one, s_test_conditional_notify_one_fn)
 
 static int s_test_conditional_notify_all_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct condition_predicate_args predicate_args = {.call_count = 0};
 

--- a/tests/cursor_test.c
+++ b/tests/cursor_test.c
@@ -25,8 +25,8 @@
 
 AWS_TEST_CASE(nospec_index_test, s_nospec_index_test_fn)
 static int s_nospec_index_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     ASSERT_UINT_EQUALS(UINTPTR_MAX, aws_nospec_mask(0, 1));
     ASSERT_UINT_EQUALS(0, aws_nospec_mask(0, 0));
@@ -96,16 +96,16 @@ static int s_test_byte_cursor_advance_internal(
 
 AWS_TEST_CASE(test_byte_cursor_advance, s_test_byte_cursor_advance_fn)
 static int s_test_byte_cursor_advance_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     return s_test_byte_cursor_advance_internal(aws_byte_cursor_advance);
 }
 
 AWS_TEST_CASE(test_byte_cursor_advance_nospec, s_test_byte_cursor_advance_nospec_fn)
 static int s_test_byte_cursor_advance_nospec_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     return s_test_byte_cursor_advance_internal(aws_byte_cursor_advance_nospec);
 }
@@ -115,8 +115,8 @@ static const uint8_t TEST_VECTOR[] = {0xaa, 0xbb, 0xaa, 0xbb, 0xcc, 0xbb, 0x42, 
 
 AWS_TEST_CASE(byte_cursor_write_tests, s_byte_cursor_write_tests_fn);
 static int s_byte_cursor_write_tests_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t buf[sizeof(TEST_VECTOR) + 1];
     memset(buf, 0, sizeof(buf));
@@ -145,8 +145,8 @@ static int s_byte_cursor_write_tests_fn(struct aws_allocator *allocator, void *c
 
 AWS_TEST_CASE(byte_cursor_read_tests, s_byte_cursor_read_tests_fn);
 static int s_byte_cursor_read_tests_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_cursor cur = aws_byte_cursor_from_array(TEST_VECTOR, sizeof(TEST_VECTOR));
 
@@ -179,8 +179,8 @@ static int s_byte_cursor_read_tests_fn(struct aws_allocator *allocator, void *ct
 
 AWS_TEST_CASE(byte_cursor_limit_tests, s_byte_cursor_limit_tests_fn);
 static int s_byte_cursor_limit_tests_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t buf[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
     uint8_t starting_buf[sizeof(buf)];
@@ -254,8 +254,8 @@ static bool s_is_whitespace(uint8_t value) {
 }
 
 static int s_test_byte_cursor_right_trim_empty(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_empty);
 
@@ -268,8 +268,8 @@ static int s_test_byte_cursor_right_trim_empty(struct aws_allocator *allocator, 
 AWS_TEST_CASE(test_byte_cursor_right_trim_empty, s_test_byte_cursor_right_trim_empty)
 
 static int s_test_byte_cursor_right_trim_all_whitespace(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_all_whitespace);
 
@@ -282,8 +282,8 @@ static int s_test_byte_cursor_right_trim_all_whitespace(struct aws_allocator *al
 AWS_TEST_CASE(test_byte_cursor_right_trim_all_whitespace, s_test_byte_cursor_right_trim_all_whitespace)
 
 static int s_test_byte_cursor_right_trim_basic(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_right_whitespace);
 
@@ -298,8 +298,8 @@ static int s_test_byte_cursor_right_trim_basic(struct aws_allocator *allocator, 
 AWS_TEST_CASE(test_byte_cursor_right_trim_basic, s_test_byte_cursor_right_trim_basic)
 
 static int s_test_byte_cursor_left_trim_empty(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_empty);
 
@@ -312,8 +312,8 @@ static int s_test_byte_cursor_left_trim_empty(struct aws_allocator *allocator, v
 AWS_TEST_CASE(test_byte_cursor_left_trim_empty, s_test_byte_cursor_left_trim_empty)
 
 static int s_test_byte_cursor_left_trim_all_whitespace(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_all_whitespace);
 
@@ -326,8 +326,8 @@ static int s_test_byte_cursor_left_trim_all_whitespace(struct aws_allocator *all
 AWS_TEST_CASE(test_byte_cursor_left_trim_all_whitespace, s_test_byte_cursor_left_trim_all_whitespace)
 
 static int s_test_byte_cursor_left_trim_basic(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_left_whitespace);
 
@@ -340,8 +340,8 @@ static int s_test_byte_cursor_left_trim_basic(struct aws_allocator *allocator, v
 AWS_TEST_CASE(test_byte_cursor_left_trim_basic, s_test_byte_cursor_left_trim_basic)
 
 static int s_test_byte_cursor_trim_basic(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_both_whitespace);
 

--- a/tests/date_time_test.c
+++ b/tests/date_time_test.c
@@ -19,8 +19,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_rfc822_utc_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const char *valid_utc_dates[] = {
         "Wed, 02 Oct 2002 08:05:09 GMT",
@@ -70,8 +70,8 @@ static int s_test_rfc822_utc_parsing_fn(struct aws_allocator *allocator, void *c
 AWS_TEST_CASE(rfc822_utc_parsing, s_test_rfc822_utc_parsing_fn)
 
 static int s_test_rfc822_utc_parsing_auto_detect_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 2002 08:05:09 GMT";
@@ -100,8 +100,8 @@ static int s_test_rfc822_utc_parsing_auto_detect_fn(struct aws_allocator *alloca
 AWS_TEST_CASE(rfc822_utc_parsing_auto_detect, s_test_rfc822_utc_parsing_auto_detect_fn)
 
 static int s_test_rfc822_local_time_east_of_gmt_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 2002 09:35:09 +0130";
@@ -133,8 +133,8 @@ static int s_test_rfc822_local_time_east_of_gmt_parsing_fn(struct aws_allocator 
 AWS_TEST_CASE(rfc822_local_time_east_of_gmt_parsing, s_test_rfc822_local_time_east_of_gmt_parsing_fn)
 
 static int s_test_rfc822_local_time_west_of_gmt_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 2002 07:05:09 -0100";
@@ -166,8 +166,8 @@ static int s_test_rfc822_local_time_west_of_gmt_parsing_fn(struct aws_allocator 
 AWS_TEST_CASE(rfc822_local_time_west_of_gmt_parsing, s_test_rfc822_local_time_west_of_gmt_parsing_fn)
 
 static int s_test_rfc822_utc_two_digit_year_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 02 08:05:09 GMT";
@@ -198,8 +198,8 @@ static int s_test_rfc822_utc_two_digit_year_parsing_fn(struct aws_allocator *all
 AWS_TEST_CASE(rfc822_utc_two_digit_year_parsing, s_test_rfc822_utc_two_digit_year_parsing_fn)
 
 static int s_test_rfc822_utc_no_dow_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "02 Oct 02 08:05:09 GMT";
@@ -230,8 +230,8 @@ static int s_test_rfc822_utc_no_dow_parsing_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(rfc822_utc_no_dow_parsing, s_test_rfc822_utc_no_dow_parsing_fn)
 
 static int s_test_rfc822_utc_dos_prevented_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Weddkasdiweijbnawei8eriojngsdgasdgsdf1gasd8asdgfasdfgsdikweisdfksdnsdksdklas"
@@ -247,8 +247,8 @@ static int s_test_rfc822_utc_dos_prevented_fn(struct aws_allocator *allocator, v
 AWS_TEST_CASE(rfc822_utc_dos_prevented, s_test_rfc822_utc_dos_prevented_fn)
 
 static int s_test_rfc822_invalid_format_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 2002";
@@ -263,8 +263,8 @@ static int s_test_rfc822_invalid_format_fn(struct aws_allocator *allocator, void
 AWS_TEST_CASE(rfc822_invalid_format, s_test_rfc822_invalid_format_fn)
 
 static int s_test_rfc822_invalid_tz_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 2002 08:05:09 DST";
@@ -279,8 +279,8 @@ static int s_test_rfc822_invalid_tz_fn(struct aws_allocator *allocator, void *ct
 AWS_TEST_CASE(rfc822_invalid_tz, s_test_rfc822_invalid_tz_fn)
 
 static int s_test_rfc822_invalid_auto_format_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Wed, 02 Oct 2002";
@@ -295,8 +295,8 @@ static int s_test_rfc822_invalid_auto_format_fn(struct aws_allocator *allocator,
 AWS_TEST_CASE(rfc822_invalid_auto_format, s_test_rfc822_invalid_auto_format_fn)
 
 static int s_test_iso8601_utc_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "2002-10-02T08:05:09.000Z";
@@ -335,8 +335,8 @@ static int s_test_iso8601_utc_parsing_fn(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(iso8601_utc_parsing, s_test_iso8601_utc_parsing_fn)
 
 static int s_test_iso8601_basic_utc_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "20021002T080509000Z";
@@ -375,8 +375,8 @@ static int s_test_iso8601_basic_utc_parsing_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(iso8601_basic_utc_parsing, s_test_iso8601_basic_utc_parsing_fn)
 
 static int s_test_iso8601_utc_parsing_auto_detect_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "2002-10-02T08:05:09.000Z";
@@ -407,8 +407,8 @@ static int s_test_iso8601_utc_parsing_auto_detect_fn(struct aws_allocator *alloc
 AWS_TEST_CASE(iso8601_utc_parsing_auto_detect, s_test_iso8601_utc_parsing_auto_detect_fn)
 
 static int s_test_iso8601_basic_utc_parsing_auto_detect_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "20021002T080509000Z";
@@ -439,8 +439,8 @@ static int s_test_iso8601_basic_utc_parsing_auto_detect_fn(struct aws_allocator 
 AWS_TEST_CASE(iso8601_basic_utc_parsing_auto_detect, s_test_iso8601_basic_utc_parsing_auto_detect_fn)
 
 static int s_test_iso8601_utc_no_colon_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "2002-10-02T080509.000Z";
@@ -471,8 +471,8 @@ static int s_test_iso8601_utc_no_colon_parsing_fn(struct aws_allocator *allocato
 AWS_TEST_CASE(iso8601_utc_no_colon_parsing, s_test_iso8601_utc_no_colon_parsing_fn)
 
 static int s_test_iso8601_date_only_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "2002-10-02";
@@ -503,8 +503,8 @@ static int s_test_iso8601_date_only_parsing_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(iso8601_date_only_parsing, s_test_iso8601_date_only_parsing_fn)
 
 static int s_test_iso8601_basic_date_only_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "20021002";
@@ -535,8 +535,8 @@ static int s_test_iso8601_basic_date_only_parsing_fn(struct aws_allocator *alloc
 AWS_TEST_CASE(iso8601_basic_date_only_parsing, s_test_iso8601_basic_date_only_parsing_fn)
 
 static int s_test_iso8601_utc_dos_prevented_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "Weddkasdiweijbnawei8eriojngsdgasdgsdf1gasd8asdgfasdfgsdikweisdfksdnsdksdklas"
@@ -552,8 +552,8 @@ static int s_test_iso8601_utc_dos_prevented_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(iso8601_utc_dos_prevented, s_test_iso8601_utc_dos_prevented_fn)
 
 static int s_test_iso8601_invalid_format_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "2002-10-02T";
@@ -568,8 +568,8 @@ static int s_test_iso8601_invalid_format_fn(struct aws_allocator *allocator, voi
 AWS_TEST_CASE(iso8601_invalid_format, s_test_iso8601_invalid_format_fn)
 
 static int s_test_iso8601_invalid_auto_format_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
     const char *date_str = "2002-10-02T";
@@ -584,8 +584,8 @@ static int s_test_iso8601_invalid_auto_format_fn(struct aws_allocator *allocator
 AWS_TEST_CASE(iso8601_invalid_auto_format, s_test_iso8601_invalid_auto_format_fn)
 
 static int s_test_unix_epoch_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
 
@@ -614,8 +614,8 @@ static int s_test_unix_epoch_parsing_fn(struct aws_allocator *allocator, void *c
 AWS_TEST_CASE(unix_epoch_parsing, s_test_unix_epoch_parsing_fn)
 
 static int s_test_millis_parsing_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_date_time date_time;
 

--- a/tests/device_random_test.c
+++ b/tests/device_random_test.c
@@ -70,8 +70,8 @@ static int s_distribution_tester_check_results(const struct distribution_tester 
 }
 
 static int s_device_rand_u64_distribution_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct distribution_tester tester = {.max_value = UINT64_MAX};
 
     for (size_t i = 0; i < DISTRIBUTION_PUT_COUNT; ++i) {
@@ -87,8 +87,8 @@ static int s_device_rand_u64_distribution_fn(struct aws_allocator *allocator, vo
 AWS_TEST_CASE(device_rand_u64_distribution, s_device_rand_u64_distribution_fn)
 
 static int s_device_rand_u32_distribution_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct distribution_tester tester = {.max_value = UINT32_MAX};
 
     for (size_t i = 0; i < DISTRIBUTION_PUT_COUNT; ++i) {
@@ -104,8 +104,8 @@ static int s_device_rand_u32_distribution_fn(struct aws_allocator *allocator, vo
 AWS_TEST_CASE(device_rand_u32_distribution, s_device_rand_u32_distribution_fn)
 
 static int s_device_rand_u16_distribution_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
     struct distribution_tester tester = {.max_value = UINT16_MAX};
 
     for (size_t i = 0; i < DISTRIBUTION_PUT_COUNT; ++i) {
@@ -121,8 +121,8 @@ static int s_device_rand_u16_distribution_fn(struct aws_allocator *allocator, vo
 AWS_TEST_CASE(device_rand_u16_distribution, s_device_rand_u16_distribution_fn)
 
 static int s_device_rand_buffer_distribution_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t array[DISTRIBUTION_PUT_COUNT];
     struct aws_byte_buf buf = aws_byte_buf_from_empty_array(array, sizeof(array));

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -90,7 +90,7 @@ static int s_run_hex_encoding_test_case(
 }
 
 static int s_hex_encoding_test_case_empty(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "";
     char expected[] = "";
@@ -101,7 +101,7 @@ static int s_hex_encoding_test_case_empty(struct aws_allocator *allocator, void 
 AWS_TEST_CASE(hex_encoding_test_case_empty_test, s_hex_encoding_test_case_empty)
 
 static int s_hex_encoding_test_case_f(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "f";
     char expected[] = "66";
@@ -112,7 +112,7 @@ static int s_hex_encoding_test_case_f(struct aws_allocator *allocator, void *ctx
 AWS_TEST_CASE(hex_encoding_test_case_f_test, s_hex_encoding_test_case_f)
 
 static int s_hex_encoding_test_case_fo(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "fo";
     char expected[] = "666f";
@@ -123,7 +123,7 @@ static int s_hex_encoding_test_case_fo(struct aws_allocator *allocator, void *ct
 AWS_TEST_CASE(hex_encoding_test_case_fo_test, s_hex_encoding_test_case_fo)
 
 static int s_hex_encoding_test_case_foo(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foo";
     char expected[] = "666f6f";
@@ -134,7 +134,7 @@ static int s_hex_encoding_test_case_foo(struct aws_allocator *allocator, void *c
 AWS_TEST_CASE(hex_encoding_test_case_foo_test, s_hex_encoding_test_case_foo)
 
 static int s_hex_encoding_test_case_foob(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foob";
     char expected[] = "666f6f62";
@@ -145,7 +145,7 @@ static int s_hex_encoding_test_case_foob(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(hex_encoding_test_case_foob_test, s_hex_encoding_test_case_foob)
 
 static int s_hex_encoding_test_case_fooba(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "fooba";
     char expected[] = "666f6f6261";
@@ -156,7 +156,7 @@ static int s_hex_encoding_test_case_fooba(struct aws_allocator *allocator, void 
 AWS_TEST_CASE(hex_encoding_test_case_fooba_test, s_hex_encoding_test_case_fooba)
 
 static int s_hex_encoding_test_case_foobar(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     char expected[] = "666f6f626172";
@@ -167,7 +167,7 @@ static int s_hex_encoding_test_case_foobar(struct aws_allocator *allocator, void
 AWS_TEST_CASE(hex_encoding_test_case_foobar_test, s_hex_encoding_test_case_foobar)
 
 static int s_hex_encoding_append_test_case(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     char expected[] = "666f6f626172";
@@ -178,8 +178,8 @@ static int s_hex_encoding_append_test_case(struct aws_allocator *allocator, void
 AWS_TEST_CASE(hex_encoding_append_test_case, s_hex_encoding_append_test_case)
 
 static int s_hex_encoding_test_case_missing_leading_zero_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t expected[] = {0x01, 0x02, 0x03, 0x04};
     char test_data[] = "1020304";
@@ -204,8 +204,8 @@ static int s_hex_encoding_test_case_missing_leading_zero_fn(struct aws_allocator
 AWS_TEST_CASE(hex_encoding_test_case_missing_leading_zero, s_hex_encoding_test_case_missing_leading_zero_fn)
 
 static int s_hex_encoding_invalid_buffer_size_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     size_t size_too_small = 2;
@@ -229,8 +229,8 @@ static int s_hex_encoding_invalid_buffer_size_test_fn(struct aws_allocator *allo
 AWS_TEST_CASE(hex_encoding_invalid_buffer_size_test, s_hex_encoding_invalid_buffer_size_test_fn)
 
 static int s_hex_encoding_highbyte_string_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char bad_input[] = "66\xb6\xb6"
                        "6f6f6617";
@@ -245,8 +245,8 @@ static int s_hex_encoding_highbyte_string_test_fn(struct aws_allocator *allocato
 AWS_TEST_CASE(hex_encoding_highbyte_string_test, s_hex_encoding_highbyte_string_test_fn)
 
 static int s_hex_encoding_overflow_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     /* kill off the last two bits, so the not a multiple of 4 check doesn't
@@ -267,8 +267,8 @@ static int s_hex_encoding_overflow_test_fn(struct aws_allocator *allocator, void
 AWS_TEST_CASE(hex_encoding_overflow_test, s_hex_encoding_overflow_test_fn)
 
 static int s_hex_encoding_invalid_string_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char bad_input[] = "666f6f6x6172";
     uint8_t output[sizeof(bad_input)] = {0};
@@ -369,7 +369,7 @@ static int s_run_base64_encoding_test_case(
 }
 
 static int s_base64_encoding_test_case_empty(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "";
     char expected[] = "";
@@ -380,7 +380,7 @@ static int s_base64_encoding_test_case_empty(struct aws_allocator *allocator, vo
 AWS_TEST_CASE(base64_encoding_test_case_empty_test, s_base64_encoding_test_case_empty)
 
 static int s_base64_encoding_test_case_f(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "f";
     char expected[] = "Zg==";
@@ -391,7 +391,7 @@ static int s_base64_encoding_test_case_f(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(base64_encoding_test_case_f_test, s_base64_encoding_test_case_f)
 
 static int s_base64_encoding_test_case_fo(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "fo";
     char expected[] = "Zm8=";
@@ -402,7 +402,7 @@ static int s_base64_encoding_test_case_fo(struct aws_allocator *allocator, void 
 AWS_TEST_CASE(base64_encoding_test_case_fo_test, s_base64_encoding_test_case_fo)
 
 static int s_base64_encoding_test_case_foo(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foo";
     char expected[] = "Zm9v";
@@ -413,7 +413,7 @@ static int s_base64_encoding_test_case_foo(struct aws_allocator *allocator, void
 AWS_TEST_CASE(base64_encoding_test_case_foo_test, s_base64_encoding_test_case_foo)
 
 static int s_base64_encoding_test_case_foob(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foob";
     char expected[] = "Zm9vYg==";
@@ -424,7 +424,7 @@ static int s_base64_encoding_test_case_foob(struct aws_allocator *allocator, voi
 AWS_TEST_CASE(base64_encoding_test_case_foob_test, s_base64_encoding_test_case_foob)
 
 static int s_base64_encoding_test_case_fooba(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "fooba";
     char expected[] = "Zm9vYmE=";
@@ -435,7 +435,7 @@ static int s_base64_encoding_test_case_fooba(struct aws_allocator *allocator, vo
 AWS_TEST_CASE(base64_encoding_test_case_fooba_test, s_base64_encoding_test_case_fooba)
 
 static int s_base64_encoding_test_case_foobar(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     char expected[] = "Zm9vYmFy";
@@ -446,7 +446,7 @@ static int s_base64_encoding_test_case_foobar(struct aws_allocator *allocator, v
 AWS_TEST_CASE(base64_encoding_test_case_foobar_test, s_base64_encoding_test_case_foobar)
 
 static int s_base64_encoding_test_case_32bytes(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /*                  01234567890123456789012345678901 */
     char test_data[] = "this is a 32 byte long string!!!";
@@ -458,7 +458,7 @@ static int s_base64_encoding_test_case_32bytes(struct aws_allocator *allocator, 
 AWS_TEST_CASE(base64_encoding_test_case_32bytes_test, s_base64_encoding_test_case_32bytes)
 
 static int s_base64_encoding_test_zeros_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t test_data[6] = {0};
     char expected[] = "AAAAAAAA";
@@ -469,8 +469,8 @@ static int s_base64_encoding_test_zeros_fn(struct aws_allocator *allocator, void
 AWS_TEST_CASE(base64_encoding_test_zeros, s_base64_encoding_test_zeros_fn)
 
 static int s_base64_encoding_test_roundtrip(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-    (void)allocator;
+    AWS_UNUSED_PARAM(ctx);
+    AWS_UNUSED_PARAM(allocator);
 
     fprintf(stderr, "--test\n");
     uint8_t test_data[32];
@@ -531,7 +531,7 @@ AWS_TEST_CASE(base64_encoding_test_roundtrip, s_base64_encoding_test_roundtrip)
  * than character value of 65 -> "A" -> 0.
  */
 static int s_base64_encoding_test_all_values_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t test_data[255] = {0};
 
@@ -550,8 +550,8 @@ static int s_base64_encoding_test_all_values_fn(struct aws_allocator *allocator,
 AWS_TEST_CASE(base64_encoding_test_all_values, s_base64_encoding_test_all_values_fn)
 
 static int s_base64_encoding_buffer_size_too_small_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     char encoded_data[] = "Zm9vYmFy";
@@ -578,8 +578,8 @@ static int s_base64_encoding_buffer_size_too_small_test_fn(struct aws_allocator 
 AWS_TEST_CASE(base64_encoding_buffer_size_too_small_test, s_base64_encoding_buffer_size_too_small_test_fn)
 
 static int s_base64_encoding_buffer_size_overflow_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "foobar";
     char encoded_data[] = "Zm9vYmFy";
@@ -608,8 +608,8 @@ static int s_base64_encoding_buffer_size_overflow_test_fn(struct aws_allocator *
 AWS_TEST_CASE(base64_encoding_buffer_size_overflow_test, s_base64_encoding_buffer_size_overflow_test_fn)
 
 static int s_base64_encoding_buffer_size_invalid_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char encoded_data[] = "Zm9vYmFy";
     /* kill off the last two bits, so the not a multiple of 4 check doesn't
@@ -629,8 +629,8 @@ static int s_base64_encoding_buffer_size_invalid_test_fn(struct aws_allocator *a
 AWS_TEST_CASE(base64_encoding_buffer_size_invalid_test, s_base64_encoding_buffer_size_invalid_test_fn)
 
 static int s_base64_encoding_invalid_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char encoded_data[] = "Z\n9vYmFy";
     uint8_t output[sizeof(encoded_data)] = {0};
@@ -648,8 +648,8 @@ static int s_base64_encoding_invalid_buffer_test_fn(struct aws_allocator *alloca
 AWS_TEST_CASE(base64_encoding_invalid_buffer_test, s_base64_encoding_invalid_buffer_test_fn)
 
 static int s_base64_encoding_highbyte_string_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char bad_input[] = "AAAA\xC1"
                        "AAA";
@@ -664,8 +664,8 @@ static int s_base64_encoding_highbyte_string_test_fn(struct aws_allocator *alloc
 AWS_TEST_CASE(base64_encoding_highbyte_string_test, s_base64_encoding_highbyte_string_test_fn)
 
 static int s_base64_encoding_invalid_padding_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     char encoded_data[] = "Zm9vY===";
     uint8_t output[sizeof(encoded_data)] = {0};
@@ -684,8 +684,8 @@ AWS_TEST_CASE(base64_encoding_invalid_padding_test, s_base64_encoding_invalid_pa
 
 /* network integer encoding tests */
 static int s_uint64_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t test_value = 0x1020304050607080;
     uint8_t buffer[8] = {0};
@@ -702,8 +702,8 @@ static int s_uint64_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(uint64_buffer_test, s_uint64_buffer_test_fn)
 
 static int s_uint64_buffer_non_aligned_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t test_value = 0x1020304050607080;
     uint8_t *buffer = (uint8_t *)aws_mem_acquire(allocator, 9);
@@ -726,8 +726,8 @@ static int s_uint64_buffer_non_aligned_test_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(uint64_buffer_non_aligned_test, s_uint64_buffer_non_aligned_test_fn)
 
 static int s_uint32_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint32_t test_value = 0x10203040;
     uint8_t buffer[4] = {0};
@@ -745,7 +745,7 @@ static int s_uint32_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(uint32_buffer_test, s_uint32_buffer_test_fn)
 
 static int s_uint32_buffer_non_aligned_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint32_t test_value = 0x10203040;
     uint8_t *buffer = (uint8_t *)aws_mem_acquire(allocator, 9);
@@ -768,8 +768,8 @@ static int s_uint32_buffer_non_aligned_test_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(uint32_buffer_non_aligned_test, s_uint32_buffer_non_aligned_test_fn)
 
 static int s_uint24_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint32_t test_value = 0x102030;
     uint8_t buffer[3] = {0};
@@ -787,7 +787,7 @@ static int s_uint24_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(uint24_buffer_test, s_uint24_buffer_test_fn)
 
 static int s_uint24_buffer_non_aligned_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint32_t test_value = 0x102030;
     uint8_t *buffer = (uint8_t *)aws_mem_acquire(allocator, 9);
@@ -808,8 +808,8 @@ static int s_uint24_buffer_non_aligned_test_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(uint24_buffer_non_aligned_test, s_uint24_buffer_non_aligned_test_fn)
 
 static int s_uint16_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint16_t test_value = 0x1020;
     uint8_t buffer[2] = {0};
@@ -827,7 +827,7 @@ static int s_uint16_buffer_test_fn(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(uint16_buffer_test, s_uint16_buffer_test_fn)
 
 static int s_uint16_buffer_non_aligned_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint16_t test_value = 0x1020;
     uint8_t *buffer = (uint8_t *)aws_mem_acquire(allocator, 9);
@@ -849,8 +849,8 @@ AWS_TEST_CASE(uint16_buffer_non_aligned_test, s_uint16_buffer_non_aligned_test_f
 
 /* sanity check that signed/unsigned work the same */
 static int s_uint16_buffer_signed_positive_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     int16_t test_value = 0x4030;
     uint8_t buffer[2] = {0};
@@ -868,8 +868,8 @@ static int s_uint16_buffer_signed_positive_test_fn(struct aws_allocator *allocat
 AWS_TEST_CASE(uint16_buffer_signed_positive_test, s_uint16_buffer_signed_positive_test_fn)
 
 static int s_uint16_buffer_signed_negative_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     int16_t test_value = -2;
     uint8_t buffer[2] = {0};
@@ -936,7 +936,7 @@ static int s_run_hex_encoding_append_dynamic_test_case(
 }
 
 static int s_hex_encoding_append_dynamic_test_case_fooba(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "fooba";
     char expected[] = "666f6f6261";
@@ -950,7 +950,7 @@ static int s_hex_encoding_append_dynamic_test_case_fooba(struct aws_allocator *a
 AWS_TEST_CASE(hex_encoding_append_dynamic_test_case_fooba, s_hex_encoding_append_dynamic_test_case_fooba)
 
 static int s_hex_encoding_append_dynamic_test_case_empty(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     char test_data[] = "";
     char expected[] = "";

--- a/tests/environment_test.c
+++ b/tests/environment_test.c
@@ -24,7 +24,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_test_variable, "AWS_TEST_VAR");
 AWS_STATIC_STRING_FROM_LITERAL(s_test_value, "SOME_VALUE");
 
 static int s_test_environment_functions_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_string *value;
 

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -29,8 +29,8 @@ static struct aws_error_info_list s_errors_list = {
 };
 
 static void s_setup_errors_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     aws_reset_error();
     aws_set_global_error_handler_fn(NULL, NULL);
@@ -39,8 +39,8 @@ static void s_setup_errors_test_fn(struct aws_allocator *allocator, void *ctx) {
 }
 
 static void s_teardown_errors_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     aws_reset_error();
     aws_set_global_error_handler_fn(NULL, NULL);
@@ -48,8 +48,8 @@ static void s_teardown_errors_test_fn(struct aws_allocator *allocator, void *ctx
 }
 
 static int s_raise_errors_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     int error = aws_last_error();
 
@@ -106,8 +106,8 @@ static int s_raise_errors_test_fn(struct aws_allocator *allocator, void *ctx) {
 }
 
 static int s_reset_errors_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_error_info test_error_1 = s_errors[0];
     struct aws_error_info test_error_2 = s_errors[1];
@@ -154,8 +154,8 @@ static void s_error_test_thread_local_cb(int err, void *ctx) {
 }
 
 static int s_error_callback_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct error_test_cb_data cb_data = {.last_seen = 0, .global_cb_called = 0, .tl_cb_called = 0};
 
@@ -240,8 +240,8 @@ static int s_error_callback_test_fn(struct aws_allocator *allocator, void *ctx) 
 }
 
 static int s_unknown_error_code_in_slot_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     int error = aws_last_error();
 
@@ -280,8 +280,8 @@ static int s_unknown_error_code_in_slot_test_fn(struct aws_allocator *allocator,
 }
 
 static int s_unknown_error_code_no_slot_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     int error = aws_last_error();
 
@@ -319,8 +319,8 @@ static int s_unknown_error_code_no_slot_test_fn(struct aws_allocator *allocator,
 }
 
 static int s_unknown_error_code_range_too_large_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     int error = aws_last_error();
 
@@ -392,7 +392,7 @@ static void s_error_thread_fn(void *arg) {
 }
 
 static int s_error_code_cross_thread_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct error_thread_test_data test_data = {.thread_1_code = 0,
                                                .thread_1_get_last_code = 0,

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -53,7 +53,7 @@ static const char *TEST_VAL_STR_2 = "value 2";
 AWS_TEST_CASE(test_hash_table_create_find, s_test_hash_table_create_find_fn)
 static int s_test_hash_table_create_find_fn(struct aws_allocator *allocator, void *ctx) {
 
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     int err_code =
@@ -105,7 +105,7 @@ static int s_test_hash_table_create_find_fn(struct aws_allocator *allocator, voi
 
 AWS_TEST_CASE(test_hash_table_string_create_find, s_test_hash_table_string_create_find_fn)
 static int s_test_hash_table_string_create_find_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     struct aws_hash_element *pElem;
@@ -228,7 +228,7 @@ static void destroy_value_record(void *value) {
 
 AWS_TEST_CASE(test_hash_table_put, s_test_hash_table_put_fn)
 static int s_test_hash_table_put_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     struct aws_hash_element *pElem;
@@ -286,7 +286,7 @@ static int s_test_hash_table_put_fn(struct aws_allocator *allocator, void *ctx) 
 }
 AWS_TEST_CASE(test_hash_table_put_null_dtor, s_test_hash_table_put_null_dtor_fn)
 static int s_test_hash_table_put_null_dtor_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
 
@@ -304,7 +304,7 @@ static int s_test_hash_table_put_null_dtor_fn(struct aws_allocator *allocator, v
 
 AWS_TEST_CASE(test_hash_table_swap_move, s_test_hash_table_swap_move)
 static int s_test_hash_table_swap_move(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     AWS_STATIC_STRING_FROM_LITERAL(foo, "foo");
     AWS_STATIC_STRING_FROM_LITERAL(bar, "bar");
@@ -353,7 +353,7 @@ static int s_test_hash_table_swap_move(struct aws_allocator *allocator, void *ct
 AWS_TEST_CASE(test_hash_table_string_clean_up, s_test_hash_table_string_clean_up_fn)
 static int s_test_hash_table_string_clean_up_fn(struct aws_allocator *allocator, void *ctx) {
 
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* Verify that clean up happens properly when a destructor function is used only on keys or only on values. */
     struct aws_hash_table hash_table;
@@ -422,13 +422,13 @@ static int s_test_hash_table_string_clean_up_fn(struct aws_allocator *allocator,
 }
 
 static uint64_t hash_collide(const void *a) {
-    (void)a;
+    AWS_UNUSED_PARAM(a);
     return 4;
 }
 
 AWS_TEST_CASE(test_hash_table_hash_collision, s_test_hash_table_hash_collision_fn)
 static int s_test_hash_table_hash_collision_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     struct aws_hash_element *pElem;
@@ -461,7 +461,7 @@ static int s_test_hash_table_hash_collision_fn(struct aws_allocator *allocator, 
 
 AWS_TEST_CASE(test_hash_table_hash_overwrite, s_test_hash_table_hash_overwrite_fn)
 static int s_test_hash_table_hash_overwrite_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     struct aws_hash_element *pElem;
@@ -515,7 +515,7 @@ static void s_reset_destroy_ck(void) {
 AWS_TEST_CASE(test_hash_table_hash_remove, s_test_hash_table_hash_remove_fn)
 static int s_test_hash_table_hash_remove_fn(struct aws_allocator *allocator, void *ctx) {
 
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     struct aws_hash_element *pElem, elem;
@@ -582,7 +582,7 @@ static int s_test_hash_table_hash_remove_fn(struct aws_allocator *allocator, voi
 
 AWS_TEST_CASE(test_hash_table_hash_clear_allows_cleanup, s_test_hash_table_hash_clear_allows_cleanup_fn)
 static int s_test_hash_table_hash_clear_allows_cleanup_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     int err_code = aws_hash_table_init(
@@ -630,7 +630,7 @@ static int s_test_hash_table_hash_clear_allows_cleanup_fn(struct aws_allocator *
 
 AWS_TEST_CASE(test_hash_table_on_resize_returns_correct_entry, s_test_hash_table_on_resize_returns_correct_entry_fn)
 static int s_test_hash_table_on_resize_returns_correct_entry_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     int err_code = aws_hash_table_init(&hash_table, allocator, 10, aws_hash_ptr, aws_ptr_eq, NULL, NULL);
@@ -675,7 +675,7 @@ static int s_foreach_cb_deltarget(void *context, struct aws_hash_element *p_elem
 }
 
 static int s_foreach_cb_cutoff(void *context, struct aws_hash_element *p_element) {
-    (void)p_element;
+    AWS_UNUSED_PARAM(p_element);
 
     int *p_remain = context;
     s_iter_count++;
@@ -696,7 +696,7 @@ static int s_foreach_cb_cutoff_del(void *context, struct aws_hash_element *p_ele
 
 AWS_TEST_CASE(test_hash_table_foreach, s_test_hash_table_foreach_fn)
 static int s_test_hash_table_foreach_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     ASSERT_SUCCESS(
@@ -762,7 +762,7 @@ static bool s_hash_uint64_eq(const void *a, const void *b) {
 AWS_TEST_CASE(test_hash_table_iter, s_test_hash_table_iter_fn)
 static int s_test_hash_table_iter_fn(struct aws_allocator *allocator, void *ctx) {
 
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* Table entries are: (2^0 -> 2^10), (2^1 -> 2^11), (2^2 -> 2^12), ..., (2^9 -> 2^19).
      * We will iterate through the table and AND all the keys and all the values together
@@ -807,7 +807,7 @@ static int s_test_hash_table_iter_fn(struct aws_allocator *allocator, void *ctx)
 
 AWS_TEST_CASE(test_hash_table_empty_iter, s_test_hash_table_empty_iter_fn)
 static int s_test_hash_table_empty_iter_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table map;
     ASSERT_SUCCESS(aws_hash_table_init(&map, allocator, 10, s_hash_uint64_identity, s_hash_uint64_eq, NULL, NULL));
@@ -823,7 +823,7 @@ static int s_test_hash_table_empty_iter_fn(struct aws_allocator *allocator, void
 
 AWS_TEST_CASE(test_hash_table_iter_detail, s_test_hash_table_iter_detail)
 static int s_test_hash_table_iter_detail(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint64_t keys[32], vals[32];
     for (uint64_t i = 0; i < 32; i++) {
@@ -914,21 +914,21 @@ static int s_test_hash_table_iter_detail(struct aws_allocator *allocator, void *
 }
 
 static uint64_t bad_hash_fn(const void *key) {
-    (void)key;
+    AWS_UNUSED_PARAM(key);
     return 4; // chosen by fair dice roll
               // guaranteed to be random
 }
 
 static bool everything_is_eq(const void *a, const void *b) {
-    (void)a;
-    (void)b;
+    AWS_UNUSED_PARAM(a);
+    AWS_UNUSED_PARAM(b);
 
     return true;
 }
 
 AWS_TEST_CASE(test_hash_table_eq, s_test_hash_table_eq)
 static int s_test_hash_table_eq(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table table_a, table_b;
 
@@ -1011,7 +1011,7 @@ static long s_timestamp(void) {
 
 AWS_TEST_CASE(test_hash_churn, s_test_hash_churn_fn)
 static int s_test_hash_churn_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     int i = 0;
     struct aws_hash_table hash_table;
@@ -1123,7 +1123,7 @@ static int s_test_hash_churn_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_hash_table_cleanup_idempotent, s_test_hash_table_cleanup_idempotent_fn)
 static int s_test_hash_table_cleanup_idempotent_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     ASSERT_SUCCESS(
@@ -1147,7 +1147,7 @@ static void s_hash_table_entry_destroy(void *item) {
 
 AWS_TEST_CASE(test_hash_table_byte_cursor_create_find, s_test_hash_table_byte_cursor_create_find_fn)
 static int s_test_hash_table_byte_cursor_create_find_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_hash_table hash_table;
     struct aws_hash_element *pElem;

--- a/tests/linked_list_test.c
+++ b/tests/linked_list_test.c
@@ -23,8 +23,8 @@ struct int_value {
 };
 
 static int s_test_linked_list_order_push_back_pop_front(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_linked_list list;
 
@@ -63,8 +63,8 @@ static int s_test_linked_list_order_push_back_pop_front(struct aws_allocator *al
 }
 
 static int s_test_linked_list_order_push_front_pop_back(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_linked_list list;
 
@@ -107,8 +107,8 @@ static int s_test_linked_list_order_push_front_pop_back(struct aws_allocator *al
 }
 
 static int s_test_linked_list_iteration(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_linked_list list;
 
@@ -143,8 +143,8 @@ static int s_test_linked_list_iteration(struct aws_allocator *allocator, void *c
 }
 
 static int s_test_linked_list_reverse_iteration(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_linked_list list;
 
@@ -179,8 +179,8 @@ static int s_test_linked_list_reverse_iteration(struct aws_allocator *allocator,
 }
 
 static int s_test_linked_list_swap_contents(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_linked_list a, b;
     struct aws_linked_list_node a1, a2, b1, b2;

--- a/tests/lru_cache_test.c
+++ b/tests/lru_cache_test.c
@@ -19,7 +19,7 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_lru_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_lru_cache cache;
 
@@ -79,7 +79,7 @@ static int s_test_lru_cache_overflow_static_members_fn(struct aws_allocator *all
 AWS_TEST_CASE(test_lru_cache_overflow_static_members, s_test_lru_cache_overflow_static_members_fn)
 
 static int s_test_lru_cache_lru_ness_static_members_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_lru_cache cache;
 
@@ -144,7 +144,7 @@ static void s_lru_test_element_value_destroy(void *value) {
 }
 
 static int s_test_lru_cache_entries_cleanup_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_lru_cache cache;
 
@@ -193,7 +193,7 @@ static int s_test_lru_cache_entries_cleanup_fn(struct aws_allocator *allocator, 
 AWS_TEST_CASE(test_lru_cache_entries_cleanup, s_test_lru_cache_entries_cleanup_fn)
 
 static int s_test_lru_cache_overwrite_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_lru_cache cache;
 
@@ -226,7 +226,7 @@ static int s_test_lru_cache_overwrite_fn(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(test_lru_cache_overwrite, s_test_lru_cache_overwrite_fn)
 
 static int s_test_lru_cache_element_access_members_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_lru_cache cache;
 

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -41,8 +41,8 @@
 
 AWS_TEST_CASE(test_is_power_of_two, s_test_is_power_of_two_fn)
 static int s_test_is_power_of_two_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     ASSERT_FALSE(aws_is_power_of_two(0));
     for (size_t i = 0; i < SIZE_BITS; ++i) {
@@ -79,8 +79,8 @@ static int s_test_is_power_of_two_fn(struct aws_allocator *allocator, void *ctx)
 
 AWS_TEST_CASE(test_round_up_to_power_of_two, s_test_round_up_to_power_of_two_fn)
 static int s_test_round_up_to_power_of_two_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     /*special case 0, 1 and 2, where subtracting from the number doesn't cause it to round back up */
     CHECK_ROUND_SUCCEEDS(0, 1);
@@ -103,8 +103,8 @@ static int s_test_round_up_to_power_of_two_fn(struct aws_allocator *allocator, v
 
 AWS_TEST_CASE(test_mul_u64_saturating, s_test_mul_u64_saturating_fn)
 static int s_test_mul_u64_saturating_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     CHECK_SAT(aws_mul_u64_saturating, 0, 0, 0);
     CHECK_SAT(aws_mul_u64_saturating, 0, 1, 0);
@@ -128,8 +128,8 @@ static int s_test_mul_u64_saturating_fn(struct aws_allocator *allocator, void *c
 
 AWS_TEST_CASE(test_mul_u32_saturating, s_test_mul_u32_saturating_fn)
 static int s_test_mul_u32_saturating_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     CHECK_SAT(aws_mul_u32_saturating, 0, 0, 0);
     CHECK_SAT(aws_mul_u32_saturating, 0, 1, 0);
@@ -155,8 +155,8 @@ static int s_test_mul_u32_saturating_fn(struct aws_allocator *allocator, void *c
 AWS_TEST_CASE(test_mul_size_saturating, s_test_mul_size_saturating_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_mul_size_saturating_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
 #if SIZE_BITS == 32
     CHECK_SAT(aws_mul_size_saturating, 0, 0, 0);
@@ -235,8 +235,8 @@ static int s_test_mul_size_saturating_fn(struct aws_allocator *allocator, void *
 
 AWS_TEST_CASE(test_mul_u64_checked, s_test_mul_u64_checked_fn)
 static int s_test_mul_u64_checked_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0, 0, 0);
     CHECK_NO_OVF(aws_mul_u64_checked, uint64_t, 0, 1, 0);
@@ -261,8 +261,8 @@ static int s_test_mul_u64_checked_fn(struct aws_allocator *allocator, void *ctx)
 AWS_TEST_CASE(test_mul_u32_checked, s_test_mul_u32_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_mul_u32_checked_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0, 0, 0);
     CHECK_NO_OVF(aws_mul_u32_checked, uint32_t, 0, 1, 0);
@@ -288,8 +288,8 @@ static int s_test_mul_u32_checked_fn(struct aws_allocator *allocator, void *ctx)
 AWS_TEST_CASE(test_mul_size_checked, s_test_mul_size_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_mul_size_checked_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
 #if SIZE_BITS == 32
     CHECK_NO_OVF(aws_mul_size_checked, size_t, 0, 0, 0);
@@ -335,8 +335,8 @@ static int s_test_mul_size_checked_fn(struct aws_allocator *allocator, void *ctx
 AWS_TEST_CASE(test_add_size_checked, s_test_add_size_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_size_checked_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
 #if SIZE_BITS == 32
     const uint32_t HALF_MAX = UINT32_MAX / 2;
@@ -373,8 +373,8 @@ static int s_test_add_size_checked_fn(struct aws_allocator *allocator, void *ctx
 AWS_TEST_CASE(test_add_size_saturating, s_test_add_size_saturating_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_size_saturating_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
 #if SIZE_BITS == 32
     const uint32_t HALF_MAX = UINT32_MAX / 2;
@@ -385,8 +385,8 @@ static int s_test_add_size_saturating_fn(struct aws_allocator *allocator, void *
 #else
     FAIL("Unexpected size for size_t: %zu", sizeof(size_t));
 #endif
-    (void)HALF_MAX;
-    (void)ACTUAL_MAX;
+    AWS_UNUSED_PARAM(HALF_MAX);
+    AWS_UNUSED_PARAM(ACTUAL_MAX);
     /* No overflow expected */
     CHECK_SAT(aws_add_size_saturating, 0, 0, 0);
     CHECK_SAT(aws_add_size_saturating, 0, 1, 1);
@@ -414,8 +414,8 @@ static int s_test_add_size_saturating_fn(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(test_add_u32_checked, s_test_add_u32_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_u32_checked_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const uint32_t HALF_MAX = UINT32_MAX / 2;
     const uint32_t ACTUAL_MAX = UINT32_MAX;
@@ -444,8 +444,8 @@ static int s_test_add_u32_checked_fn(struct aws_allocator *allocator, void *ctx)
 AWS_TEST_CASE(test_add_u32_saturating, s_test_add_u32_saturating_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_u32_saturating_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const uint32_t HALF_MAX = UINT32_MAX / 2;
     const uint32_t ACTUAL_MAX = UINT32_MAX;
@@ -477,8 +477,8 @@ static int s_test_add_u32_saturating_fn(struct aws_allocator *allocator, void *c
 AWS_TEST_CASE(test_add_u64_checked, s_test_add_u64_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_u64_checked_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const uint64_t HALF_MAX = UINT64_MAX / 2;
     const uint64_t ACTUAL_MAX = UINT64_MAX;
@@ -507,8 +507,8 @@ static int s_test_add_u64_checked_fn(struct aws_allocator *allocator, void *ctx)
 AWS_TEST_CASE(test_add_u64_saturating, s_test_add_u64_saturating_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_u64_saturating_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const uint64_t HALF_MAX = UINT64_MAX / 2;
     const uint64_t ACTUAL_MAX = UINT64_MAX;

--- a/tests/mutex_test.c
+++ b/tests/mutex_test.c
@@ -19,8 +19,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_mutex_acquire_release(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_mutex mutex;
     aws_mutex_init(&mutex);
@@ -58,7 +58,7 @@ static void s_mutex_thread_fn(void *mutex_data) {
 }
 
 static int s_test_mutex_is_actually_mutex(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct thread_mutex_data mutex_data = {
         .counter = 0,

--- a/tests/priority_queue_test.c
+++ b/tests/priority_queue_test.c
@@ -33,7 +33,7 @@ static int s_compare_ints(const void *a, const void *b) {
 }
 
 static int s_test_priority_queue_preserves_order(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_priority_queue queue;
 
@@ -107,8 +107,8 @@ static int s_test_priority_queue_preserves_order(struct aws_allocator *allocator
 }
 
 static int s_test_priority_queue_random_values(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     enum { SIZE = 20 };
     struct aws_priority_queue queue;
@@ -155,7 +155,7 @@ static int s_test_priority_queue_random_values(struct aws_allocator *allocator, 
 }
 
 static int s_test_priority_queue_size_and_capacity(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_priority_queue queue;
     int err = aws_priority_queue_init_dynamic(&queue, allocator, 5, sizeof(int), s_compare_ints);
@@ -202,7 +202,7 @@ static int s_test_priority_queue_size_and_capacity(struct aws_allocator *allocat
     } while (0)
 
 static int s_test_remove_root(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_priority_queue queue;
     struct aws_priority_queue_node node = {12345};
@@ -225,7 +225,7 @@ static int s_test_remove_root(struct aws_allocator *allocator, void *ctx) {
 }
 
 static int s_test_remove_leaf(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_priority_queue queue;
     struct aws_priority_queue_node node = {12345};
@@ -284,7 +284,7 @@ static int s_test_remove_leaf(struct aws_allocator *allocator, void *ctx) {
  *     15
  */
 static int s_test_remove_interior_sift_up(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_priority_queue queue;
     struct aws_priority_queue_node node = {12345};
@@ -375,7 +375,7 @@ static int s_test_remove_interior_sift_up(struct aws_allocator *allocator, void 
  *     30
  */
 static int s_test_remove_interior_sift_down(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_priority_queue queue;
     struct aws_priority_queue_node node = {12345};

--- a/tests/realloc_test.c
+++ b/tests/realloc_test.c
@@ -24,7 +24,7 @@
 static size_t s_alloc_counter, s_alloc_total_size, s_call_ct_malloc, s_call_ct_free, s_call_ct_realloc;
 
 static void *s_test_alloc_acquire(struct aws_allocator *allocator, size_t size) {
-    (void)allocator;
+    AWS_UNUSED_PARAM(allocator);
 
     s_alloc_counter++;
     s_call_ct_malloc++;
@@ -37,7 +37,7 @@ static void *s_test_alloc_acquire(struct aws_allocator *allocator, size_t size) 
 }
 
 static void s_test_alloc_release(struct aws_allocator *allocator, void *ptr) {
-    (void)allocator;
+    AWS_UNUSED_PARAM(allocator);
 
     uint8_t *buf = ptr;
     s_call_ct_free++;
@@ -53,7 +53,7 @@ static void s_test_alloc_release(struct aws_allocator *allocator, void *ptr) {
 static size_t s_original_size, s_reported_oldsize;
 
 static void *s_test_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
-    (void)allocator;
+    AWS_UNUSED_PARAM(allocator);
 
     uint8_t *buf = ptr;
     buf -= 16;
@@ -79,16 +79,16 @@ static void *s_test_realloc(struct aws_allocator *allocator, void *ptr, size_t o
 }
 
 static void *s_test_malloc_failing(struct aws_allocator *allocator, size_t size) {
-    (void)allocator;
-    (void)size;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(size);
     return NULL;
 }
 
 static void *s_test_realloc_failing(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
-    (void)allocator;
-    (void)ptr;
-    (void)oldsize;
-    (void)newsize;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ptr);
+    AWS_UNUSED_PARAM(oldsize);
+    AWS_UNUSED_PARAM(newsize);
     return NULL;
 }
 
@@ -98,8 +98,8 @@ static const uint8_t TEST_PATTERN[32] = {0xa5, 0x41, 0xcb, 0xe7, 0x00, 0x19, 0xd
 
 AWS_TEST_CASE(test_realloc_fallback, s_test_realloc_fallback_fn)
 static int s_test_realloc_fallback_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_allocator test_allocator = {
         .mem_acquire = s_test_alloc_acquire,
@@ -127,8 +127,8 @@ static int s_test_realloc_fallback_fn(struct aws_allocator *allocator, void *ctx
 
 AWS_TEST_CASE(test_realloc_fallback_oom, s_test_realloc_fallback_oom_fn)
 static int s_test_realloc_fallback_oom_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_allocator test_allocator = {
         .mem_acquire = s_test_alloc_acquire,
@@ -153,8 +153,8 @@ static int s_test_realloc_fallback_oom_fn(struct aws_allocator *allocator, void 
 
 AWS_TEST_CASE(test_realloc_passthrough_oom, s_test_realloc_passthrough_oom_fn)
 static int s_test_realloc_passthrough_oom_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_allocator test_allocator = {
         .mem_acquire = s_test_alloc_acquire,
@@ -178,8 +178,8 @@ static int s_test_realloc_passthrough_oom_fn(struct aws_allocator *allocator, vo
 
 AWS_TEST_CASE(test_realloc_passthrough, s_test_realloc_passthrough_fn)
 static int s_test_realloc_passthrough_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_allocator test_allocator = {
         .mem_acquire = s_test_alloc_acquire,
@@ -209,8 +209,8 @@ static int s_test_realloc_passthrough_fn(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(test_cf_allocator_wrapper, s_test_cf_allocator_wrapper_fn)
 
 static int s_test_cf_allocator_wrapper_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
 #ifdef __MACH__
     CFAllocatorRef cf_allocator = aws_wrapped_cf_allocator_new(allocator);
@@ -235,8 +235,8 @@ static int s_test_cf_allocator_wrapper_fn(struct aws_allocator *allocator, void 
 
 AWS_TEST_CASE(test_acquire_many, s_test_acquire_many_fn)
 static int s_test_acquire_many_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     void *a = NULL;
     void *b = NULL;

--- a/tests/rw_lock_test.c
+++ b/tests/rw_lock_test.c
@@ -19,8 +19,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_rw_lock_acquire_release(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_rw_lock rw_lock;
     aws_rw_lock_init(&rw_lock);
@@ -73,7 +73,7 @@ static void s_rw_lock_thread_fn(void *rw_lock_data) {
 }
 
 static int s_test_rw_lock_is_actually_rw_lock(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct thread_rw_lock_data rw_lock_data = {
         .counter = 0,
@@ -129,7 +129,7 @@ static void s_thread_reader_fn(void *ud) {
 }
 
 static int s_test_rw_lock_many_readers(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_rw_lock lock;
     aws_rw_lock_init(&lock);

--- a/tests/secure_zero_test.c
+++ b/tests/secure_zero_test.c
@@ -19,8 +19,8 @@
 
 AWS_TEST_CASE(test_secure_zero, s_test_secure_zero_fn)
 static int s_test_secure_zero_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     /* We can't actually test the secure part of the zero operation - anything
      * we do to observe the buffer will teach the compiler that it needs to
@@ -52,7 +52,7 @@ static int s_test_secure_zero_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_buffer_secure_zero, s_test_buffer_secure_zero_fn)
 static int s_test_buffer_secure_zero_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_byte_buf buf;
     size_t len = 27;
@@ -74,7 +74,7 @@ static int s_test_buffer_secure_zero_fn(struct aws_allocator *allocator, void *c
 
 AWS_TEST_CASE(test_buffer_clean_up_secure, s_test_buffer_clean_up_secure_fn)
 static int s_test_buffer_clean_up_secure_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* We cannot test the zeroing of data here, because that would require reading
      * memory that has already been freed. Simply verifies that there is no memory leak.

--- a/tests/split_test.c
+++ b/tests/split_test.c
@@ -19,7 +19,7 @@
 
 AWS_TEST_CASE(test_char_split_happy_path, s_test_char_split_happy_path_fn)
 static int s_test_char_split_happy_path_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = "testa;testb;testc";
 
@@ -52,7 +52,7 @@ static int s_test_char_split_happy_path_fn(struct aws_allocator *allocator, void
 
 AWS_TEST_CASE(test_char_split_ends_with_token, s_test_char_split_ends_with_token_fn)
 static int s_test_char_split_ends_with_token_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = "testa;testb;testc;";
 
@@ -87,7 +87,7 @@ static int s_test_char_split_ends_with_token_fn(struct aws_allocator *allocator,
 
 AWS_TEST_CASE(test_char_split_begins_with_token, s_test_char_split_begins_with_token_fn)
 static int s_test_char_split_begins_with_token_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = ";testa;testb;testc";
 
@@ -124,7 +124,7 @@ static int s_test_char_split_begins_with_token_fn(struct aws_allocator *allocato
 
 AWS_TEST_CASE(test_char_split_token_not_present, s_test_char_split_token_not_present_fn)
 static int s_test_char_split_token_not_present_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = "testa";
 
@@ -149,7 +149,7 @@ static int s_test_char_split_token_not_present_fn(struct aws_allocator *allocato
 
 AWS_TEST_CASE(test_char_split_empty, s_test_char_split_empty_fn)
 static int s_test_char_split_empty_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = "";
 
@@ -171,7 +171,7 @@ static int s_test_char_split_empty_fn(struct aws_allocator *allocator, void *ctx
 
 AWS_TEST_CASE(test_char_split_adj_tokens, s_test_char_split_adj_tokens_fn)
 static int s_test_char_split_adj_tokens_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = "testa;;testb;testc";
 
@@ -208,7 +208,7 @@ static int s_test_char_split_adj_tokens_fn(struct aws_allocator *allocator, void
 
 AWS_TEST_CASE(test_char_split_with_max_splits, s_test_char_split_with_max_splits_fn)
 static int s_test_char_split_with_max_splits_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = ";testa;testb;testc";
 
@@ -241,8 +241,8 @@ static int s_test_char_split_with_max_splits_fn(struct aws_allocator *allocator,
 
 AWS_TEST_CASE(test_char_split_output_too_small, s_test_char_split_output_too_small_fn)
 static int s_test_char_split_output_too_small_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const char str_to_split[] = "testa;testb;testc;";
 

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -20,7 +20,7 @@
 
 AWS_TEST_CASE(string_tests, s_string_tests_fn);
 static int s_string_tests_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* Test: static string creation from macro works. */
     AWS_STATIC_STRING_FROM_LITERAL(test_string_1, "foofaraw");
@@ -95,7 +95,7 @@ static int s_string_tests_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(binary_string_test, s_binary_string_test_fn);
 static int s_binary_string_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t test_array[] = {0x86, 0x75, 0x30, 0x90, 0x00, 0xde, 0xad, 0xbe, 0xef};
     size_t len = sizeof(test_array);
@@ -119,8 +119,8 @@ static int s_binary_string_test_fn(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(string_compare_test, s_string_compare_test_fn);
 static int s_string_compare_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     AWS_STATIC_STRING_FROM_LITERAL(empty, "");
     AWS_STATIC_STRING_FROM_LITERAL(foo, "foo");
@@ -156,7 +156,7 @@ static int s_string_compare_test_fn(struct aws_allocator *allocator, void *ctx) 
 
 AWS_TEST_CASE(string_destroy_secure_test, string_destroy_secure_test_fn);
 static int string_destroy_secure_test_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* Just verifies all memory was freed. */
     struct aws_string *empty = aws_string_new_from_c_str(allocator, "");

--- a/tests/system_info_tests.c
+++ b/tests/system_info_tests.c
@@ -18,8 +18,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_cpu_count_at_least_works_superficially_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     size_t processor_count = aws_system_info_processor_count();
     /* I think this is a fairly reasonable assumption given the circumstances
@@ -37,7 +37,7 @@ AWS_TEST_CASE(test_cpu_count_at_least_works_superficially, s_test_cpu_count_at_l
 #endif
 
 static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
     char tmp_filename[] = "backtraceXXXXXX";
     FILE *tmp_file = NULL;
 

--- a/tests/task_scheduler_test.c
+++ b/tests/task_scheduler_test.c
@@ -40,7 +40,7 @@ static void s_task_n_fn(struct aws_task *task, void *arg, enum aws_task_status s
 }
 
 static int s_test_scheduler_ordering(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
     s_executed_tasks_n = 0;
 
     struct aws_task_scheduler scheduler;
@@ -96,13 +96,13 @@ static int s_test_scheduler_ordering(struct aws_allocator *allocator, void *ctx)
 }
 
 static void s_null_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
-    (void)task;
-    (void)arg;
-    (void)status;
+    AWS_UNUSED_PARAM(task);
+    AWS_UNUSED_PARAM(arg);
+    AWS_UNUSED_PARAM(status);
 }
 
 static int s_test_scheduler_has_tasks(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_task_scheduler scheduler;
     aws_task_scheduler_init(&scheduler, allocator);
@@ -133,7 +133,7 @@ static int s_test_scheduler_has_tasks(struct aws_allocator *allocator, void *ctx
 }
 
 static int s_test_scheduler_pops_task_fashionably_late(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
     s_executed_tasks_n = 0;
 
     struct aws_task_scheduler scheduler;
@@ -172,7 +172,7 @@ struct task_scheduler_reentrancy_args {
 };
 
 static void s_reentrancy_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
-    (void)task;
+    AWS_UNUSED_PARAM(task);
     struct task_scheduler_reentrancy_args *reentrancy_args = (struct task_scheduler_reentrancy_args *)arg;
 
     if (reentrancy_args->next_task_args) {
@@ -196,7 +196,7 @@ static void s_reentrancy_args_init(
 }
 
 static int s_test_scheduler_reentrant_safe(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_task_scheduler scheduler;
     aws_task_scheduler_init(&scheduler, allocator);
@@ -234,14 +234,14 @@ struct cancellation_args {
 
 static void s_cancellation_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
 
-    (void)task;
+    AWS_UNUSED_PARAM(task);
     struct cancellation_args *cancellation_args = (struct cancellation_args *)arg;
 
     cancellation_args->status = status;
 }
 
 static int s_test_scheduler_cleanup_cancellation(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_task_scheduler scheduler;
     aws_task_scheduler_init(&scheduler, allocator);
@@ -264,7 +264,7 @@ static int s_test_scheduler_cleanup_cancellation(struct aws_allocator *allocator
 }
 
 static int s_test_scheduler_cleanup_reentrants(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_task_scheduler scheduler;
     aws_task_scheduler_init(&scheduler, allocator);
@@ -349,13 +349,13 @@ static void s_oom_allocator_destroy(struct aws_allocator *oom_allocator) {
 }
 
 static void s_oom_task_fn(struct aws_task *task, void *arg, enum aws_task_status status) {
-    (void)status;
+    AWS_UNUSED_PARAM(status);
     struct aws_linked_list *done_list = arg;
     aws_linked_list_push_back(done_list, &task->node);
 }
 
 static int s_test_scheduler_oom_still_works(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
 
     /* Create allocator for scheduler that limits how many allocations it can make.
      * Note that timed_queue is an array-list under the hood, so it only grabs memory at init and resize time */
@@ -456,7 +456,7 @@ static void s_task_cancelling_task(struct aws_task *task, void *arg, enum aws_ta
 }
 
 static int s_test_scheduler_schedule_cancellation(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
     s_executed_tasks_n = 0;
 
     struct aws_task_scheduler scheduler;

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -27,7 +27,7 @@ static void s_thread_fn(void *arg) {
 }
 
 static int s_test_thread_creation_join_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
+    AWS_UNUSED_PARAM(ctx);
     struct thread_test_data test_data;
     test_data.thread_id = 0;
 

--- a/tests/uuid_test.c
+++ b/tests/uuid_test.c
@@ -19,8 +19,8 @@
 #include <aws/testing/aws_test_harness.h>
 
 static int s_uuid_string_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
@@ -40,8 +40,8 @@ static int s_uuid_string_fn(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(uuid_string, s_uuid_string_fn)
 
 static int s_prefilled_uuid_string_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_uuid uuid = {
         .uuid_data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10},
@@ -63,8 +63,8 @@ static int s_prefilled_uuid_string_fn(struct aws_allocator *allocator, void *ctx
 AWS_TEST_CASE(prefilled_uuid_string, s_prefilled_uuid_string_fn)
 
 static int s_uuid_string_short_buffer_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
@@ -81,8 +81,8 @@ static int s_uuid_string_short_buffer_fn(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(uuid_string_short_buffer, s_uuid_string_short_buffer_fn)
 
 static int s_uuid_string_parse_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     uint8_t expected_uuid[] = {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10};
@@ -101,8 +101,8 @@ static int s_uuid_string_parse_fn(struct aws_allocator *allocator, void *ctx) {
 AWS_TEST_CASE(uuid_string_parse, s_uuid_string_parse_fn)
 
 static int s_uuid_string_parse_too_short_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const char *uuid_str = "01020304-0506-0708-090a-0b0c0d0e0f1";
     struct aws_byte_buf uuid_buf = aws_byte_buf_from_c_str(uuid_str);
@@ -117,8 +117,8 @@ static int s_uuid_string_parse_too_short_fn(struct aws_allocator *allocator, voi
 AWS_TEST_CASE(uuid_string_parse_too_short, s_uuid_string_parse_too_short_fn)
 
 static int s_uuid_string_parse_malformed_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)allocator;
-    (void)ctx;
+    AWS_UNUSED_PARAM(allocator);
+    AWS_UNUSED_PARAM(ctx);
 
     const char *uuid_str = "010203-040506-0708-090a-0b0c0d0e0f10";
     struct aws_byte_buf uuid_buf = aws_byte_buf_from_c_str(uuid_str);


### PR DESCRIPTION
*Description of changes:*

This PR adds an AWS_UNUSED_PARAM(param) macro and respectively replaces all usages of the (void)param pattern. This makes identification of unused parameters simpler.

For context, I've been migrating a large database proxy system and compiler (of interest to AWS) from libevent/libuv over to AWS-C-IO. The code uses a number of portability/convenience macros, similar to those found in [Hedley](https://nemequ.github.io/hedley/api-reference.html), and I'm looking to add the commonly-useful ones to AWS-C-COMMON. Accordingly, I'll update the other common-based libraries (io, http, mqtt, etc.) to use any new addition as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
