### PR TITLE
Adds proof harness for aws_byte_cursor_compare* functions

### DIFF
--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += memcmp.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_compare_lexical_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
@@ -43,11 +43,11 @@ void aws_byte_cursor_compare_lexical_harness() {
     save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_cursor_compare_lexical((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL))) {
+    if (aws_byte_cursor_compare_lexical((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL)) == 0) {
         assert(lhs.len == rhs.len);
-        /*if (lhs.len > 0) {
+        if (lhs.len > 0) {
             assert_bytes_match(lhs.ptr, rhs.ptr, lhs.len);
-        }*/
+        }
     }
 
     /* assertions */

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
@@ -51,6 +51,7 @@ void aws_byte_cursor_compare_lexical_harness() {
     }
 
     /* assertions */
+    assert(aws_byte_cursor_compare_lexical(&lhs, &lhs) == 0);
     assert(aws_byte_cursor_is_valid(&lhs));
     assert(aws_byte_cursor_is_valid(&rhs));
     if (lhs.len != 0) {

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_compare_lexical_harness() {
+    /* parameters */
+    struct aws_byte_cursor lhs;
+    struct aws_byte_cursor rhs;
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&lhs, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&lhs);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&lhs));
+    if (nondet_bool()) {
+        rhs = lhs;
+    } else {
+        __CPROVER_assume(aws_byte_cursor_is_bounded(&rhs, MAX_BUFFER_SIZE));
+        ensure_byte_cursor_has_allocated_buffer_member(&rhs);
+        __CPROVER_assume(aws_byte_cursor_is_valid(&rhs));
+    }
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_lhs = lhs;
+    struct store_byte_from_buffer old_byte_from_lhs;
+    save_byte_from_array(lhs.ptr, lhs.len, &old_byte_from_lhs);
+    struct aws_byte_cursor old_rhs = rhs;
+    struct store_byte_from_buffer old_byte_from_rhs;
+    save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
+
+    /* operation under verification */
+    if (aws_byte_cursor_compare_lexical((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL))) {
+        assert(lhs.len == rhs.len);
+        /*if (lhs.len > 0) {
+            assert_bytes_match(lhs.ptr, rhs.ptr, lhs.len);
+        }*/
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&lhs));
+    assert(aws_byte_cursor_is_valid(&rhs));
+    if (lhs.len != 0) {
+        assert_byte_from_buffer_matches(lhs.ptr, &old_byte_from_lhs);
+    }
+    if (rhs.len != 0) {
+        assert_byte_from_buffer_matches(rhs.ptr, &old_byte_from_rhs);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/aws_byte_cursor_compare_lexical_harness.c
@@ -26,12 +26,14 @@ void aws_byte_cursor_compare_lexical_harness() {
     __CPROVER_assume(aws_byte_cursor_is_bounded(&lhs, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&lhs);
     __CPROVER_assume(aws_byte_cursor_is_valid(&lhs));
+    __CPROVER_assume(lhs.ptr != NULL);
     if (nondet_bool()) {
         rhs = lhs;
     } else {
         __CPROVER_assume(aws_byte_cursor_is_bounded(&rhs, MAX_BUFFER_SIZE));
         ensure_byte_cursor_has_allocated_buffer_member(&rhs);
         __CPROVER_assume(aws_byte_cursor_is_valid(&rhs));
+        __CPROVER_assume(rhs.ptr != NULL);
     }
 
     /* save current state of the data structure */
@@ -43,15 +45,15 @@ void aws_byte_cursor_compare_lexical_harness() {
     save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_cursor_compare_lexical((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL)) == 0) {
+    if (aws_byte_cursor_compare_lexical(&lhs, &rhs) == 0) {
         assert(lhs.len == rhs.len);
         if (lhs.len > 0) {
             assert_bytes_match(lhs.ptr, rhs.ptr, lhs.len);
         }
     }
+    assert(aws_byte_cursor_compare_lexical(&lhs, &lhs) == 0);
 
     /* assertions */
-    assert(aws_byte_cursor_compare_lexical(&lhs, &lhs) == 0);
     assert(aws_byte_cursor_is_valid(&lhs));
     assert(aws_byte_cursor_is_valid(&rhs));
     if (lhs.len != 0) {

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:11;--object-bits;8"
+goto: aws_byte_cursor_eq_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:11;--object-bits;8"
-goto: aws_byte_cursor_eq_harness.goto
+goto: aws_byte_cursor_compare_lexical_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/Makefile
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += aws_byte_cursor_compare_lookup.0:$(shell echo $$(($(MAX_BUFFER_SIZE) + 1)))
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_byte_cursor_compare_lookup_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/aws_byte_cursor_compare_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/aws_byte_cursor_compare_lookup_harness.c
@@ -48,13 +48,12 @@ void aws_byte_cursor_compare_lookup_harness() {
     save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
 
     /* operation under verification */
-    if (aws_byte_cursor_compare_lookup((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL), lookup_table) ==
-        0) {
+    if (aws_byte_cursor_compare_lookup(&lhs, &rhs, lookup_table) == 0) {
         assert(lhs.len == rhs.len);
     }
+    assert(aws_byte_cursor_compare_lookup(&lhs, &lhs, lookup_table) == 0);
 
     /* assertions */
-    assert(aws_byte_cursor_compare_lookup(&lhs, &lhs, lookup_table) == 0);
     assert(aws_byte_cursor_is_valid(&lhs));
     assert(aws_byte_cursor_is_valid(&rhs));
     if (lhs.len != 0) {

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/aws_byte_cursor_compare_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/aws_byte_cursor_compare_lookup_harness.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_byte_cursor_compare_lookup_harness() {
+    /* parameters */
+    struct aws_byte_cursor lhs;
+    struct aws_byte_cursor rhs;
+    /**
+     * The specification for the function requires that the buffer
+     * be at least 256 bytes.
+     */
+    uint8_t lookup_table[256];
+
+    /* assumptions */
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&lhs, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&lhs);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&lhs));
+    if (nondet_bool()) {
+        rhs = lhs;
+    } else {
+        __CPROVER_assume(aws_byte_cursor_is_bounded(&rhs, MAX_BUFFER_SIZE));
+        ensure_byte_cursor_has_allocated_buffer_member(&rhs);
+        __CPROVER_assume(aws_byte_cursor_is_valid(&rhs));
+    }
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_lhs = lhs;
+    struct store_byte_from_buffer old_byte_from_lhs;
+    save_byte_from_array(lhs.ptr, lhs.len, &old_byte_from_lhs);
+    struct aws_byte_cursor old_rhs = rhs;
+    struct store_byte_from_buffer old_byte_from_rhs;
+    save_byte_from_array(rhs.ptr, rhs.len, &old_byte_from_rhs);
+
+    /* operation under verification */
+    if (aws_byte_cursor_compare_lookup((nondet_bool() ? &lhs : NULL), (nondet_bool() ? &rhs : NULL), lookup_table) ==
+        0) {
+        assert(lhs.len == rhs.len);
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&lhs));
+    assert(aws_byte_cursor_is_valid(&rhs));
+    if (lhs.len != 0) {
+        assert_byte_from_buffer_matches(lhs.ptr, &old_byte_from_lhs);
+    }
+    if (rhs.len != 0) {
+        assert_byte_from_buffer_matches(rhs.ptr, &old_byte_from_rhs);
+    }
+}

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/aws_byte_cursor_compare_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/aws_byte_cursor_compare_lookup_harness.c
@@ -54,6 +54,7 @@ void aws_byte_cursor_compare_lookup_harness() {
     }
 
     /* assertions */
+    assert(aws_byte_cursor_compare_lookup(&lhs, &lhs, lookup_table) == 0);
     assert(aws_byte_cursor_is_valid(&lhs));
     assert(aws_byte_cursor_is_valid(&rhs));
     if (lhs.len != 0) {

--- a/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_byte_cursor_compare_lookup/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_byte_cursor_compare_lookup.0:11;--object-bits;8"
+goto: aws_byte_cursor_compare_lookup_harness.goto
+expected: "SUCCESSFUL"

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -453,7 +453,7 @@ const uint8_t *aws_lookup_table_to_lower_get(void);
  * Lexical (byte value) comparison of two byte cursors
  */
 AWS_COMMON_API
-int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const struct aws_byte_cursor *rhs);
+int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *const lhs, const struct aws_byte_cursor *const rhs);
 
 /**
  * Lexical (byte value) comparison of two byte cursors where the raw values are sent through a lookup table first

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -453,7 +453,7 @@ const uint8_t *aws_lookup_table_to_lower_get(void);
  * Lexical (byte value) comparison of two byte cursors
  */
 AWS_COMMON_API
-int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *const lhs, const struct aws_byte_cursor *const rhs);
+int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const struct aws_byte_cursor *rhs);
 
 /**
  * Lexical (byte value) comparison of two byte cursors where the raw values are sent through a lookup table first

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -717,8 +717,9 @@ bool aws_byte_cursor_satisfies_pred(const struct aws_byte_cursor *source, aws_by
 int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const struct aws_byte_cursor *rhs) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
-    AWS_PRECONDITION(AWS_MEM_IS_READABLE(lhs->ptr, lhs->len));
-    AWS_PRECONDITION(AWS_MEM_IS_READABLE(rhs->ptr, rhs->len));
+    /* make sure we don't pass NULL pointers to memcmp */
+    AWS_PRECONDITION(lhs->ptr != NULL);
+    AWS_PRECONDITION(rhs->ptr != NULL);
     size_t comparison_length = lhs->len;
     if (comparison_length > rhs->len) {
         comparison_length = rhs->len;

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -714,9 +714,11 @@ bool aws_byte_cursor_satisfies_pred(const struct aws_byte_cursor *source, aws_by
     return rval;
 }
 
-int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *const lhs, const struct aws_byte_cursor *const rhs) {
+int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const struct aws_byte_cursor *rhs) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
+    AWS_PRECONDITION(AWS_MEM_IS_READABLE(lhs->ptr, lhs->len));
+    AWS_PRECONDITION(AWS_MEM_IS_READABLE(rhs->ptr, rhs->len));
     size_t comparison_length = lhs->len;
     if (comparison_length > rhs->len) {
         comparison_length = rhs->len;
@@ -724,10 +726,14 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *const lhs, con
 
     int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
     if (result != 0) {
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return result;
     }
 
     if (lhs->len != rhs->len) {
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return comparison_length == lhs->len ? -1 : 1;
     }
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
@@ -739,7 +745,9 @@ int aws_byte_cursor_compare_lookup(
     const struct aws_byte_cursor *lhs,
     const struct aws_byte_cursor *rhs,
     const uint8_t *lookup_table) {
-
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
+    AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
     const uint8_t *lhs_curr = lhs->ptr;
     const uint8_t *lhs_end = lhs_curr + lhs->len;
 
@@ -751,10 +759,14 @@ int aws_byte_cursor_compare_lookup(
         uint8_t rhc = lookup_table[*rhs_curr];
 
         if (lhc < rhc) {
+            AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+            AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
             return -1;
         }
 
         if (lhc > rhc) {
+            AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+            AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
             return 1;
         }
 
@@ -763,12 +775,17 @@ int aws_byte_cursor_compare_lookup(
     }
 
     if (lhs_curr < lhs_end) {
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return 1;
     }
 
     if (rhs_curr < rhs_end) {
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return -1;
     }
-
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
     return 0;
 }

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -726,19 +726,17 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
     }
 
     int result = memcmp(lhs->ptr, rhs->ptr, comparison_length);
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
     if (result != 0) {
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return result;
     }
 
     if (lhs->len != rhs->len) {
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return comparison_length == lhs->len ? -1 : 1;
     }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
+
     return 0;
 }
 
@@ -759,15 +757,13 @@ int aws_byte_cursor_compare_lookup(
         uint8_t lhc = lookup_table[*lhs_curr];
         uint8_t rhc = lookup_table[*rhs_curr];
 
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         if (lhc < rhc) {
-            AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-            AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
             return -1;
         }
 
         if (lhc > rhc) {
-            AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-            AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
             return 1;
         }
 
@@ -775,18 +771,15 @@ int aws_byte_cursor_compare_lookup(
         rhs_curr++;
     }
 
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
     if (lhs_curr < lhs_end) {
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return 1;
     }
 
     if (rhs_curr < rhs_end) {
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
         return -1;
     }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
+
     return 0;
 }

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -714,8 +714,9 @@ bool aws_byte_cursor_satisfies_pred(const struct aws_byte_cursor *source, aws_by
     return rval;
 }
 
-int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const struct aws_byte_cursor *rhs) {
-
+int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *const lhs, const struct aws_byte_cursor *const rhs) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
     size_t comparison_length = lhs->len;
     if (comparison_length > rhs->len) {
         comparison_length = rhs->len;
@@ -729,7 +730,8 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
     if (lhs->len != rhs->len) {
         return comparison_length == lhs->len ? -1 : 1;
     }
-
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(lhs));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(rhs));
     return 0;
 }
 


### PR DESCRIPTION
*Description of changes:*
1. Updates implementation of `aws_byte_cursor_compare*` functions with pre- and post-conditions;
2. Adds proof harnesses for `aws_byte_cursor_compare*` functions;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
