### PR TITLE
Implement a harness for priority_queue sift_down/up/either

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -78,6 +78,12 @@ bool aws_priority_queue_is_bounded(
     const size_t max_initial_item_allocation,
     const size_t max_item_size);
 
+/*
+ * Ensures that a cell of the backpointer array is NULL or points to
+ * an allocated [aws_priority_queue_object].
+ */
+void ensure_backpointer_cell_points_to_allocated(struct aws_array_list *const backpointers, const size_t index);
+
 /**
  * Ensures members of an aws_priority_queue structure are correctly
  * allocated and returns whether the backpointers list was allocated

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -78,12 +78,6 @@ bool aws_priority_queue_is_bounded(
     const size_t max_initial_item_allocation,
     const size_t max_item_size);
 
-/*
- * Ensures that a cell of the backpointer array is NULL or points to
- * an allocated [aws_priority_queue_object].
- */
-void ensure_backpointer_cell_points_to_allocated(struct aws_array_list *const backpointers, const size_t index);
-
 /**
  * Ensures members of an aws_priority_queue structure are correctly
  * allocated and returns whether the backpointers list was allocated

--- a/.cbmc-batch/jobs/Makefile.aws_priority_queue_sift
+++ b/.cbmc-batch/jobs/Makefile.aws_priority_queue_sift
@@ -1,0 +1,18 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#################################
+
+MAX_PRIORITY_QUEUE_ITEMS ?= 5
+# This should be the ceil(1 + log2(MAX_PRIORITY_QUEUE_ITEMS))
+MAX_HEAP_HEIGHT ?= 3
+DEFINES += -DMAX_PRIORITY_QUEUE_ITEMS=$(MAX_PRIORITY_QUEUE_ITEMS)

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/Makefile
@@ -22,14 +22,11 @@ include ../Makefile.aws_priority_queue_sift
 # - 300s for MAX_PRIORITY_QUEUE_ITEMS=4 items
 
 # Note:
-# In order to reach full coverage we have to unwind
-# log(NUMBER_PRIO_QUEUE_ITEMS) but this number is huge so we only
-# unwind a small number of times. However, this shouldn't be a problem
-# for checking memory safety and overflows as the index of the element
-# to be sifted down is left unconstrained.
-UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_down.0:$(MAX_HEAP_HEIGHT)
+# In order to reach full coverage we need to unwind the harness loop
+# as many times as the number of queue items, and the sift down loop
+# log(NUMBER_PRIO_QUEUE_ITEMS) times.
 UNWINDSET += aws_priority_queue_s_sift_down_harness.0:$(shell echo $$((1 + $(MAX_PRIORITY_QUEUE_ITEMS))))
-
+UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_down.0:$(MAX_HEAP_HEIGHT)
 
 CBMCFLAGS += 
 

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+include ../Makefile.aws_priority_queue_sift
+
+###########
+#
+# Runtime:
+# - 300s for MAX_PRIORITY_QUEUE_ITEMS=3 items
+# - 300s for MAX_PRIORITY_QUEUE_ITEMS=4 items
+
+# Note:
+# In order to reach full coverage we have to unwind
+# log(NUMBER_PRIO_QUEUE_ITEMS) but this number is huge so we only
+# unwind a small number of times. However, this shouldn't be a problem
+# for checking memory safety and overflows as the index of the element
+# to be sifted down is left unconstrained.
+UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_down.0:$(MAX_HEAP_HEIGHT)
+UNWINDSET += aws_priority_queue_s_sift_down_harness.0:$(shell echo $$((1 + $(MAX_PRIORITY_QUEUE_ITEMS))))
+
+
+CBMCFLAGS += 
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/array_list.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+
+
+ENTRY = aws_priority_queue_s_sift_down_harness
+###########
+
+include ../Makefile.common
+

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/aws_priority_queue_s_sift_down_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/aws_priority_queue_s_sift_down_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void __CPROVER_file_local_priority_queue_c_s_sift_down(struct aws_priority_queue *queue, size_t root);
+
+void aws_priority_queue_s_sift_down_harness() {
+    /* Data structure */
+    struct aws_priority_queue queue;
+
+    /* Assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_PRIORITY_QUEUE_ITEMS, MAX_ITEM_SIZE));
+    bool backpointers_allocated = ensure_priority_queue_has_allocated_members(&queue);
+
+    /* Assume the function preconditions */
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+    size_t root;
+    __CPROVER_assume(root < queue.container.length);
+
+    if (backpointers_allocated) {
+        /* Assume that all backpointers are valid valid, either by
+         * being NULL or by allocating their objects. */
+
+        size_t i;
+        for (i = 0; i < queue.container.length; i++) {
+            ((struct aws_priority_queue_node **)queue.backpointers.data)[i] =
+                can_fail_malloc(sizeof(struct aws_priority_queue_node));
+        }
+    }
+
+    /* Perform operation under verification */
+    __CPROVER_file_local_priority_queue_c_s_sift_down(&queue, root);
+
+    /* Assert the postconditions */
+    assert(aws_priority_queue_is_valid(&queue));
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_priority_queue_c_s_sift_down.0:3,aws_priority_queue_s_sift_down_harness.0:6;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_priority_queue_s_sift_down_harness.0:6,__CPROVER_file_local_priority_queue_c_s_sift_down.0:3;--object-bits;8"
 goto: aws_priority_queue_s_sift_down_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_down/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_priority_queue_c_s_sift_down.0:3,aws_priority_queue_s_sift_down_harness.0:6;--object-bits;8"
