### PR TITLE
Extend functions set_at and push_back to have a non-NULL pointer precondition

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
@@ -35,7 +35,7 @@ void aws_array_list_push_back_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification and assertions */
-    void *val = malloc(list.item_size);
+    void *val = can_fail_malloc(list.item_size);
     if (!aws_array_list_push_back(&list, val)) {
         assert(list.length == old.length + 1);
     } else {

--- a/.cbmc-batch/jobs/aws_array_list_set_at/aws_array_list_set_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/aws_array_list_set_at_harness.c
@@ -35,7 +35,7 @@ void aws_array_list_set_at_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification and assertions */
-    void *val = malloc(list.item_size);
+    void *val = can_fail_malloc(list.item_size);
     size_t index;
     if (!aws_array_list_set_at(&list, val, index)) {
         if (index > old.length)

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -107,6 +107,7 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val);
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
@@ -296,6 +297,7 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val);
     size_t necessary_size;
     if (aws_array_list_calc_necessary_size(list, index, &necessary_size)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
