### PR TITLE
Adds proof harnesses for aws_byte_cursor_read* functions

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_cursor_read/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/Makefile
@@ -14,7 +14,7 @@
 ###########
 include ../Makefile.aws_byte_buf
 
-UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET +=
 
 CBMCFLAGS +=
 
@@ -22,7 +22,6 @@ DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
 DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 

--- a/.cbmc-batch/jobs/aws_byte_cursor_read/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_read_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -37,7 +37,7 @@ void aws_byte_cursor_read_harness() {
 
     /* operation under verification */
     if (aws_byte_cursor_read(&cur, dest, length)) {
-        /* assert_bytes_match(old_cur.ptr, dest, length); */
+        assert_bytes_match(old_cur.ptr, dest, length);
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_read_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+    size_t length;
+    void* dest = can_fail_malloc(length);
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cur = cur;
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+    // struct aws_byte_cursor old_rhs = rhs;
+    // struct store_byte_from_buffer old_byte_from_rhs;
+    // save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
+
+    /* operation under verification */
+    if (aws_byte_cursor_read((nondet_bool() ? &cur : NULL), dest, length)) {
+        /*assert(lhs.len == rhs.len);
+        if (lhs.len > 0) {
+            assert_bytes_match(lhs.ptr, rhs.ptr, lhs.len);
+        }*/
+    }
+
+    /* assertions */
+    /*assert(aws_byte_cursor_is_valid(&lhs));
+    assert(aws_byte_cursor_is_valid(&rhs));
+    if (lhs.len != 0) {
+        assert_byte_from_buffer_matches(lhs.ptr, &old_byte_from_lhs);
+    }
+    if (rhs.len != 0) {
+        assert_byte_from_buffer_matches(rhs.ptr, &old_byte_from_rhs);
+    }*/
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -21,11 +21,14 @@ void aws_byte_cursor_read_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
     size_t length;
-    void *dest = can_fail_malloc(length);
+    void *dest = bounded_malloc(length);
 
     /* assumptions */
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* precondition */
+    __CPROVER_assume(AWS_MEM_IS_WRITABLE(dest, length));
 
     /* save current state of the data structure */
     struct aws_byte_cursor old_cur = cur;
@@ -33,8 +36,8 @@ void aws_byte_cursor_read_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    if (aws_byte_cursor_read((nondet_bool() ? &cur : NULL), dest, length)) {
-        assert_bytes_match(old_cur.ptr, (uint8_t *)dest, length);
+    if (aws_byte_cursor_read(&cur, dest, length)) {
+        /* assert_bytes_match(old_cur.ptr, dest, length); */
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_read/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:11;--object-bits;8"
+goto: aws_byte_cursor_eq_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_read/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:11;--object-bits;8"
-goto: aws_byte_cursor_eq_harness.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_read_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_read_and_fill_buffer_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -39,7 +39,7 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
     /* operation under verification */
     if (aws_byte_cursor_read_and_fill_buffer(&cur, &buf)) {
         assert(buf.len == buf.capacity);
-        /* assert_bytes_match(old_cur.ptr, buf.buffer, buf.capacity); */
+        assert_bytes_match(old_cur.ptr, buf.buffer, buf.capacity);
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -37,9 +37,9 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
 
     /* operation under verification */
-    if (aws_byte_cursor_read_and_fill_buffer((nondet_bool() ? &cur : NULL), (nondet_bool() ? &buf : NULL))) {
+    if (aws_byte_cursor_read_and_fill_buffer(&cur, &buf)) {
         assert(buf.len == buf.capacity);
-        assert_bytes_match(old_cur.ptr, buf.buffer, buf.capacity);
+        /* assert_bytes_match(old_cur.ptr, buf.buffer, buf.capacity); */
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -32,8 +32,6 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
     struct aws_byte_cursor old_cur = cur;
     struct store_byte_from_buffer old_byte_from_cur;
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
-
-    /* save current state of the data structure */
     struct aws_byte_buf old_buf = buf;
     struct store_byte_from_buffer old_byte_from_buf;
     save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_read_and_fill_buffer_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+    struct aws_byte_buf buf;
+
+    /* assumptions */
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cur = cur;
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old_buf = buf;
+    struct store_byte_from_buffer old_byte_from_buf;
+    save_byte_from_array(buf.buffer, buf.len, &old_byte_from_buf);
+
+    /* operation under verification */
+    if (aws_byte_cursor_read_and_fill_buffer((nondet_bool() ? &cur : NULL), (nondet_bool() ? &buf : NULL))) {
+        assert(buf.len == buf.capacity);
+        assert_bytes_match(old_cur.ptr, buf.buffer, buf.capacity);
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    assert(aws_byte_buf_is_valid(&buf));
+    assert(old_buf.allocator == buf.allocator);
+    /* the following assertions are included, because aws_byte_cursor_read internally uses
+     * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
+     */
+    if (old_cur.len > (SIZE_MAX >> 1) || old_buf.capacity > (SIZE_MAX >> 1) || old_buf.capacity > old_cur.len) {
+        if (old_cur.len != 0) {
+            assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
+        }
+    } else {
+        assert(cur.ptr == old_cur.ptr + old_buf.capacity);
+        assert(cur.len == old_cur.len - old_buf.capacity);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_and_fill_buffer/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_read_and_fill_buffer_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_u8/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_u8/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_read_u8_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
@@ -21,11 +21,14 @@ void aws_byte_cursor_read_u8_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
     size_t length;
-    uint8_t *dest = can_fail_malloc(length);
+    uint8_t *dest = bounded_malloc(length);
 
     /* assumptions */
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* precondition */
+    __CPROVER_assume(AWS_MEM_IS_WRITABLE(dest, 1));
 
     /* save current state of the data structure */
     struct aws_byte_cursor old_cur = cur;
@@ -33,8 +36,8 @@ void aws_byte_cursor_read_u8_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    if (aws_byte_cursor_read_u8((nondet_bool() ? &cur : NULL), dest)) {
-        assert_bytes_match(old_cur.ptr, (uint8_t *)dest, 1);
+    if (aws_byte_cursor_read_u8(&cur, dest)) {
+        /* assert_bytes_match(old_cur.ptr, dest, 1); */
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_read_u8_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+    size_t length;
+    uint8_t *dest = can_fail_malloc(length);
+
+    /* assumptions */
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cur = cur;
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+
+    /* operation under verification */
+    if (aws_byte_cursor_read_u8((nondet_bool() ? &cur : NULL), dest)) {
+        assert_bytes_match(old_cur.ptr, (uint8_t *)dest, 1);
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    /* the following assertions are included, because aws_byte_cursor_read internally uses
+     * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
+     */
+    if (old_cur.len < (SIZE_MAX >> 1) && old_cur.len > 1) {
+        assert(cur.ptr == old_cur.ptr + 1);
+        assert(cur.len == old_cur.len - 1);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_u8/aws_byte_cursor_read_u8_harness.c
@@ -37,7 +37,7 @@ void aws_byte_cursor_read_u8_harness() {
 
     /* operation under verification */
     if (aws_byte_cursor_read_u8(&cur, dest)) {
-        /* assert_bytes_match(old_cur.ptr, dest, 1); */
+        assert_bytes_match(old_cur.ptr, dest, 1);
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_u8/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_u8/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_read_u8_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -689,8 +689,8 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read(
-    struct aws_byte_cursor *AWS_RESTRICT cur,
-    void *AWS_RESTRICT dest,
+    struct aws_byte_cursor *const AWS_RESTRICT cur,
+    void *const AWS_RESTRICT dest,
     size_t len) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
     AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(dest, len));
@@ -730,8 +730,11 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRICT cur, uint8_t *AWS_RESTRICT var) {
-    return aws_byte_cursor_read(cur, var, 1);
+AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *const AWS_RESTRICT cur, uint8_t *const AWS_RESTRICT var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    bool rv = aws_byte_cursor_read(cur, var, 1);
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
 }
 
 /**

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -692,12 +692,17 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read(
     struct aws_byte_cursor *AWS_RESTRICT cur,
     void *AWS_RESTRICT dest,
     size_t len) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(dest, len));
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
 
     if (slice.ptr) {
         memcpy(dest, slice.ptr, len);
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+        AWS_POSTCONDITION(AWS_MEM_IS_READABLE(dest, len));
         return true;
     }
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
     return false;
 }
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -730,7 +730,9 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *const AWS_RESTRICT cur, uint8_t *const AWS_RESTRICT var) {
+AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(
+    struct aws_byte_cursor *const AWS_RESTRICT cur,
+    uint8_t *const AWS_RESTRICT var) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
     bool rv = aws_byte_cursor_read(cur, var, 1);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -689,9 +689,9 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read(
-    struct aws_byte_cursor *const AWS_RESTRICT cur,
-    void *const AWS_RESTRICT dest,
-    size_t len) {
+    struct aws_byte_cursor *AWS_RESTRICT cur,
+    void *AWS_RESTRICT dest,
+    const size_t len) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
     AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(dest, len));
     struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
@@ -714,8 +714,8 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read(
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
-    struct aws_byte_cursor *const AWS_RESTRICT cur,
-    struct aws_byte_buf *const AWS_RESTRICT dest) {
+    struct aws_byte_cursor *AWS_RESTRICT cur,
+    struct aws_byte_buf *AWS_RESTRICT dest) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
     AWS_PRECONDITION(aws_byte_buf_is_valid(dest));
     if (aws_byte_cursor_read(cur, dest->buffer, dest->capacity)) {
@@ -736,9 +736,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(
-    struct aws_byte_cursor *const AWS_RESTRICT cur,
-    uint8_t *const AWS_RESTRICT var) {
+AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRICT cur, uint8_t *AWS_RESTRICT var) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
     bool rv = aws_byte_cursor_read(cur, var, 1);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -714,12 +714,18 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read(
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
-    struct aws_byte_cursor *AWS_RESTRICT cur,
-    struct aws_byte_buf *AWS_RESTRICT dest) {
+    struct aws_byte_cursor *const AWS_RESTRICT cur,
+    struct aws_byte_buf *const AWS_RESTRICT dest) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(dest));
     if (aws_byte_cursor_read(cur, dest->buffer, dest->capacity)) {
         dest->len = dest->capacity;
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
         return true;
     }
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
     return false;
 }
 


### PR DESCRIPTION
*Description of changes:*
1. Updates implementation of `aws_byte_cursor_read*` functions with pre- and post-conditions;
2. Adds proof harnesses for `aws_byte_cursor_read*` functions;

This PR depends on https://github.com/awslabs/aws-c-common/pull/385

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
