### PR TITLE
Implement aws_ntoh24 and aws_hton24

### DIFF
--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -85,6 +85,44 @@ AWS_STATIC_IMPL uint32_t aws_ntoh32(uint32_t x) {
 }
 
 /**
+ * Convert 24 bit integer from host to network byte order.
+ */
+AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
+    AWS_PRECONDITION(x < (UINT32_MAX >> 8));
+    if (aws_is_big_endian()) {
+        return x;
+    } else {
+        uint32_t result = 0;
+        uint8_t *result_ptr = (uint8_t *)&result;
+
+        *result_ptr++ = (x >> 16) & 0xFF;
+        *result_ptr++ = (x >> 8) & 0xFF;
+        *result_ptr++ = (x >> 0) & 0xFF;
+
+        return result;
+    }
+}
+
+/**
+ * Convert 24 bit integer from network to host byte order.
+ */
+AWS_STATIC_IMPL uint32_t aws_ntoh24(uint32_t x) {
+    AWS_PRECONDITION(x < (UINT32_MAX >> 8));
+    if (aws_is_big_endian()) {
+        return x;
+    } else {
+        uint32_t result = 0;
+        uint8_t *result_ptr = (uint8_t *)&result;
+
+        *result_ptr++ = (x >> 16) & 0xFF;
+        *result_ptr++ = (x >> 8) & 0xFF;
+        *result_ptr++ = (x >> 0) & 0xFF;
+
+        return result;
+    }
+}
+
+/**
  * Convert 16 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint16_t aws_hton16(uint16_t x) {

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -88,18 +88,11 @@ AWS_STATIC_IMPL uint32_t aws_ntoh32(uint32_t x) {
  * Convert 24 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
-    AWS_PRECONDITION(x < (UINT32_MAX >> 8));
+    AWS_PRECONDITION(x <= 0xFFFFFF);
     if (aws_is_big_endian()) {
         return x;
     } else {
-        uint32_t result = 0;
-        uint8_t *result_ptr = (uint8_t *)&result;
-
-        *result_ptr++ = (x >> 16) & 0xFF;
-        *result_ptr++ = (x >> 8) & 0xFF;
-        *result_ptr++ = (x >> 0) & 0xFF;
-
-        return result;
+        return aws_hton32(x) >> 8;
     }
 }
 
@@ -107,18 +100,11 @@ AWS_STATIC_IMPL uint32_t aws_hton24(uint32_t x) {
  * Convert 24 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_ntoh24(uint32_t x) {
-    AWS_PRECONDITION(x < (UINT32_MAX >> 8));
+    AWS_PRECONDITION((x) <= 0xFFFFFFF);
     if (aws_is_big_endian()) {
         return x;
     } else {
-        uint32_t result = 0;
-        uint8_t *result_ptr = (uint8_t *)&result;
-
-        *result_ptr++ = (x >> 16) & 0xFF;
-        *result_ptr++ = (x >> 8) & 0xFF;
-        *result_ptr++ = (x >> 0) & 0xFF;
-
-        return result;
+        return aws_ntoh32(x) >> 8;
     }
 }
 

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -23,19 +23,23 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
 
     uint64_t ans_x = 0x1122334455667788ULL;
     uint32_t ans_y = 0xaabbccdd;
-    uint16_t ans_z = 0xeeff;
+    uint32_t ans_z = 0xaabbcc;
+    uint16_t ans_w = 0xeeff;
 
     uint8_t x[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
     uint8_t y[] = {0xaa, 0xbb, 0xcc, 0xdd};
-    uint8_t z[] = {0xee, 0xff};
+    uint8_t z[] = {0xaa, 0xbb, 0xcc};
+    uint8_t w[] = {0xee, 0xff};
 
     uint64_t x64;
     uint32_t y32;
-    uint16_t z16;
+    uint32_t z24;
+    uint16_t w16;
 
-    memcpy(&x64, x, sizeof(x64));
-    memcpy(&y32, y, sizeof(y32));
-    memcpy(&z16, z, sizeof(z16));
+    memcpy(&x64, x, sizeof(x));
+    memcpy(&y32, y, sizeof(y));
+    memcpy(&z24, z, sizeof(z));
+    memcpy(&w16, w, sizeof(w));
 
     ASSERT_UINT_EQUALS(aws_ntoh64(x64), ans_x);
     ASSERT_UINT_EQUALS(aws_hton64(x64), ans_x);
@@ -43,8 +47,11 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_UINT_EQUALS(aws_ntoh32(y32), ans_y);
     ASSERT_UINT_EQUALS(aws_hton32(y32), ans_y);
 
-    ASSERT_UINT_EQUALS(aws_ntoh16(z16), ans_z);
-    ASSERT_UINT_EQUALS(aws_hton16(z16), ans_z);
+    ASSERT_UINT_EQUALS(aws_ntoh24(z24), ans_z);
+    ASSERT_UINT_EQUALS(aws_hton24(z24), ans_z);
+
+    ASSERT_UINT_EQUALS(aws_ntoh16(w16), ans_w);
+    ASSERT_UINT_EQUALS(aws_hton16(w16), ans_w);
 
     return 0;
 }

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -28,7 +28,7 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
 
     uint8_t x[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
     uint8_t y[] = {0xaa, 0xbb, 0xcc, 0xdd};
-    uint8_t z[] = {0xaa, 0xbb, 0xcc};
+    uint8_t z[] = {0x00, 0xaa, 0xbb, 0xcc}; /* Leading 0 needed avoid buffer overflows */
     uint8_t w[] = {0xee, 0xff};
 
     uint64_t x64;
@@ -41,6 +41,8 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
     memcpy(&z24, z, sizeof(z));
     memcpy(&w16, w, sizeof(w));
 
+    z24 >>= 8; /* Throw away the fake byte */
+
     ASSERT_UINT_EQUALS(aws_ntoh64(x64), ans_x);
     ASSERT_UINT_EQUALS(aws_hton64(x64), ans_x);
 
@@ -49,6 +51,9 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_UINT_EQUALS(aws_ntoh24(z24), ans_z);
     ASSERT_UINT_EQUALS(aws_hton24(z24), ans_z);
+    /* Make sure top byte is untouched */
+    ASSERT_UINT_EQUALS(aws_ntoh24(z24) & 0xFF000000, 0);
+    ASSERT_UINT_EQUALS(aws_hton24(z24) & 0xFF000000, 0);
 
     ASSERT_UINT_EQUALS(aws_ntoh16(w16), ans_w);
     ASSERT_UINT_EQUALS(aws_hton16(w16), ans_w);


### PR DESCRIPTION
HTTP/2 stores frame length as a 24 bit integer, so here we are.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
