### PR TITLE
Add typecast to AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -469,7 +469,7 @@ AWS_EXTERN_C_END
 /**
  */
 #define AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(literal)                                                                 \
-    { .ptr = (uint8_t *)(const char *)(literal), .len = sizeof(literal) - 1 }
+    (struct aws_byte_cursor) { .ptr = (uint8_t *)(const char *)(literal), .len = sizeof(literal) - 1 }
 
 /**
  * For creating a byte buffer from a null-terminated string literal.


### PR DESCRIPTION
This allows the macro to be used when assigning to a cursor, instead of just during initialization.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
