### PR TITLE
Proof harness for aws_byte_cursor_read_be* functions

### DIFF
--- a/.cbmc-batch/include/proof_helpers/aws_byte_cursor_read_common.h
+++ b/.cbmc-batch/include/proof_helpers/aws_byte_cursor_read_common.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_read_common_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+    size_t length;
+    DEST_TYPE *dest = can_fail_malloc(length);
+
+    /* assumptions */
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cur = cur;
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+
+    /* operation under verification */
+    if (BYTE_CURSOR_READ((nondet_bool() ? &cur : NULL), dest)) {
+        DEST_TYPE dest_copy;
+        memcpy(&dest_copy, old_cur.ptr, BYTE_WIDTH);
+        dest_copy = AWS_NTOH(dest_copy);
+        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, BYTE_WIDTH);
+        /* the following assertions are included, because aws_byte_cursor_read internally uses
+         * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
+         */
+        assert(BYTE_WIDTH <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
+        assert(cur.ptr == old_cur.ptr + BYTE_WIDTH);
+        assert(cur.len == old_cur.len - BYTE_WIDTH);
+    } else {
+        assert(cur.len == old_cur.len);
+        if (cur.len != 0) {
+            assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
+        }
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+}

--- a/.cbmc-batch/include/proof_helpers/aws_byte_cursor_read_common.h
+++ b/.cbmc-batch/include/proof_helpers/aws_byte_cursor_read_common.h
@@ -26,17 +26,19 @@ void aws_byte_cursor_read_common_harness() {
     /* assumptions */
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+    __CPROVER_assume(AWS_MEM_IS_READABLE(cur.ptr, BYTE_WIDTH));
+    __CPROVER_assume(AWS_OBJECT_PTR_IS_WRITABLE(dest));
 
     /* save current state of the data structure */
     struct aws_byte_cursor old_cur = cur;
     struct store_byte_from_buffer old_byte_from_cur;
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+    DEST_TYPE dest_copy;
+    memcpy(&dest_copy, old_cur.ptr, BYTE_WIDTH);
+    dest_copy = AWS_NTOH(dest_copy);
 
     /* operation under verification */
-    if (BYTE_CURSOR_READ((nondet_bool() ? &cur : NULL), dest)) {
-        DEST_TYPE dest_copy;
-        memcpy(&dest_copy, old_cur.ptr, BYTE_WIDTH);
-        dest_copy = AWS_NTOH(dest_copy);
+    if (BYTE_CURSOR_READ(&cur, dest)) {
         assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, BYTE_WIDTH);
         /* the following assertions are included, because aws_byte_cursor_read internally uses
          * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be16/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be16/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_read_be16_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_read_be16_harness() {
+    /* parameters */
+    struct aws_byte_cursor cur;
+    size_t length;
+    uint16_t *dest = can_fail_malloc(length);
+
+    /* assumptions */
+    ensure_byte_cursor_has_allocated_buffer_member(&cur);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cur = cur;
+    struct store_byte_from_buffer old_byte_from_cur;
+    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
+
+    /* operation under verification */
+    if (aws_byte_cursor_read_be16((nondet_bool() ? &cur : NULL), dest)) {
+        uint16_t tmp;
+        memcpy(&tmp, old_cur.ptr, 2);
+        tmp = ntohs(tmp);
+        assert_bytes_match((uint8_t *)&tmp, (uint8_t *)dest, 2);
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&cur));
+    /* the following assertions are included, because aws_byte_cursor_read internally uses
+     * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
+     */
+    if (old_cur.len < (SIZE_MAX >> 1) && old_cur.len > 2) {
+        assert(cur.ptr == old_cur.ptr + 2);
+        assert(cur.len == old_cur.len - 2);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be16/aws_byte_cursor_read_be16_harness.c
@@ -13,44 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/byte_buf.h>
-#include <proof_helpers/make_common_data_structures.h>
-#include <proof_helpers/proof_allocators.h>
+#define DEST_TYPE uint16_t
+#define BYTE_WIDTH 2
+#define BYTE_CURSOR_READ aws_byte_cursor_read_be16
+#define AWS_NTOH aws_ntoh16
+
+#include <proof_helpers/aws_byte_cursor_read_common.h>
 
 void aws_byte_cursor_read_be16_harness() {
-    /* parameters */
-    struct aws_byte_cursor cur;
-    size_t length;
-    uint16_t *dest = can_fail_malloc(length);
-
-    /* assumptions */
-    ensure_byte_cursor_has_allocated_buffer_member(&cur);
-    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
-
-    /* save current state of the data structure */
-    struct aws_byte_cursor old_cur = cur;
-    struct store_byte_from_buffer old_byte_from_cur;
-    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
-
-    /* operation under verification */
-    if (aws_byte_cursor_read_be16((nondet_bool() ? &cur : NULL), dest)) {
-        uint16_t dest_copy;
-        memcpy(&dest_copy, old_cur.ptr, 2);
-        dest_copy = aws_ntoh16(dest_copy);
-        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, 2);
-        /* the following assertions are included, because aws_byte_cursor_read internally uses
-         * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
-         */
-        assert(2 <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
-        assert(cur.ptr == old_cur.ptr + 2);
-        assert(cur.len == old_cur.len - 2);
-    } else {
-        assert(cur.len == old_cur.len);
-        if (cur.len != 0) {
-            assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
-        }
-    }
-
-    /* assertions */
-    assert(aws_byte_cursor_is_valid(&cur));
+    aws_byte_cursor_read_common_harness();
 }

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be16/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be16/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_read_be16_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be32/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be32/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_read_be32_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be32/aws_byte_cursor_read_be32_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be32/aws_byte_cursor_read_be32_harness.c
@@ -17,11 +17,11 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
-void aws_byte_cursor_read_be16_harness() {
+void aws_byte_cursor_read_be32_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
     size_t length;
-    uint16_t *dest = can_fail_malloc(length);
+    uint32_t *dest = can_fail_malloc(length);
 
     /* assumptions */
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
@@ -33,17 +33,17 @@ void aws_byte_cursor_read_be16_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    if (aws_byte_cursor_read_be16((nondet_bool() ? &cur : NULL), dest)) {
-        uint16_t dest_copy;
-        memcpy(&dest_copy, old_cur.ptr, 2);
-        dest_copy = aws_ntoh16(dest_copy);
-        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, 2);
+    if (aws_byte_cursor_read_be32((nondet_bool() ? &cur : NULL), dest)) {
+        uint32_t dest_copy;
+        memcpy(&dest_copy, old_cur.ptr, 4);
+        dest_copy = aws_ntoh32(dest_copy);
+        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, 4);
         /* the following assertions are included, because aws_byte_cursor_read internally uses
          * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
          */
-        assert(2 <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
-        assert(cur.ptr == old_cur.ptr + 2);
-        assert(cur.len == old_cur.len - 2);
+        assert(4 <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
+        assert(cur.ptr == old_cur.ptr + 4);
+        assert(cur.len == old_cur.len - 4);
     } else {
         assert(cur.len == old_cur.len);
         if (cur.len != 0) {

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be64/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be64/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_read_be64_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
@@ -17,11 +17,11 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
-void aws_byte_cursor_read_be16_harness() {
+void aws_byte_cursor_read_be64_harness() {
     /* parameters */
     struct aws_byte_cursor cur;
     size_t length;
-    uint16_t *dest = can_fail_malloc(length);
+    uint64_t *dest = can_fail_malloc(length);
 
     /* assumptions */
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
@@ -33,17 +33,17 @@ void aws_byte_cursor_read_be16_harness() {
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
 
     /* operation under verification */
-    if (aws_byte_cursor_read_be16((nondet_bool() ? &cur : NULL), dest)) {
-        uint16_t dest_copy;
-        memcpy(&dest_copy, old_cur.ptr, 2);
-        dest_copy = aws_ntoh16(dest_copy);
-        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, 2);
+    if (aws_byte_cursor_read_be64((nondet_bool() ? &cur : NULL), dest)) {
+        uint64_t dest_copy;
+        memcpy(&dest_copy, old_cur.ptr, 8);
+        dest_copy = aws_ntoh64(dest_copy);
+        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, 8);
         /* the following assertions are included, because aws_byte_cursor_read internally uses
          * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
          */
-        assert(2 <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
-        assert(cur.ptr == old_cur.ptr + 2);
-        assert(cur.len == old_cur.len - 2);
+        assert(8 <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
+        assert(cur.ptr == old_cur.ptr + 8);
+        assert(cur.len == old_cur.len - 8);
     } else {
         assert(cur.len == old_cur.len);
         if (cur.len != 0) {

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be64/aws_byte_cursor_read_be64_harness.c
@@ -13,44 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/byte_buf.h>
-#include <proof_helpers/make_common_data_structures.h>
-#include <proof_helpers/proof_allocators.h>
+#define DEST_TYPE uint64_t
+#define BYTE_WIDTH 8
+#define BYTE_CURSOR_READ aws_byte_cursor_read_be64
+#define AWS_NTOH aws_ntoh64
+
+#include <proof_helpers/aws_byte_cursor_read_common.h>
 
 void aws_byte_cursor_read_be64_harness() {
-    /* parameters */
-    struct aws_byte_cursor cur;
-    size_t length;
-    uint64_t *dest = can_fail_malloc(length);
-
-    /* assumptions */
-    ensure_byte_cursor_has_allocated_buffer_member(&cur);
-    __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
-
-    /* save current state of the data structure */
-    struct aws_byte_cursor old_cur = cur;
-    struct store_byte_from_buffer old_byte_from_cur;
-    save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cur);
-
-    /* operation under verification */
-    if (aws_byte_cursor_read_be64((nondet_bool() ? &cur : NULL), dest)) {
-        uint64_t dest_copy;
-        memcpy(&dest_copy, old_cur.ptr, 8);
-        dest_copy = aws_ntoh64(dest_copy);
-        assert_bytes_match((uint8_t *)&dest_copy, (uint8_t *)dest, 8);
-        /* the following assertions are included, because aws_byte_cursor_read internally uses
-         * aws_byte_cursor_advance_nospec and it copies the bytes from the advanced cursor to *dest
-         */
-        assert(8 <= old_cur.len && old_cur.len <= (SIZE_MAX >> 1));
-        assert(cur.ptr == old_cur.ptr + 8);
-        assert(cur.len == old_cur.len - 8);
-    } else {
-        assert(cur.len == old_cur.len);
-        if (cur.len != 0) {
-            assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
-        }
-    }
-
-    /* assertions */
-    assert(aws_byte_cursor_is_valid(&cur));
+    aws_byte_cursor_read_common_harness();
 }

--- a/.cbmc-batch/jobs/aws_byte_cursor_read_be64/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_read_be64/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_read_be64_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -752,12 +752,15 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRIC
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint16_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
     bool rv = aws_byte_cursor_read(cur, var, 2);
 
     if (AWS_LIKELY(rv)) {
         *var = aws_ntoh16(*var);
     }
 
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
     return rv;
 }
 
@@ -770,12 +773,15 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
     bool rv = aws_byte_cursor_read(cur, var, 4);
 
     if (AWS_LIKELY(rv)) {
         *var = aws_ntoh32(*var);
     }
 
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
     return rv;
 }
 
@@ -788,12 +794,15 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint
  * cursor unchanged.
  */
 AWS_STATIC_IMPL bool aws_byte_cursor_read_be64(struct aws_byte_cursor *cur, uint64_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
     bool rv = aws_byte_cursor_read(cur, var, sizeof(*var));
 
     if (AWS_LIKELY(rv)) {
         *var = aws_ntoh64(*var);
     }
 
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
     return rv;
 }
 

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -42,7 +42,7 @@ AWS_STATIC_IMPL uint64_t aws_hton64(uint64_t x) {
     if (aws_is_big_endian()) {
         return x;
     }
-#if defined(__x86_64__) && (defined(__GNUC__) || defined(__clang__))
+#if defined(__x86_64__) && (defined(__GNUC__) || defined(__clang__)) && !defined(CBMC)
     uint64_t v;
     __asm__("bswap %q0" : "=r"(v) : "0"(x));
     return v;


### PR DESCRIPTION
*Description of changes:*

1. Updates implementation of aws_byte_cursor_read_be* functions with pre- and post-conditions;
2. Adds proof harnesses for aws_byte_cursor_read_be* functions;
3. Adds a preprocessor check to hton64 function to avoid assembly instruction when using CBMC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
