### PR TITLE
alter code so it can compile in c++ as well

### DIFF
--- a/include/aws/common/assert.inl
+++ b/include/aws/common/assert.inl
@@ -32,13 +32,31 @@ void aws_backtrace_print(FILE *fp, void *call_site_data);
 AWS_EXTERN_C_END
 
 #if defined(CBMC)
-#   include <assert.h>
+#    define AWS_FATAL_ASSERT(cond)                                                                                     \
+        if (!(cond)) {                                                                                                 \
+            abort();                                                                                                   \
+        }
+#else
+#    if defined(_MSC_VER)
+#        define AWS_FATAL_ASSERT(cond)                                                                                 \
+            __pragma(warning(push)) __pragma(warning(disable : 4127)) /* conditional expression is constant */         \
+                if (!(cond)) {                                                                                         \
+                aws_fatal_assert(#cond, __FILE__, __LINE__);                                                           \
+            }                                                                                                          \
+            __pragma(warning(pop))
+#    else
+#        define AWS_FATAL_ASSERT(cond)                                                                                 \
+            if (!(cond)) {                                                                                             \
+                aws_fatal_assert(#cond, __FILE__, __LINE__);                                                           \
+            }
+#    endif
+#endif
+
+#if defined(CBMC)
+#    include <assert.h>
 #    define AWS_ASSERT(cond) assert(cond)
 #elif defined(DEBUG_BUILD)
-#    define AWS_ASSERT(cond)                                                                                           \
-        if (!(cond)) {                                                                                                 \
-            aws_fatal_assert(#cond, __FILE__, __LINE__);                                                               \
-        }
+#    define AWS_ASSERT(cond) AWS_FATAL_ASSERT(cond)
 #else
 #    define AWS_ASSERT(cond)
 #endif
@@ -46,15 +64,3 @@ AWS_EXTERN_C_END
 #define AWS_STATIC_ASSERT0(cond, msg) typedef char AWS_CONCAT(static_assertion_, msg)[(!!(cond)) * 2 - 1]
 #define AWS_STATIC_ASSERT1(cond, line) AWS_STATIC_ASSERT0(cond, AWS_CONCAT(at_line_, line))
 #define AWS_STATIC_ASSERT(cond) AWS_STATIC_ASSERT1(cond, __LINE__)
-
-#if defined(CBMC)
-#    define AWS_FATAL_ASSERT(cond)                                                                                     \
-        if (!(cond)) {                                                                                                 \
-            abort();                                                                                                   \
-        }
-#else
-#define AWS_FATAL_ASSERT(cond)                                                                                         \
-    if (!(cond)) {                                                                                                     \
-        aws_fatal_assert(#cond, __FILE__, __LINE__);                                                                   \
-    }
-#endif

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -451,11 +451,11 @@ static inline int enable_vt_mode(void) {
         AWS_MUTEX_INIT,                                                                                                \
     };                                                                                                                 \
     static struct aws_allocator name##_allocator = {                                                                   \
-        .mem_acquire = s_mem_acquire_malloc,                                                                           \
-        .mem_release = s_mem_release_free,                                                                             \
-        .mem_realloc = NULL,                                                                                           \
-        .mem_calloc = NULL,                                                                                            \
-        .impl = &name##_alloc_impl,                                                                                    \
+        s_mem_acquire_malloc,                                                                                          \
+        s_mem_release_free,                                                                                            \
+        NULL,                                                                                                          \
+        NULL,                                                                                                          \
+        &name##_alloc_impl,                                                                                            \
     };
 
 #define AWS_TEST_CASE_SUPRESSION(name, fn, s)                                                                          \


### PR DESCRIPTION
This header is used by aws-crt-cpp, and needs to compile in c++ as well


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
