### PR TITLE
Extend the preconditions of array list function to catch NULL pointers

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
@@ -35,7 +35,9 @@ void aws_array_list_back_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification */
-    uint8_t *val = bounded_malloc(list.item_size);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
     if (aws_array_list_back(&list, val) == AWS_OP_SUCCESS) {
         /* In the case aws_array_list_back is successful, we can ensure the list isn't empty */
         assert(list.data != NULL);

--- a/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_back/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--object-bits;8"
 goto: aws_array_list_back_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
@@ -34,7 +34,9 @@ void aws_array_list_front_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification */
-    void *val = malloc(list.item_size);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
     if (!aws_array_list_front(&list, val)) {
         /* In the case aws_array_list_front is successful, we can ensure the list isn't empty */
         assert(list.data);

--- a/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_front/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--object-bits;8"
 goto: aws_array_list_front_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
@@ -34,7 +34,9 @@ void aws_array_list_get_at_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification */
-    void *val = malloc(list.item_size);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
     size_t index;
     if (!aws_array_list_get_at(&list, val, index)) {
         /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty

--- a/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--object-bits;8"
 goto: aws_array_list_get_at_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
@@ -34,9 +34,9 @@ void aws_array_list_get_at_ptr_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification */
-    void *val = malloc(list.item_size);
+    void **val = can_fail_malloc(sizeof(void *));
     size_t index;
-    if (!aws_array_list_get_at_ptr(&list, &val, index)) {
+    if (!aws_array_list_get_at_ptr(&list, val, index)) {
         /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
          * and index is within bounds.
          */

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--unwind;1"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcpy_impl.0:3;--object-bits;8"
 goto: aws_array_list_get_at_ptr_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_push_back/aws_array_list_push_back_harness.c
@@ -35,7 +35,9 @@ void aws_array_list_push_back_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification and assertions */
-    void *val = can_fail_malloc(list.item_size);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
     if (!aws_array_list_push_back(&list, val)) {
         assert(list.length == old.length + 1);
     } else {

--- a/.cbmc-batch/jobs/aws_array_list_set_at/aws_array_list_set_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/aws_array_list_set_at_harness.c
@@ -35,7 +35,9 @@ void aws_array_list_set_at_harness() {
     save_byte_from_array((uint8_t *)list.data, list.current_size, &old_byte);
 
     /* perform operation under verification and assertions */
-    void *val = can_fail_malloc(list.item_size);
+    size_t malloc_size;
+    __CPROVER_assume(malloc_size <= list.item_size);
+    void *val = can_fail_malloc(malloc_size);
     size_t index;
     if (!aws_array_list_set_at(&list, val, index)) {
         if (index > old.length)

--- a/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_array_list_set_at/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--div-by-zero-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--undefined-shift-check;--float-overflow-check;--nan-check;--unwinding-assertions;--unwind;1"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_array_list_set_at_harness.goto
 expected: "SUCCESSFUL"

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -107,7 +107,7 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val);
+    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size));
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
     if (err_code && aws_last_error() == AWS_ERROR_INVALID_INDEX && !list->alloc) {
@@ -122,6 +122,7 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size));
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -170,6 +171,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size));
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -256,6 +258,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size));
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -268,6 +271,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
+    AWS_PRECONDITION(val);
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -297,7 +301,7 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val);
+    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size));
     
     if (aws_array_list_ensure_capacity(list, index)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));


### PR DESCRIPTION
Extend the preconditions of array list function to catch NULL and badly allocated source/destination pointers in memcpy operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
