### PR TITLE
Adds memory safety proofs for aws_ring_buffer

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -20,6 +20,7 @@
 #include <aws/common/common.h>
 #include <aws/common/priority_queue.h>
 #include <aws/common/private/hash_table_impl.h>
+#include <aws/common/ring_buffer.h>
 #include <aws/common/string.h>
 #include <proof_helpers/nondet.h>
 #include <proof_helpers/proof_allocators.h>
@@ -46,6 +47,11 @@ bool aws_byte_buf_has_allocator(const struct aws_byte_buf *const buf);
  * Ensures aws_byte_buf has a proper allocated buffer member
  */
 void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf);
+
+/*
+ * Ensures aws_ring_buffer has proper allocated members
+ */
+void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *const ring_buf, size_t size);
 
 /*
  * Checks whether aws_byte_cursor is bounded by max_size

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/Makefile
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/ring_buffer.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_ring_buffer_acquire_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/ring_buffer.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_ring_buffer_acquire_harness() {
+    /* parameters */
+    struct aws_ring_buffer ring_buf;
+    size_t ring_buf_size;
+    size_t requested_size;
+    struct aws_byte_buf buf;
+
+    /* assumptions */
+    ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
+    __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    if (aws_ring_buffer_acquire(nondet_bool() ? &ring_buf : NULL, requested_size, nondet_bool() ? &buf : NULL) ==
+        AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_ring_buffer_is_valid(&ring_buf));
+        assert(aws_byte_buf_is_valid(&buf));
+    }
+}

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -37,6 +37,8 @@ void aws_ring_buffer_acquire_harness() {
         assert(aws_ring_buffer_is_valid(&ring_buf));
         assert(aws_byte_buf_is_valid(&buf));
         assert(AWS_MEM_IS_WRITABLE(buf.buffer, requested_size));
-        assert(buf.buffer >= ring_buf.allocation && (buf.buffer + requested_size) < (ring_buf.allocation_end));
+        assert(buf.capacity == requested_size);
+        assert(buf.len == 0); /* aws_byte_buf always created with aws_byte_buf_from_empty_array */
+        assert(buf.buffer >= ring_buf.allocation && (buf.buffer + buf.capacity) < (ring_buf.allocation_end));
     }
 }

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -36,5 +36,7 @@ void aws_ring_buffer_acquire_harness() {
         /* assertions */
         assert(aws_ring_buffer_is_valid(&ring_buf));
         assert(aws_byte_buf_is_valid(&buf));
+        assert(AWS_MEM_IS_WRITABLE(buf.buffer, requested_size));
+        assert(buf.buffer >= ring_buf.allocation && (buf.buffer + requested_size) < (ring_buf.allocation_end));
     }
 }

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
-goto: aws_byte_buf_init_harness.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_ring_buffer_acquire_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
+goto: aws_byte_buf_init_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/Makefile
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/source/ring_buffer.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_ring_buffer_acquire_up_to_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
@@ -23,6 +23,7 @@ void aws_ring_buffer_acquire_up_to_harness() {
     struct aws_ring_buffer ring_buf;
     size_t ring_buf_size;
     size_t requested_size;
+    size_t minimum_size;
     struct aws_byte_buf buf;
 
     /* assumptions */
@@ -31,12 +32,13 @@ void aws_ring_buffer_acquire_up_to_harness() {
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 
-    if (aws_ring_buffer_acquire_up_to(nondet_bool() ? &ring_buf : NULL, requested_size, nondet_bool() ? &buf : NULL) ==
+    if (aws_ring_buffer_acquire_up_to(
+            nondet_bool() ? &ring_buf : NULL, minimum_size, requested_size, nondet_bool() ? &buf : NULL) ==
         AWS_OP_SUCCESS) {
         /* assertions */
         assert(aws_ring_buffer_is_valid(&ring_buf));
         assert(aws_byte_buf_is_valid(&buf));
-        assert(buf.capacity <= requested_size);
+        assert(buf.capacity >= minimum_size && buf.capacity <= requested_size);
         assert(buf.len == 0); /* aws_byte_buf always created with aws_byte_buf_from_empty_array */
         assert(buf.buffer >= ring_buf.allocation && (buf.buffer + buf.capacity) < (ring_buf.allocation_end));
     }

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/ring_buffer.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_ring_buffer_acquire_up_to_harness() {
+    /* parameters */
+    struct aws_ring_buffer ring_buf;
+    size_t ring_buf_size;
+    size_t requested_size;
+    struct aws_byte_buf buf;
+
+    /* assumptions */
+    ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
+    __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
+    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&buf));
+
+    if (aws_ring_buffer_acquire_up_to(nondet_bool() ? &ring_buf : NULL, requested_size, nondet_bool() ? &buf : NULL) ==
+        AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_ring_buffer_is_valid(&ring_buf));
+        assert(aws_byte_buf_is_valid(&buf));
+        assert(buf.capacity <= requested_size);
+        assert(buf.len == 0); /* aws_byte_buf always created with aws_byte_buf_from_empty_array */
+        assert(buf.buffer >= ring_buf.allocation && (buf.buffer + buf.capacity) < (ring_buf.allocation_end));
+    }
+}

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_ring_buffer_acquire_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_ring_buffer_acquire_harness.goto
+goto: aws_ring_buffer_acquire_up_to_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_ring_buffer_init/Makefile
+++ b/.cbmc-batch/jobs/aws_ring_buffer_init/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
+DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
+DEPENDENCIES += $(HELPERDIR)/source/utils.c
+DEPENDENCIES += $(HELPERDIR)/stubs/error.c
+DEPENDENCIES += $(SRCDIR)/source/ring_buffer.c
+DEPENDENCIES += $(SRCDIR)/source/common.c
+
+ENTRY = aws_ring_buffer_init_harness
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_ring_buffer_init/aws_ring_buffer_init_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_init/aws_ring_buffer_init_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/ring_buffer.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+void aws_ring_buffer_init_harness() {
+    /* parameters */
+    struct aws_ring_buffer ring_buf;
+    struct aws_allocator *allocator = can_fail_allocator();
+    size_t size;
+
+    if (aws_ring_buffer_init(nondet_bool() ? &ring_buf : NULL, nondet_bool() ? allocator : NULL, size) ==
+        AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_ring_buffer_is_valid(&ring_buf));
+        assert(ring_buf.allocator == allocator);
+        assert(ring_buf.allocation_end - ring_buf.allocation - 1 == size);
+    }
+}

