### PR TITLE
Revert "Add typecast (#408)"

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -469,7 +469,7 @@ AWS_EXTERN_C_END
 /**
  */
 #define AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(literal)                                                                 \
-    (struct aws_byte_cursor) { .ptr = (uint8_t *)(const char *)(literal), .len = sizeof(literal) - 1 }
+    { .ptr = (uint8_t *)(const char *)(literal), .len = sizeof(literal) - 1 }
 
 /**
  * For creating a byte buffer from a null-terminated string literal.


### PR DESCRIPTION
This reverts commit d994a57bc5c38c99554462ce0010c1b9173c2fdf.

Turns out this breaks using the macro as a designated initializer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
