### PR TITLE
aws_hash_table_eq() CBMC proof

### DIFF
--- a/.cbmc-batch/jobs/aws_hash_table_eq/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_eq/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# 8: 2m30s
+MAX_TABLE_SIZE ?= 8
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
+
+UNWINDSET +=  aws_hash_table_eq.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/hash_table.c
+
+ABSTRACTIONS += $(HELPERDIR)/stubs/aws_hash_table_find_override.c
+
+ADDITIONAL_REMOVE_FUNCTION_BODY +=  --remove-function-body aws_hash_table_find
+
+ENTRY = aws_hash_table_eq_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_hash_table_eq/aws_hash_table_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_eq/aws_hash_table_eq_harness.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_hash_table_eq_harness() {
+    struct aws_hash_table map_a;
+    ensure_allocated_hash_table(&map_a, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map_a));
+    map_a.p_impl->equals_fn = uninterpreted_equals_assert_inputs_nonnull;
+    map_a.p_impl->hash_fn = uninterpreted_hasher;
+    struct store_byte_from_buffer old_byte_a;
+    save_byte_from_hash_table(&map_a, &old_byte_a);
+
+    struct aws_hash_table map_b;
+    ensure_allocated_hash_table(&map_b, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map_b));
+    map_b.p_impl->equals_fn = uninterpreted_equals_assert_inputs_nonnull;
+    map_b.p_impl->hash_fn = uninterpreted_hasher;
+    struct store_byte_from_buffer old_byte_b;
+    save_byte_from_hash_table(&map_b, &old_byte_b);
+
+    bool rval = aws_hash_table_eq(&map_a, &map_b, uninterpreted_equals_assert_inputs_nonnull);
+
+    assert(aws_hash_table_is_valid(&map_a));
+    assert(aws_hash_table_is_valid(&map_b));
+    check_hash_table_unchanged(&map_a, &old_byte_a);
+    check_hash_table_unchanged(&map_b, &old_byte_b);
+}

--- a/.cbmc-batch/jobs/aws_hash_table_eq/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_eq/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_hash_table_eq.0:9;--object-bits;8"
+goto: aws_hash_table_eq_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/stubs/aws_hash_table_find_override.c
+++ b/.cbmc-batch/stubs/aws_hash_table_find_override.c
@@ -1,0 +1,30 @@
+#include <aws/common/hash_table.h>
+#include <aws/common/math.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/common/string.h>
+
+#include <limits.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <stdio.h>
+#include <stdlib.h>
+bool __CPROVER_file_local_hash_table_c_s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b);
+
+int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struct aws_hash_element **p_elem) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(p_elem));
+
+    const struct hash_table_state *const state = map->p_impl;
+    size_t i;
+
+    __CPROVER_assume(i < state->size);
+    if (nondet_bool()) {
+        *p_elem = NULL;
+    } else {
+        const struct hash_table_entry *const entry = &state->slots[i];
+        __CPROVER_assume(__CPROVER_file_local_hash_table_c_s_hash_keys_eq(state, key, entry->element.key));
+        *p_elem = &entry->element;
+    }
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    return AWS_OP_SUCCESS;
+}

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -64,11 +64,9 @@ static uint64_t s_hash_for(struct hash_table_state *state, const void *key) {
 }
 
 /**
- * Check equality of two hash keys, with a reasonable semantics for null keys.
+ * Check equality of two objects, with a reasonable semantics for null.
  */
-static bool s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b) {
-    AWS_PRECONDITION(hash_table_state_is_valid(state));
-
+static bool s_safe_eq_check(aws_hash_callback_eq_fn *equals_fn, const void *a, const void *b) {
     /* Short circuit if the pointers are the same */
     if (a == b) {
         return true;
@@ -78,7 +76,17 @@ static bool s_hash_keys_eq(struct hash_table_state *state, const void *a, const 
         return false;
     }
     /* If both are non-null, call the underlying equals fn */
-    return state->equals_fn(a, b);
+    return equals_fn(a, b);
+}
+
+/**
+ * Check equality of two hash keys, with a reasonable semantics for null keys.
+ */
+static bool s_hash_keys_eq(struct hash_table_state *state, const void *a, const void *b) {
+    AWS_PRECONDITION(hash_table_state_is_valid(state));
+    bool rval = s_safe_eq_check(state->equals_fn, a, b);
+    AWS_POSTCONDITION(hash_table_state_is_valid(state));
+    return rval;
 }
 
 static size_t s_index_for(struct hash_table_state *map, struct hash_table_entry *entry) {
@@ -400,7 +408,7 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
     } else {
         *p_elem = NULL;
     }
-
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
     return AWS_OP_SUCCESS;
 }
 
@@ -697,7 +705,14 @@ bool aws_hash_table_eq(
     const struct aws_hash_table *a,
     const struct aws_hash_table *b,
     aws_hash_callback_eq_fn *value_eq) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(a));
+    AWS_PRECONDITION(aws_hash_table_is_valid(b));
+    AWS_PRECONDITION(value_eq != NULL);
+
     if (aws_hash_table_get_entry_count(a) != aws_hash_table_get_entry_count(b)) {
+        AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+        AWS_POSTCONDITION(aws_hash_table_is_valid(b));
+
         return false;
     }
 
@@ -706,21 +721,31 @@ bool aws_hash_table_eq(
      * entries, we can simply iterate one and compare against the same key in
      * the other.
      */
-    for (struct aws_hash_iter iter = aws_hash_iter_begin(a); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) {
+    for (size_t i = 0; i < a->p_impl->size; ++i) {
+        const struct hash_table_entry *const a_entry = &a->p_impl->slots[i];
+        if (a_entry->hash_code == 0) {
+            continue;
+        }
+
         struct aws_hash_element *b_element = NULL;
 
-        aws_hash_table_find(b, iter.element.key, &b_element);
+        aws_hash_table_find(b, a_entry->element.key, &b_element);
 
         if (!b_element) {
             /* Key is present in A only */
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b));
             return false;
         }
 
-        if (!value_eq(iter.element.value, b_element->value)) {
+        if (!s_safe_eq_check(value_eq, a_entry->element.value, b_element->value)) {
+            AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+            AWS_POSTCONDITION(aws_hash_table_is_valid(b));
             return false;
         }
     }
-
+    AWS_POSTCONDITION(aws_hash_table_is_valid(a));
+    AWS_POSTCONDITION(aws_hash_table_is_valid(b));
     return true;
 }
 


### PR DESCRIPTION
* aws_hash_table_eq() CBMC proof
* code cleanup for aws_hash_table_eq
* add new function s_safe_eq_check to prevent a NULL dereference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