--- a/.cbmc-batch/jobs/aws_ring_buffer_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_ring_buffer_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
-goto: aws_byte_buf_init_harness.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_ring_buffer_init_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_ring_buffer_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_ring_buffer_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
+goto: aws_byte_buf_init_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -33,6 +33,18 @@ void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf)
     buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * buf->capacity);
 }
 
+void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *const ring_buf, size_t size) {
+    ring_buf->allocator = can_fail_allocator();
+    ring_buf->allocation = bounded_malloc(sizeof(*(ring_buf->allocation)) * size);
+    size_t position_head;
+    size_t position_tail;
+    __CPROVER_assume(position_head < size);
+    __CPROVER_assume(position_tail < size);
+    aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
+    aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
+    ring_buf->allocation_end = ring_buf->allocation + size + 1;
+}
+
 bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, const size_t max_size) {
     return cursor->len <= max_size;
 }

--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -1,0 +1,88 @@
+#ifndef AWS_COMMON_RING_BUFFER_H
+#define AWS_COMMON_RING_BUFFER_H
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/atomics.h>
+
+/**
+ * Lockless ring buffer implementation that is thread safe assuming a single thread acquires and a single thread
+ * releases. For any other use case (other than the single-threaded use-case), you must manage thread-safety manually.
+ *
+ * Also, a very important note: release must happen in the same order as acquire. If you do not your application, and
+ * possibly computers within a thousand mile radius, may die terrible deaths, and the local drinking water will be
+ * poisoned for generations with fragments of what is left of your radioactive corrupted memory.
+ */
+struct aws_ring_buffer {
+    struct aws_allocator *allocator;
+    uint8_t *allocation;
+    struct aws_atomic_var head;
+    struct aws_atomic_var tail;
+    uint8_t *allocation_end;
+};
+
+struct aws_byte_buf;
+
+AWS_EXTERN_C_BEGIN
+
+/**
+ * Initializes a ring buffer with an allocation of size `size`. Returns AWS_OP_SUCCESS on a successful initialization,
+ * AWS_OP_ERR otherwise.
+ */
+AWS_COMMON_API int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct aws_allocator *allocator, size_t size);
+
+/**
+ * Cleans up the ring buffer's resources.
+ */
+AWS_COMMON_API void aws_ring_buffer_clean_up(struct aws_ring_buffer *ring_buf);
+
+/**
+ * Attempts to acquire `requested_size` buffer and stores the result in `dest` if successful. Returns AWS_OP_SUCCESS if
+ * the requested size was available for use, AWS_OP_ERR otherwise.
+ */
+AWS_COMMON_API int aws_ring_buffer_acquire(
+    struct aws_ring_buffer *ring_buf,
+    size_t requested_size,
+    struct aws_byte_buf *dest);
+
+/**
+ * Attempts to acquire `requested_size` buffer and stores the result in `dest` if successful. If not available, it will
+ * attempt to acquire anywhere from 1 byte to `requested_size`. Returns AWS_OP_SUCCESS if some buffer space is available
+ * for use, AWS_OP_ERR otherwise.
+ */
+AWS_COMMON_API int aws_ring_buffer_acquire_up_to(
+    struct aws_ring_buffer *ring_buf,
+    size_t minimum_size,
+    size_t requested_size,
+    struct aws_byte_buf *dest);
+
+/**
+ * Releases `buf` back to the ring buffer for further use. RELEASE MUST HAPPEN in the SAME ORDER AS ACQUIRE.
+ * If you do not, your application, and possibly computers within a thousand mile radius, may die terrible deaths,
+ * and the local drinking water will be poisoned for generations
+ * with fragments of what is left of your radioactive corrupted memory.
+ */
+AWS_COMMON_API void aws_ring_buffer_release(struct aws_ring_buffer *ring_buffer, struct aws_byte_buf *buf);
+
+/**
+ * Returns true if the memory in `buf` was vended by this ring buffer, false otherwise.
+ */
+AWS_COMMON_API bool aws_ring_buffer_buf_belongs_to_pool(
+    const struct aws_ring_buffer *ring_buffer,
+    const struct aws_byte_buf *buf);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_RING_BUFFER_H */

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/ring_buffer.h>
+
+#include <aws/common/byte_buf.h>
+
+int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct aws_allocator *allocator, size_t size) {
+    AWS_ZERO_STRUCT(*ring_buf);
+
+    ring_buf->allocation = aws_mem_acquire(allocator, size);
+
+    if (!ring_buf->allocation) {
+        return AWS_OP_ERR;
+    }
+
+    ring_buf->allocator = allocator;
+    aws_atomic_init_ptr(&ring_buf->head, ring_buf->allocation);
+    aws_atomic_init_ptr(&ring_buf->tail, ring_buf->allocation);
+    ring_buf->allocation_end = ring_buf->allocation + size;
+
+    return AWS_OP_SUCCESS;
+}
+
+void aws_ring_buffer_clean_up(struct aws_ring_buffer *ring_buf) {
+    if (ring_buf->allocation) {
+        aws_mem_release(ring_buf->allocator, ring_buf->allocation);
+    }
+
+    AWS_ZERO_STRUCT(*ring_buf);
+}
+
+int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_size, struct aws_byte_buf *dest) {
+    if (requested_size == 0) {
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
+
+    uint8_t *tail_cpy = aws_atomic_load_ptr(&ring_buf->tail);
+    uint8_t *head_cpy = aws_atomic_load_ptr(&ring_buf->head);
+
+    /* this branch is, we don't have any vended buffers. */
+    if (head_cpy == tail_cpy) {
+        size_t ring_space = ring_buf->allocation_end - ring_buf->allocation;
+
+        if (requested_size > ring_space) {
+            return aws_raise_error(AWS_ERROR_OOM);
+        }
+
+        aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
+        aws_atomic_store_ptr(&ring_buf->tail, ring_buf->allocation);
+        *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
+        return AWS_OP_SUCCESS;
+    }
+
+    /* you'll constantly bounce between the next two branches as the ring buffer is traversed. */
+    /* after N + 1 wraps */
+    if (tail_cpy > head_cpy) {
+        size_t space = tail_cpy - head_cpy - 1;
+
+        if (space >= requested_size) {
+            aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
+            *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
+            return AWS_OP_SUCCESS;
+        }
+        /* After N wraps */
+    } else if (tail_cpy < head_cpy) {
+        /* prefer the head space for efficiency. */
+        if ((size_t)(ring_buf->allocation_end - head_cpy) >= requested_size) {
+            aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
+            *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
+            return AWS_OP_SUCCESS;
+        }
+
+        if ((size_t)(tail_cpy - ring_buf->allocation) > requested_size) {
+            aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
+            *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
+            return AWS_OP_SUCCESS;
+        }
+    }
+
+    return aws_raise_error(AWS_ERROR_OOM);
+}
+
+int aws_ring_buffer_acquire_up_to(
+    struct aws_ring_buffer *ring_buf,
+    size_t minimum_size,
+    size_t requested_size,
+    struct aws_byte_buf *dest) {
+    AWS_ASSERT(requested_size >= minimum_size)
+
+    if (requested_size == 0) {
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
+
+    uint8_t *tail_cpy = aws_atomic_load_ptr(&ring_buf->tail);
+    uint8_t *head_cpy = aws_atomic_load_ptr(&ring_buf->head);
+
+    /* this branch is, we don't have any vended buffers. */
+    if (head_cpy == tail_cpy) {
+        size_t ring_space = ring_buf->allocation_end - ring_buf->allocation;
+
+        size_t allocation_size = ring_space > requested_size ? requested_size : ring_space;
+
+        if (allocation_size < minimum_size) {
+            return aws_raise_error(AWS_ERROR_OOM);
+        }
+
+        /* go as big as we can. */
+        /* we don't have any vended, so this should be safe. */
+        aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + allocation_size);
+        aws_atomic_store_ptr(&ring_buf->tail, ring_buf->allocation);
+        *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, allocation_size);
+        return AWS_OP_SUCCESS;
+    }
+    /* you'll constantly bounce between the next two branches as the ring buffer is traversed. */
+    /* after N + 1 wraps */
+    if (tail_cpy > head_cpy) {
+        size_t space = tail_cpy - head_cpy;
+        /* this shouldn't be possible. */
+        AWS_ASSERT(space);
+        space -= 1;
+
+        size_t returnable_size = space > requested_size ? requested_size : space;
+
+        if (returnable_size >= minimum_size) {
+            aws_atomic_store_ptr(&ring_buf->head, head_cpy + returnable_size);
+            *dest = aws_byte_buf_from_empty_array(head_cpy, returnable_size);
+            return AWS_OP_SUCCESS;
+        }
+        /* after N wraps */
+    } else if (tail_cpy < head_cpy) {
+        size_t head_space = ring_buf->allocation_end - head_cpy;
+        size_t tail_space = tail_cpy - ring_buf->allocation;
+
+        /* if you can vend the whole thing do it. Also prefer head space to tail space. */
+        if (head_space >= requested_size) {
+            aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
+            *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
+            return AWS_OP_SUCCESS;
+        }
+
+        if (tail_space > requested_size) {
+            aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
+            *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
+            return AWS_OP_SUCCESS;
+        }
+
+        /* now vend as much as possible, once again preferring head space. */
+        if (head_space >= minimum_size && head_space >= tail_space) {
+            aws_atomic_store_ptr(&ring_buf->head, head_cpy + head_space);
+            *dest = aws_byte_buf_from_empty_array(head_cpy, head_space);
+            return AWS_OP_SUCCESS;
+        }
+
+        if (tail_space > minimum_size) {
+            aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + tail_space - 1);
+            *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, tail_space - 1);
+            return AWS_OP_SUCCESS;
+        }
+    }
+
+    return aws_raise_error(AWS_ERROR_OOM);
+}
+
+static inline bool s_buf_belongs_to_pool(const struct aws_ring_buffer *ring_buffer, const struct aws_byte_buf *buf) {
+    return buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;
+}
+
+void aws_ring_buffer_release(struct aws_ring_buffer *ring_buffer, struct aws_byte_buf *buf) {
+    AWS_ASSERT(s_buf_belongs_to_pool(ring_buffer, buf));
+    aws_atomic_store_ptr(&ring_buffer->tail, buf->buffer + buf->capacity);
+    AWS_ZERO_STRUCT(*buf);
+}
+
+bool aws_ring_buffer_buf_belongs_to_pool(const struct aws_ring_buffer *ring_buffer, const struct aws_byte_buf *buf) {
+    return s_buf_belongs_to_pool(ring_buffer, buf);
+}

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -130,30 +130,41 @@ int aws_ring_buffer_acquire_up_to(
     size_t minimum_size,
     size_t requested_size,
     struct aws_byte_buf *dest) {
-    AWS_ASSERT(requested_size >= minimum_size)
+    AWS_PRECONDITION(requested_size >= minimum_size)
+    AWS_PRECONDITION(aws_ring_buffer_is_valid(ring_buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(dest));
 
     if (requested_size == 0) {
+        AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    uint8_t *tail_cpy = aws_atomic_load_ptr(&ring_buf->tail);
-    uint8_t *head_cpy = aws_atomic_load_ptr(&ring_buf->head);
+    uint8_t *tail_cpy;
+    uint8_t *head_cpy;
+    AWS_ATOMIC_LOAD_PTR(tail_cpy, ring_buf, &ring_buf->tail);
+    AWS_ATOMIC_LOAD_PTR(head_cpy, ring_buf, &ring_buf->head);
 
     /* this branch is, we don't have any vended buffers. */
     if (head_cpy == tail_cpy) {
-        size_t ring_space = ring_buf->allocation_end - ring_buf->allocation;
+        size_t ring_space = ring_buf->allocation_end - ring_buf->allocation - 1;
 
         size_t allocation_size = ring_space > requested_size ? requested_size : ring_space;
 
         if (allocation_size < minimum_size) {
+            AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
             return aws_raise_error(AWS_ERROR_OOM);
         }
 
         /* go as big as we can. */
         /* we don't have any vended, so this should be safe. */
-        aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + allocation_size);
-        aws_atomic_store_ptr(&ring_buf->tail, ring_buf->allocation);
+
+        AWS_ATOMIC_STORE_PTR(ring_buf->allocation + allocation_size, ring_buf, &ring_buf->head);
+        AWS_ATOMIC_STORE_PTR(ring_buf->allocation, ring_buf, &ring_buf->tail);
         *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, allocation_size);
+        AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
         return AWS_OP_SUCCESS;
     }
     /* you'll constantly bounce between the next two branches as the ring buffer is traversed. */
@@ -167,8 +178,10 @@ int aws_ring_buffer_acquire_up_to(
         size_t returnable_size = space > requested_size ? requested_size : space;
 
         if (returnable_size >= minimum_size) {
-            aws_atomic_store_ptr(&ring_buf->head, head_cpy + returnable_size);
+            AWS_ATOMIC_STORE_PTR(head_cpy + returnable_size, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(head_cpy, returnable_size);
+            AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
             return AWS_OP_SUCCESS;
         }
         /* after N wraps */
@@ -178,31 +191,41 @@ int aws_ring_buffer_acquire_up_to(
 
         /* if you can vend the whole thing do it. Also prefer head space to tail space. */
         if (head_space >= requested_size) {
-            aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
+            AWS_ATOMIC_STORE_PTR(head_cpy + requested_size, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
+            AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
             return AWS_OP_SUCCESS;
         }
 
         if (tail_space > requested_size) {
-            aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
+            AWS_ATOMIC_STORE_PTR(ring_buf->allocation + requested_size, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
+            AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
             return AWS_OP_SUCCESS;
         }
 
         /* now vend as much as possible, once again preferring head space. */
         if (head_space >= minimum_size && head_space >= tail_space) {
             aws_atomic_store_ptr(&ring_buf->head, head_cpy + head_space);
+            AWS_ATOMIC_STORE_PTR(head_cpy + head_space, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(head_cpy, head_space);
+            AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
             return AWS_OP_SUCCESS;
         }
 
         if (tail_space > minimum_size) {
-            aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + tail_space - 1);
+            AWS_ATOMIC_STORE_PTR(ring_buf->allocation + tail_space - 1, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, tail_space - 1);
+            AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+            AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
             return AWS_OP_SUCCESS;
         }
     }
-
+    AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
     return aws_raise_error(AWS_ERROR_OOM);
 }
 

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -104,7 +104,7 @@ int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_s
         /* After N wraps */
     } else if (tail_cpy < head_cpy) {
         /* prefer the head space for efficiency. */
-        if ((size_t)(ring_buf->allocation_end - head_cpy) >= requested_size) {
+        if ((size_t)(ring_buf->allocation_end - head_cpy - 1) >= requested_size) {
             AWS_ATOMIC_STORE_PTR(head_cpy + requested_size, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
             AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
@@ -186,7 +186,7 @@ int aws_ring_buffer_acquire_up_to(
         }
         /* after N wraps */
     } else if (tail_cpy < head_cpy) {
-        size_t head_space = ring_buf->allocation_end - head_cpy;
+        size_t head_space = ring_buf->allocation_end - head_cpy - 1;
         size_t tail_space = tail_cpy - ring_buf->allocation;
 
         /* if you can vend the whole thing do it. Also prefer head space to tail space. */
@@ -208,7 +208,6 @@ int aws_ring_buffer_acquire_up_to(
 
         /* now vend as much as possible, once again preferring head space. */
         if (head_space >= minimum_size && head_space >= tail_space) {
-            aws_atomic_store_ptr(&ring_buf->head, head_cpy + head_space);
             AWS_ATOMIC_STORE_PTR(head_cpy + head_space, ring_buf, &ring_buf->head);
             *dest = aws_byte_buf_from_empty_array(head_cpy, head_space);
             AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -130,7 +130,7 @@ int aws_ring_buffer_acquire_up_to(
     size_t minimum_size,
     size_t requested_size,
     struct aws_byte_buf *dest) {
-    AWS_PRECONDITION(requested_size >= minimum_size)
+    AWS_PRECONDITION(minimum_size > 0 && requested_size >= minimum_size);
     AWS_PRECONDITION(aws_ring_buffer_is_valid(ring_buf));
     AWS_PRECONDITION(aws_byte_buf_is_valid(dest));
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -305,6 +305,13 @@ add_test_case(long_argument_parse)
 add_test_case(unqualified_argument_parse)
 add_test_case(unknown_argument_parse)
 
+add_test_case(ring_buffer_1_to_1_acquire_release_wraps_test)
+add_test_case(ring_buffer_release_after_full_test)
+add_test_case(ring_buffer_acquire_up_to_test)
+add_test_case(ring_buffer_acquire_tail_always_chases_head_test)
+add_test_case(ring_buffer_acquire_multi_threaded_test)
+add_test_case(ring_buffer_acquire_up_to_multi_threaded_test)
+
 generate_test_driver(${CMAKE_PROJECT_NAME}-tests)
 
 if (NOT MSVC)

--- a/tests/ring_buffer_test.c
+++ b/tests/ring_buffer_test.c
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/condition_variable.h>
+#include <aws/common/linked_list.h>
+#include <aws/common/mutex.h>
+#include <aws/common/ring_buffer.h>
+#include <aws/common/thread.h>
+#include <aws/testing/aws_test_harness.h>
+
+static int s_test_1_to_1_acquire_release_wraps(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_ring_buffer ring_buffer;
+    size_t buf_size = 16;
+    ASSERT_SUCCESS(aws_ring_buffer_init(&ring_buffer, allocator, buf_size));
+
+    struct aws_byte_buf vended_buffer;
+    AWS_ZERO_STRUCT(vended_buffer);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 4, &vended_buffer));
+    uint8_t *ptr = vended_buffer.buffer;
+    ASSERT_UINT_EQUALS(4, vended_buffer.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer));
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer));
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 4, &vended_buffer));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer.buffer);
+    ASSERT_UINT_EQUALS(4, vended_buffer.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer));
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer));
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer));
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer);
+
+    aws_ring_buffer_clean_up(&ring_buffer);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(ring_buffer_1_to_1_acquire_release_wraps_test, s_test_1_to_1_acquire_release_wraps)
+
+static int s_test_release_after_full(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_ring_buffer ring_buffer;
+    size_t buf_size = 16;
+    ASSERT_SUCCESS(aws_ring_buffer_init(&ring_buffer, allocator, buf_size));
+
+    struct aws_byte_buf vended_buffer_1;
+    AWS_ZERO_STRUCT(vended_buffer_1);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 12, &vended_buffer_1));
+    uint8_t *ptr = vended_buffer_1.buffer;
+    ASSERT_UINT_EQUALS(12, vended_buffer_1.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_1));
+
+    struct aws_byte_buf vended_buffer_2;
+    AWS_ZERO_STRUCT(vended_buffer_2);
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 4, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr + 12, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(4, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire(&ring_buffer, 1, &vended_buffer_1));
+
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_1);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_2);
+
+    aws_ring_buffer_clean_up(&ring_buffer);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(ring_buffer_release_after_full_test, s_test_release_after_full)
+
+static int s_test_acquire_up_to(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_ring_buffer ring_buffer;
+    size_t buf_size = 16;
+    ASSERT_SUCCESS(aws_ring_buffer_init(&ring_buffer, allocator, buf_size));
+
+    struct aws_byte_buf vended_buffer_1;
+    AWS_ZERO_STRUCT(vended_buffer_1);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire_up_to(&ring_buffer, 1, 12, &vended_buffer_1));
+    uint8_t *ptr = vended_buffer_1.buffer;
+    ASSERT_UINT_EQUALS(12, vended_buffer_1.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_1));
+
+    struct aws_byte_buf vended_buffer_2;
+    AWS_ZERO_STRUCT(vended_buffer_2);
+
+    /* only 4 are available, so this should error. */
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire_up_to(&ring_buffer, 5, 8, &vended_buffer_2));
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire_up_to(&ring_buffer, 4, 8, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr + 12, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(4, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire_up_to(&ring_buffer, 1, 1, &vended_buffer_1));
+
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_1);
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_2);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire_up_to(&ring_buffer, 1, 8, &vended_buffer_1));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer_1.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer_1.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_1));
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire_up_to(&ring_buffer, 1, 8, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr + 8, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_1);
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_2);
+
+    aws_ring_buffer_clean_up(&ring_buffer);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(ring_buffer_acquire_up_to_test, s_test_acquire_up_to)
+
+static int s_test_acquire_tail_always_chases_head(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_ring_buffer ring_buffer;
+    size_t buf_size = 16;
+    ASSERT_SUCCESS(aws_ring_buffer_init(&ring_buffer, allocator, buf_size));
+
+    struct aws_byte_buf vended_buffer_1;
+    AWS_ZERO_STRUCT(vended_buffer_1);
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 12, &vended_buffer_1));
+    uint8_t *ptr = vended_buffer_1.buffer;
+    ASSERT_UINT_EQUALS(12, vended_buffer_1.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_1));
+
+    struct aws_byte_buf vended_buffer_2;
+    AWS_ZERO_STRUCT(vended_buffer_2);
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 4, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr + 12, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(4, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire(&ring_buffer, 1, &vended_buffer_1));
+
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_1);
+
+    /* we should turn over right here*/
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer_1));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer_1.buffer);
+    ASSERT_UINT_EQUALS(8, vended_buffer_1.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_1));
+
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_2);
+
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer_2));
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 7, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr + 8, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(7, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+    /* tail will flip here. */
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_1);
+
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer_1));
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 7, &vended_buffer_1));
+    ASSERT_PTR_EQUALS(ptr, vended_buffer_1.buffer);
+    ASSERT_UINT_EQUALS(7, vended_buffer_1.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_1));
+
+    aws_ring_buffer_release(&ring_buffer, &vended_buffer_2);
+
+    ASSERT_ERROR(AWS_ERROR_OOM, aws_ring_buffer_acquire(&ring_buffer, 8, &vended_buffer_2));
+
+    ASSERT_SUCCESS(aws_ring_buffer_acquire(&ring_buffer, 7, &vended_buffer_2));
+    ASSERT_PTR_EQUALS(ptr + 7, vended_buffer_2.buffer);
+    ASSERT_UINT_EQUALS(7, vended_buffer_2.capacity);
+    ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
+    aws_ring_buffer_clean_up(&ring_buffer);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(ring_buffer_acquire_tail_always_chases_head_test, s_test_acquire_tail_always_chases_head)
+
+struct mt_test_data {
+    struct aws_ring_buffer ring_buf;
+    struct aws_linked_list buffer_queue;
+    struct aws_mutex mutex;
+    struct aws_condition_variable termination_signal;
+    int consumer_count;
+    int max_count;
+    bool consumer_finished;
+    bool match_failed;
+};
+
+struct mt_test_buffer_node {
+    struct aws_linked_list_node node;
+    struct aws_byte_buf buf;
+};
+
+/* why so high? because the up_to allocs can get REALLY fragmented. */
+#define MT_BUFFER_COUNT 60
+#define MT_TEST_BUFFER_SIZE 16
+
+static void s_consumer_thread(void *args) {
+    struct mt_test_data *test_data = args;
+
+    while (test_data->consumer_count < test_data->max_count) {
+        aws_mutex_lock(&test_data->mutex);
+
+        struct aws_linked_list_node *node = NULL;
+
+        if (!aws_linked_list_empty(&test_data->buffer_queue)) {
+            node = aws_linked_list_pop_front(&test_data->buffer_queue);
+        }
+
+        aws_mutex_unlock(&test_data->mutex);
+
+        if (!node) {
+            continue;
+        }
+
+        struct mt_test_buffer_node *buffer_node = AWS_CONTAINER_OF(node, struct mt_test_buffer_node, node);
+
+        char counter_data[MT_TEST_BUFFER_SIZE + 1];
+        AWS_ZERO_ARRAY(counter_data);
+
+        size_t written = 0;
+        int num_to_write = test_data->consumer_count++;
+        /* all this does is print count out as far as it can to fill the buffer. */
+        while (written < buffer_node->buf.capacity) {
+            int bytes_written =
+                snprintf(counter_data + written, buffer_node->buf.capacity - written, "%d", num_to_write);
+
+            if (bytes_written > 0 && bytes_written < (int)(buffer_node->buf.capacity - written)) {
+                written += bytes_written;
+            } else {
+                break;
+            }
+        }
+
+        int not_matched = memcmp(buffer_node->buf.buffer, counter_data, written);
+
+        if (not_matched) {
+            fprintf(stderr, "match failed!\n");
+            fprintf(stderr, "produced buffer was ");
+            fwrite(buffer_node->buf.buffer, 1, buffer_node->buf.capacity, stderr);
+            fprintf(stderr, " but we were expecting %s\n", counter_data);
+            test_data->match_failed = true;
+            aws_ring_buffer_release(&test_data->ring_buf, &buffer_node->buf);
+            break;
+        }
+
+        aws_ring_buffer_release(&test_data->ring_buf, &buffer_node->buf);
+    }
+
+    aws_mutex_lock(&test_data->mutex);
+    test_data->consumer_finished = true;
+    aws_mutex_unlock(&test_data->mutex);
+
+    aws_condition_variable_notify_one(&test_data->termination_signal);
+}
+
+static bool s_termination_predicate(void *args) {
+    struct mt_test_data *test_data = args;
+
+    return test_data->consumer_finished;
+}
+
+static int s_acquire_up_to_wrapper(struct aws_ring_buffer *ring_buf, size_t requested, struct aws_byte_buf *dest) {
+    if (requested >= 4) {
+        return aws_ring_buffer_acquire_up_to(ring_buf, 4, requested, dest);
+    }
+
+    return aws_ring_buffer_acquire_up_to(ring_buf, 1, requested, dest);
+}
+
+static int s_test_acquire_any_muti_threaded(
+    struct aws_allocator *allocator,
+    int (*acquire_fn)(struct aws_ring_buffer *, size_t, struct aws_byte_buf *)) {
+    /* spin up a consumer thread, let current thread be the producer. Let them fight it out and give a chance
+     * for race conditions to happen and explode the universe. */
+
+    struct mt_test_data test_data = {
+        .match_failed = false,
+        .consumer_count = 0,
+        .mutex = AWS_MUTEX_INIT,
+        .max_count = 1000000,
+        .consumer_finished = false,
+        .termination_signal = AWS_CONDITION_VARIABLE_INIT,
+    };
+
+    static struct mt_test_buffer_node s_buffer_nodes[MT_BUFFER_COUNT];
+
+    /* 3 16 byte acquirable buffers + 15 bytes == 54 */
+    ASSERT_SUCCESS(aws_ring_buffer_init(&test_data.ring_buf, allocator, 3 * MT_TEST_BUFFER_SIZE + 15));
+    aws_linked_list_init(&test_data.buffer_queue);
+
+    struct aws_thread consumer_thread;
+
+    ASSERT_SUCCESS(aws_thread_init(&consumer_thread, allocator));
+    ASSERT_SUCCESS(aws_thread_launch(&consumer_thread, s_consumer_thread, &test_data, NULL));
+
+    int counter = 0;
+
+    /* consumer_finished isn't protected and we don't need it to be immediately and it won't rip,
+     * we just need it eventually if the consumer thread fails prematurely. */
+    while (counter < test_data.max_count && !test_data.consumer_finished) {
+        struct aws_byte_buf dest;
+        AWS_ZERO_STRUCT(dest);
+
+        if (!acquire_fn(&test_data.ring_buf, MT_TEST_BUFFER_SIZE, &dest)) {
+            size_t written = 0;
+            memset(dest.buffer, 0, dest.capacity);
+            /* all this does is print count out as far as it can to fill the buffer. */
+            while (written < dest.capacity) {
+                int bytes_written = snprintf((char *)dest.buffer + written, dest.capacity - written, "%d", counter);
+
+                if (bytes_written > 0 && bytes_written < (int)(dest.capacity - written)) {
+                    written += bytes_written;
+                } else {
+                    break;
+                }
+            }
+
+            int index = counter % MT_BUFFER_COUNT;
+            s_buffer_nodes[index].buf = dest;
+            counter++;
+
+            aws_mutex_lock(&test_data.mutex);
+            aws_linked_list_push_back(&test_data.buffer_queue, &s_buffer_nodes[index].node);
+            aws_mutex_unlock(&test_data.mutex);
+        }
+    }
+
+    aws_mutex_lock(&test_data.mutex);
+    aws_condition_variable_wait_pred(
+        &test_data.termination_signal, &test_data.mutex, s_termination_predicate, &test_data);
+    aws_mutex_unlock(&test_data.mutex);
+
+    aws_ring_buffer_clean_up(&test_data.ring_buf);
+    aws_thread_clean_up(&consumer_thread);
+
+    ASSERT_FALSE(test_data.match_failed);
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_test_acquire_multi_threaded(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    return s_test_acquire_any_muti_threaded(allocator, aws_ring_buffer_acquire);
+}
+
+AWS_TEST_CASE(ring_buffer_acquire_multi_threaded_test, s_test_acquire_multi_threaded)
+
+static int s_test_acquire_up_to_multi_threaded(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    return s_test_acquire_any_muti_threaded(allocator, s_acquire_up_to_wrapper);
+}
+
+AWS_TEST_CASE(ring_buffer_acquire_up_to_multi_threaded_test, s_test_acquire_up_to_multi_threaded)


### PR DESCRIPTION
*Description of changes:*

1. Adds invariants for the `aws_ring_buffer`;
2. Adds pre and post conditions to `aws_ring_buffer_init` and `aws_ring_buffer_acquire`;
3. Fix possible invalid memory accesses;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
