### PR TITLE
Adds proof harnesses for aws_byte_cursor_*_pred functions

### DIFF
--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -134,3 +134,8 @@ uint64_t nondet_hasher(const void *a);
  * Standard stub function to hash one item.
  */
 uint64_t uninterpreted_hasher(const void *a);
+
+/**
+ * Standard stub function of a predicate
+ */
+bool predicate_fn(uint8_t value);

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -138,4 +138,4 @@ uint64_t uninterpreted_hasher(const void *a);
 /**
  * Standard stub function of a predicate
  */
-bool __CPROVER_uninterpreted_predicate_fn(uint8_t value);
+bool uninterpreted_predicate_fn(uint8_t value);

--- a/.cbmc-batch/include/proof_helpers/utils.h
+++ b/.cbmc-batch/include/proof_helpers/utils.h
@@ -138,4 +138,4 @@ uint64_t uninterpreted_hasher(const void *a);
 /**
  * Standard stub function of a predicate
  */
-bool predicate_fn(uint8_t value);
+bool __CPROVER_uninterpreted_predicate_fn(uint8_t value);

--- a/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_byte_cursor_left_trim_pred.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_left_trim_pred_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
@@ -31,8 +31,7 @@ void aws_byte_cursor_left_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv = aws_byte_cursor_left_trim_pred(
-        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_left_trim_pred(&cur, uninterpreted_predicate_fn);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
@@ -17,7 +17,7 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
-void aws_byte_cursor_trim_pred_harness() {
+void aws_byte_cursor_left_trim_pred_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
 
@@ -31,7 +31,7 @@ void aws_byte_cursor_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv = aws_byte_cursor_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_left_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/aws_byte_cursor_left_trim_pred_harness.c
@@ -31,8 +31,8 @@ void aws_byte_cursor_left_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv =
-        aws_byte_cursor_left_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_left_trim_pred(
+        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_left_trim_pred/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_byte_cursor_left_trim_pred.0:11;--object-bits;8"
+goto: aws_byte_cursor_left_trim_pred_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_byte_cursor_right_trim_pred.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_right_trim_pred_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
@@ -31,8 +31,8 @@ void aws_byte_cursor_right_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv =
-        aws_byte_cursor_right_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_right_trim_pred(
+        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
@@ -17,7 +17,7 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
-void aws_byte_cursor_left_trim_pred_harness() {
+void aws_byte_cursor_right_trim_pred_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
 
@@ -32,7 +32,7 @@ void aws_byte_cursor_left_trim_pred_harness() {
 
     /* operation under verification */
     struct aws_byte_cursor rv =
-        aws_byte_cursor_left_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+        aws_byte_cursor_right_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/aws_byte_cursor_right_trim_pred_harness.c
@@ -31,8 +31,7 @@ void aws_byte_cursor_right_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv = aws_byte_cursor_right_trim_pred(
-        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_right_trim_pred(&cur, uninterpreted_predicate_fn);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_right_trim_pred/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_byte_cursor_right_trim_pred.0:11;--object-bits;8"
+goto: aws_byte_cursor_right_trim_pred_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_byte_cursor_left_trim_pred.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_satisfies_pred_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
@@ -31,8 +31,7 @@ void aws_byte_cursor_satisfies_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    aws_byte_cursor_satisfies_pred(
-        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
+    aws_byte_cursor_satisfies_pred(&cur, uninterpreted_predicate_fn);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
@@ -31,7 +31,8 @@ void aws_byte_cursor_satisfies_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    aws_byte_cursor_satisfies_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+    aws_byte_cursor_satisfies_pred(
+        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/aws_byte_cursor_satisfies_pred_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_satisfies_pred_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* save current state of the data structure */
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+
+    /* operation under verification */
+    aws_byte_cursor_satisfies_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    if (cur.len > 0) {
+        assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_satisfies_pred/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_byte_cursor_left_trim_pred.0:11;--object-bits;8"
+goto: aws_byte_cursor_satisfies_pred_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_byte_cursor_left_trim_pred.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+UNWINDSET += aws_byte_cursor_right_trim_pred.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_trim_pred_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
@@ -31,7 +31,8 @@ void aws_byte_cursor_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv = aws_byte_cursor_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+    struct aws_byte_cursor rv =
+        aws_byte_cursor_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_trim_pred_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* save current state of the data structure */
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+
+    /* operation under verification */
+    aws_byte_cursor_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    if (cur.len > 0) {
+        assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
@@ -31,8 +31,8 @@ void aws_byte_cursor_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv =
-        aws_byte_cursor_trim_pred(nondet_bool() ? &cur : NULL, nondet_bool() ? predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_trim_pred(
+        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/aws_byte_cursor_trim_pred_harness.c
@@ -31,8 +31,7 @@ void aws_byte_cursor_trim_pred_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    struct aws_byte_cursor rv = aws_byte_cursor_trim_pred(
-        nondet_bool() ? &cur : NULL, nondet_bool() ? __CPROVER_uninterpreted_predicate_fn : NULL);
+    struct aws_byte_cursor rv = aws_byte_cursor_trim_pred(&cur, uninterpreted_predicate_fn);
 
     /* assertions */
     assert(aws_byte_cursor_is_valid(&cur));

--- a/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_trim_pred/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_byte_cursor_left_trim_pred.0:11,aws_byte_cursor_right_trim_pred.0:11;--object-bits;8"
+goto: aws_byte_cursor_trim_pred_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -179,3 +179,7 @@ uint64_t uninterpreted_hasher(const void *a) {
     assert(a != NULL);
     return __CPROVER_uninterpreted_hasher(a);
 }
+
+bool predicate_fn(uint8_t value) {
+    return nondet_bool();
+}

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -180,4 +180,4 @@ uint64_t uninterpreted_hasher(const void *a) {
     return __CPROVER_uninterpreted_hasher(a);
 }
 
-bool __CPROVER_uninterpreted_predicate_fn(uint8_t value);
+bool uninterpreted_predicate_fn(uint8_t value);

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -180,6 +180,4 @@ uint64_t uninterpreted_hasher(const void *a) {
     return __CPROVER_uninterpreted_hasher(a);
 }
 
-bool predicate_fn(uint8_t value) {
-    return nondet_bool();
-}
+bool __CPROVER_uninterpreted_predicate_fn(uint8_t value);

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -685,8 +685,9 @@ struct aws_byte_cursor aws_byte_cursor_trim_pred(
 
 bool aws_byte_cursor_satisfies_pred(const struct aws_byte_cursor *source, aws_byte_predicate_fn *predicate) {
     struct aws_byte_cursor trimmed = aws_byte_cursor_left_trim_pred(source, predicate);
-
-    return trimmed.len == 0;
+    bool rval = (trimmed.len == 0);
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(source));
+    return rval;
 }
 
 int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const struct aws_byte_cursor *rhs) {

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -652,35 +652,46 @@ int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional
 }
 
 struct aws_byte_cursor aws_byte_cursor_right_trim_pred(
-    const struct aws_byte_cursor *source,
-    aws_byte_predicate_fn *predicate) {
+    const struct aws_byte_cursor *const source,
+    aws_byte_predicate_fn *const predicate) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
+    AWS_PRECONDITION(predicate != NULL);
     struct aws_byte_cursor trimmed = *source;
 
     while (trimmed.len > 0 && predicate(*(trimmed.ptr + trimmed.len - 1))) {
         --trimmed.len;
     }
-
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(source));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&trimmed));
     return trimmed;
 }
 
 struct aws_byte_cursor aws_byte_cursor_left_trim_pred(
-    const struct aws_byte_cursor *source,
-    aws_byte_predicate_fn *predicate) {
+    const struct aws_byte_cursor *const source,
+    aws_byte_predicate_fn *const predicate) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
+    AWS_PRECONDITION(predicate != NULL);
     struct aws_byte_cursor trimmed = *source;
 
     while (trimmed.len > 0 && predicate(*(trimmed.ptr))) {
         --trimmed.len;
         ++trimmed.ptr;
     }
-
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(source));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&trimmed));
     return trimmed;
 }
 
 struct aws_byte_cursor aws_byte_cursor_trim_pred(
-    const struct aws_byte_cursor *source,
-    aws_byte_predicate_fn *predicate) {
+    const struct aws_byte_cursor *const source,
+    aws_byte_predicate_fn *const predicate) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
+    AWS_PRECONDITION(predicate != NULL);
     struct aws_byte_cursor left_trimmed = aws_byte_cursor_left_trim_pred(source, predicate);
-    return aws_byte_cursor_right_trim_pred(&left_trimmed, predicate);
+    struct aws_byte_cursor dest = aws_byte_cursor_right_trim_pred(&left_trimmed, predicate);
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(source));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&dest));
+    return dest;
 }
 
 bool aws_byte_cursor_satisfies_pred(const struct aws_byte_cursor *source, aws_byte_predicate_fn *predicate) {

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -652,8 +652,8 @@ int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional
 }
 
 struct aws_byte_cursor aws_byte_cursor_right_trim_pred(
-    const struct aws_byte_cursor *const source,
-    aws_byte_predicate_fn *const predicate) {
+    const struct aws_byte_cursor *source,
+    aws_byte_predicate_fn *predicate) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
     AWS_PRECONDITION(predicate != NULL);
     struct aws_byte_cursor trimmed = *source;