+goto: aws_priority_queue_s_sift_down_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+include ../Makefile.aws_priority_queue_sift
+
+###########
+#
+# Runtime:
+# - 300s for MAX_PRIORITY_QUEUE_ITEMS=3 items
+# 
+
+# Note:
+# In order to reach full coverage we have to unwind
+# log(NUMBER_PRIO_QUEUE_ITEMS) but this number is huge so we only
+# unwind a small number of times. However, this shouldn't be a problem
+# for checking memory safety and overflows as the index of the element
+# to be sifted down is left unconstrained.
+UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_down.0:$(MAX_HEAP_HEIGHT)
+UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_up.0:$(MAX_HEAP_HEIGHT)
+UNWINDSET += aws_priority_queue_s_sift_either_harness.0:$(shell echo $$((1 + $(MAX_PRIORITY_QUEUE_ITEMS))))
+
+
+CBMCFLAGS += 
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/array_list.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+
+
+ENTRY = aws_priority_queue_s_sift_either_harness
+###########
+
+include ../Makefile.common
+

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/Makefile
@@ -22,11 +22,9 @@ include ../Makefile.aws_priority_queue_sift
 # 
 
 # Note:
-# In order to reach full coverage we have to unwind
-# log(NUMBER_PRIO_QUEUE_ITEMS) but this number is huge so we only
-# unwind a small number of times. However, this shouldn't be a problem
-# for checking memory safety and overflows as the index of the element
-# to be sifted down is left unconstrained.
+# In order to reach full coverage we need to unwind the harness loop
+# as many times as the number of queue items, and the sift down loop
+# log(NUMBER_PRIO_QUEUE_ITEMS) times.
 UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_down.0:$(MAX_HEAP_HEIGHT)
 UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_up.0:$(MAX_HEAP_HEIGHT)
 UNWINDSET += aws_priority_queue_s_sift_either_harness.0:$(shell echo $$((1 + $(MAX_PRIORITY_QUEUE_ITEMS))))

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/aws_priority_queue_s_sift_either_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/aws_priority_queue_s_sift_either_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void __CPROVER_file_local_priority_queue_c_s_sift_either(struct aws_priority_queue *queue, size_t root);
+
+void aws_priority_queue_s_sift_either_harness() {
+    /* Data structure */
+    struct aws_priority_queue queue;
+
+    /* Assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_PRIORITY_QUEUE_ITEMS, MAX_ITEM_SIZE));
+    bool backpointers_allocated = ensure_priority_queue_has_allocated_members(&queue);
+
+    /* Assume the function preconditions */
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+    size_t root;
+    __CPROVER_assume(root < queue.container.length);
+
+    if (backpointers_allocated) {
+        /* Ensuring that just the root cell is correctly allocated is
+         * not enough, as the swap requires that both the swapped
+         * cells are correctly allocated.  Therefore, if swap is to
+         * not be overriden, I have to ensure that all of the root
+         * descendants at least are correctly allocated. For now it is
+         * ensured that all of them are. */
+        size_t i;
+        for (i = 0; i < queue.container.length; i++) {
+            ((struct aws_priority_queue_node **)queue.backpointers.data)[i] =
+                can_fail_malloc(sizeof(struct aws_priority_queue_node));
+        }
+    }
+
+    /* Perform operation under verification */
+    __CPROVER_file_local_priority_queue_c_s_sift_either(&queue, root);
+
+    /* Assert the postconditions */
+    assert(aws_priority_queue_is_valid(&queue));
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_either/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_priority_queue_c_s_sift_down.0:3,__CPROVER_file_local_priority_queue_c_s_sift_up.0:3,aws_priority_queue_s_sift_either_harness.0:6;--object-bits;8"
+goto: aws_priority_queue_s_sift_either_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/Makefile
@@ -23,13 +23,11 @@ include ../Makefile.aws_priority_queue_sift
 
 
 # Note:
-# In order to reach full coverage we have to unwind
-# log(NUMBER_PRIO_QUEUE_ITEMS) but this number is huge so we only
-# unwind a small number of times. However, this shouldn't be a problem
-# for checking memory safety and overflows as the index of the element
-# to be sifted down is left unconstrained.
-UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_up.0:$(MAX_HEAP_HEIGHT)
+# In order to reach full coverage we need to unwind the harness loop
+# as many times as the number of queue items, and the sift down loop
+# log(NUMBER_PRIO_QUEUE_ITEMS) times.
 UNWINDSET += aws_priority_queue_s_sift_up_harness.0:$(shell echo $$((1 + $(MAX_PRIORITY_QUEUE_ITEMS))))
+UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_up.0:$(MAX_HEAP_HEIGHT)
 
 CBMCFLAGS += 
 

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/Makefile
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+include ../Makefile.aws_priority_queue_sift
+
+###########
+#
+# Runtime:
+# - 300s for MAX_PRIORITY_QUEUE_ITEMS=3 items
+# - 450s for MAX_PRIORITY_QUEUE_ITEMS=5 items 
+
+
+# Note:
+# In order to reach full coverage we have to unwind
+# log(NUMBER_PRIO_QUEUE_ITEMS) but this number is huge so we only
+# unwind a small number of times. However, this shouldn't be a problem
+# for checking memory safety and overflows as the index of the element
+# to be sifted down is left unconstrained.
+UNWINDSET += __CPROVER_file_local_priority_queue_c_s_sift_up.0:$(MAX_HEAP_HEIGHT)
+UNWINDSET += aws_priority_queue_s_sift_up_harness.0:$(shell echo $$((1 + $(MAX_PRIORITY_QUEUE_ITEMS))))
+
+CBMCFLAGS += 
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcpy_override_no_op.c
+DEPENDENCIES += $(SRCDIR)/source/array_list.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+DEPENDENCIES += $(SRCDIR)/source/priority_queue.c
+
+
+ENTRY = aws_priority_queue_s_sift_up_harness
+###########
+
+include ../Makefile.common
+

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/aws_priority_queue_s_sift_up_harness.c
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/aws_priority_queue_s_sift_up_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/priority_queue.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void __CPROVER_file_local_priority_queue_c_s_sift_up(struct aws_priority_queue *queue, size_t root);
+
+void aws_priority_queue_s_sift_up_harness() {
+    /* Data structure */
+    struct aws_priority_queue queue;
+
+    /* Assumptions */
+    __CPROVER_assume(aws_priority_queue_is_bounded(&queue, MAX_PRIORITY_QUEUE_ITEMS, MAX_ITEM_SIZE));
+    bool backpointers_allocated = ensure_priority_queue_has_allocated_members(&queue);
+
+    /* Assume the function preconditions */
+    __CPROVER_assume(aws_priority_queue_is_valid(&queue));
+    size_t root;
+    __CPROVER_assume(root < queue.container.length);
+
+    if (backpointers_allocated) {
+        /* Ensuring that just the root cell is correctly allocated is
+         * not enough, as the swap requires that both the swapped
+         * cells are correctly allocated.  Therefore, if swap is to
+         * not be overriden, I have to ensure that all of the root
+         * descendants at least are correctly allocated. For now it is
+         * ensured that all of them are. */
+        size_t i;
+        for (i = 0; i < queue.container.length; i++) {
+            ((struct aws_priority_queue_node **)queue.backpointers.data)[i] =
+                can_fail_malloc(sizeof(struct aws_priority_queue_node));
+        }
+    }
+
+    /* Perform operation under verification */
+    __CPROVER_file_local_priority_queue_c_s_sift_up(&queue, root);
+
+    /* Assert the postconditions */
+    assert(aws_priority_queue_is_valid(&queue));
+}

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_priority_queue_c_s_sift_up.0:3,aws_priority_queue_s_sift_up_harness.0:6;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_priority_queue_s_sift_up_harness.0:6,__CPROVER_file_local_priority_queue_c_s_sift_up.0:3;--object-bits;8"
 goto: aws_priority_queue_s_sift_up_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_priority_queue_s_sift_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_priority_queue_c_s_sift_up.0:3,aws_priority_queue_s_sift_up_harness.0:6;--object-bits;8"
+goto: aws_priority_queue_s_sift_up_harness.goto
+expected: "SUCCESSFUL"

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -25,7 +25,7 @@ static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
     AWS_PRECONDITION(a < queue->container.length);
     AWS_PRECONDITION(b < queue->container.length);
-    
+
     aws_array_list_swap(&queue->container, a, b);
 
     /* Invariant: If the backpointer array is initialized, we have enough room for all elements */

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -61,7 +61,6 @@ static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
 
     size_t len = aws_array_list_length(&queue->container);
 
-    /* Note: There is an unwinding loop assertion here. */
     while (LEFT_OF(root) < len) {
         size_t left = LEFT_OF(root);
         size_t right = RIGHT_OF(root);
@@ -88,9 +87,6 @@ static bool s_sift_down(struct aws_priority_queue *queue, size_t root) {
         }
 
         if (first != root) {
-            /* Note: If swap is called, we have to make sure that the
-             * backpointer cells are correctly allocated for cell, and
-             * thus for the whole array. */
             s_swap(queue, first, root);
             did_move = true;
             root = first;

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -25,7 +25,7 @@ static void s_swap(struct aws_priority_queue *queue, size_t a, size_t b) {
     AWS_PRECONDITION(aws_priority_queue_is_valid(queue));
     AWS_PRECONDITION(a < queue->container.length);
     AWS_PRECONDITION(b < queue->container.length);
-
+    
     aws_array_list_swap(&queue->container, a, b);
 
     /* Invariant: If the backpointer array is initialized, we have enough room for all elements */

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -174,7 +174,7 @@ bool aws_priority_queue_is_valid(const struct aws_priority_queue *const queue) {
     bool backpointer_list_is_valid = aws_array_list_is_valid(&queue->backpointers);
 
     /* Backpointer struct should either be zero or should be
-     * initialized to be the same length as the container, and having
+     * initialized to be at most as long as the container, and having
      * as elements potentially null pointers to
      * aws_priority_queue_nodes */
     bool backpointer_list_item_size = queue->backpointers.item_size == sizeof(struct aws_priority_queue_node *);

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -158,8 +158,8 @@ int aws_priority_queue_init_dynamic(
     queue->pred = pred;
     AWS_ZERO_STRUCT(queue->backpointers);
 
-    bool ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
-    if (!ret) {
+    int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
+    if (ret == AWS_OP_SUCCESS) {
         AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
     }
     return ret;

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -174,7 +174,7 @@ bool aws_priority_queue_is_valid(const struct aws_priority_queue *const queue) {
     bool backpointer_list_is_valid = aws_array_list_is_valid(&queue->backpointers);
 
     /* Backpointer struct should either be zero or should be
-     * initialized to be at most as long as the container, and having
+     * initialized to be the same length as the container, and having
      * as elements potentially null pointers to
      * aws_priority_queue_nodes */
     bool backpointer_list_item_size = queue->backpointers.item_size == sizeof(struct aws_priority_queue_node *);


### PR DESCRIPTION
Implement a first working harness for `sift_down`, `sift_up`, and `sift_either`. For now the priority queue size is bounded by a very small number due to unwinding complicating the proof.

Depends on: #377 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
