### PR TITLE
Assert unchanged byte buffers in the definition of aws_byte_buf_eq

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -41,6 +41,7 @@
 #endif
 
 #define AWS_CONCAT(A, B) A ## B
+#define GHOST(x) ghost_ ## x
 
 #define AWS_ZERO_STRUCT(object)                                                                                        \
         do {                                                                                                           \

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -110,8 +110,12 @@ void aws_byte_buf_clean_up_secure(struct aws_byte_buf *buf) {
 
 bool aws_byte_buf_eq(const struct aws_byte_buf *const a, const struct aws_byte_buf *const b) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_GHOST_BYTE_BUF(a);
+    AWS_GHOST_BYTE_BUF(b);
     bool rval = aws_array_eq(a->buffer, a->len, b->buffer, b->len);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(a) && aws_byte_buf_is_valid(b));
+    AWS_ASSERT_BYTE_BUF_UNCHANGED(a);
+    AWS_ASSERT_BYTE_BUF_UNCHANGED(b);
     return rval;
 }
 


### PR DESCRIPTION
This PR is an experiment as a first step of a proposal to "push" assertions (and assumptions) to the function definitions. At the moment, function pre and postconditions check whether the arguments and return values satisfy simple validity constraints. In contrast, more complex assertions are checked in harnesses. By moving assertions to the definitions, the code becomes self documented and the risk of assertions (and assumptions) in harnesses lagging behind the definition is reduced.

This PR mostly serves as a discussion thread for the proposal.

There are two main discussions points:

1. What is the ideal amount of work to do when testing? Is it reasonable to copy the input argument byte buffer and check that every byte in the byte buffer after the execution of the function is the same as before? In my opinion we should check the assertion while testing by default, and only check some simplified version of it when a specific test takes too much time to finish.

2. What should the macros used for these conditions look like? We have to find a balance between expressiveness and visual clarity, as it wouldn't make sense to introduce heavyweight conditions in every function definition. In my opinion, a good first step would be to introduce macros for frequently used assertions (such as equivalence of an argument before and after the execution of a function), so that they can be easily used by anyone developing the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