@@ -667,8 +667,8 @@ struct aws_byte_cursor aws_byte_cursor_right_trim_pred(
 }
 
 struct aws_byte_cursor aws_byte_cursor_left_trim_pred(
-    const struct aws_byte_cursor *const source,
-    aws_byte_predicate_fn *const predicate) {
+    const struct aws_byte_cursor *source,
+    aws_byte_predicate_fn *predicate) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
     AWS_PRECONDITION(predicate != NULL);
     struct aws_byte_cursor trimmed = *source;
@@ -683,8 +683,8 @@ struct aws_byte_cursor aws_byte_cursor_left_trim_pred(
 }
 
 struct aws_byte_cursor aws_byte_cursor_trim_pred(
-    const struct aws_byte_cursor *const source,
-    aws_byte_predicate_fn *const predicate) {
+    const struct aws_byte_cursor *source,
+    aws_byte_predicate_fn *predicate) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
     AWS_PRECONDITION(predicate != NULL);
     struct aws_byte_cursor left_trimmed = aws_byte_cursor_left_trim_pred(source, predicate);


### PR DESCRIPTION
*Description of changes:*
1. Updates implementation of `aws_byte_cursor_*_pred` functions with pre- and post-conditions;
2. Adds proof harnesses for `aws_byte_cursor_*_pred` functions;
3. Adds `const` qualifiers to function parameters;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
