### PR TITLE
Implement aws_hash_table_remove_element

### DIFF
--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -240,6 +240,13 @@ typedef long aws_off_t;
 
 AWS_STATIC_ASSERT(sizeof(int64_t) >= sizeof(aws_off_t));
 
+/**
+ * from a pointer and a type of the struct containing the node
+ * this will get you back to the pointer of the object. member is the name of
+ * the instance of struct aws_linked_list_node in your struct.
+ */
+#define AWS_CONTAINER_OF(ptr, type, member) ((type *)((uint8_t *)(ptr)-offsetof(type, member)))
+
 /*
  * Due to the recursive inclusion of error.h and common.h, we need to define these
  * before including error.h

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -303,6 +303,17 @@ int aws_hash_table_remove(
     int *was_present);
 
 /**
+ * Removes element already known (typically by find()).
+ *
+ * p_value should point to a valid element returned by create() or find().
+ *
+ * NOTE: DO NOT call this method from inside of a aws_hash_table_foreach callback, return
+ * AWS_COMMON_HASH_TABLE_ITER_DELETE instead.
+ */
+AWS_COMMON_API
+int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value);
+
+/**
  * Iterates through every element in the map and invokes the callback on
  * that item. Iteration is performed in an arbitrary, implementation-defined
  * order, and is not guaranteed to be consistent across invocations.

--- a/include/aws/common/linked_list.h
+++ b/include/aws/common/linked_list.h
@@ -20,13 +20,6 @@
 
 #include <stddef.h>
 
-/**
- * from a pointer and a type of the struct containing the node
- * this will get you back to the pointer of the object. member is the name of
- * the instance of struct aws_linked_list_node in your struct.
- */
-#define AWS_CONTAINER_OF(ptr, type, member) ((type *)((uint8_t *)(ptr)-offsetof(type, member)))
-
 struct aws_linked_list_node {
     struct aws_linked_list_node *next;
     struct aws_linked_list_node *prev;

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -686,6 +686,19 @@ int aws_hash_table_remove(
     return AWS_OP_SUCCESS;
 }
 
+int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+    AWS_PRECONDITION(p_value);
+
+    struct hash_table_state *state = map->p_impl;
+    struct hash_table_entry *entry = AWS_CONTAINER_OF(p_value, struct hash_table_entry, element);
+
+    s_remove_entry(state, entry);
+
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    return AWS_OP_SUCCESS;
+}
+
 int aws_hash_table_foreach(
     struct aws_hash_table *map,
     int (*callback)(void *context, struct aws_hash_element *pElement),

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -99,6 +99,11 @@ static int s_test_hash_table_create_find_fn(struct aws_allocator *allocator, voi
         TEST_VAL_STR_2);
 
     ASSERT_HASH_TABLE_ENTRY_COUNT(&hash_table, 2);
+
+    err_code = aws_hash_table_remove_element(&hash_table, pElem);
+    ASSERT_SUCCESS(err_code, "Hash Map remove element should have succeeded.");
+    ASSERT_HASH_TABLE_ENTRY_COUNT(&hash_table, 1);
+
     aws_hash_table_clean_up(&hash_table);
     return 0;
 }
@@ -211,6 +216,13 @@ static int s_test_hash_table_string_create_find_fn(struct aws_allocator *allocat
         ((struct aws_string *)pElem->value)->len,
         "Returned value for binary bytes should have been %s",
         "hunter2");
+
+    aws_string_destroy((struct aws_string *)pElem->key);
+    aws_string_destroy(pElem->value);
+    ret = aws_hash_table_remove_element(&hash_table, pElem);
+    ASSERT_SUCCESS(ret, "Hash Map remove element should have succeeded.");
+    ASSERT_HASH_TABLE_ENTRY_COUNT(&hash_table, 2);
+
     aws_hash_table_clean_up(&hash_table);
 
     return 0;


### PR DESCRIPTION
Helpful if you're conditionally removing an element from a table based on it's value.

Use case: In HPACK, I need to remove an element from the dynamic table only if it's value pointer is exactly what I want it to be. Therefore, I call find, check the value, and remove.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
