### PR TITLE
Ensure AWS_OP_ERR and AWS_OP_SUCCESS use same abbreviation scheme

### DIFF
--- a/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_add_size_checked/aws_add_size_checked_harness.c
@@ -10,7 +10,7 @@
  *
  * Assertions:
  *     - r does not overflow, if aws_add_u32_checked or
- *       aws_add_u64_checked functions return AWS_OP_SUCCESS
+ *       aws_add_u64_checked functions return AWS_OP_SUCC
  */
 void aws_add_size_checked_harness() {
     if (nondet_bool()) {

--- a/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_back/aws_array_list_back_harness.c
@@ -38,7 +38,7 @@ void aws_array_list_back_harness() {
     size_t malloc_size;
     __CPROVER_assume(malloc_size <= list.item_size);
     void *val = can_fail_malloc(malloc_size);
-    if (aws_array_list_back(&list, val) == AWS_OP_SUCCESS) {
+    if (aws_array_list_back(&list, val) == AWS_OP_SUCC) {
         /* In the case aws_array_list_back is successful, we can ensure the list isn't empty */
         assert(list.data != NULL);
         assert(list.length != 0);

--- a/.cbmc-batch/jobs/aws_byte_buf_append/aws_byte_buf_append_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append/aws_byte_buf_append_harness.c
@@ -33,7 +33,7 @@ void aws_byte_buf_append_harness() {
     /* save current state of the data structure */
     struct aws_byte_cursor from_old = from;
 
-    if (aws_byte_buf_append(&to, &from) == AWS_OP_SUCCESS) {
+    if (aws_byte_buf_append(&to, &from) == AWS_OP_SUCC) {
         assert(to.len == to_old.len + from.len);
     } else {
         /* if the operation return an error, to must not change */

--- a/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_dynamic/aws_byte_buf_append_dynamic_harness.c
@@ -31,7 +31,7 @@ void aws_byte_buf_append_dynamic_harness() {
     /* save current state of the data structure */
     struct aws_byte_cursor from_old = from;
 
-    if (aws_byte_buf_append_dynamic(&to, &from) == AWS_OP_SUCCESS) {
+    if (aws_byte_buf_append_dynamic(&to, &from) == AWS_OP_SUCC) {
         assert(to.len == to_old.len + from.len);
     } else {
         /* if the operation return an error, to must not change */

--- a/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_append_with_lookup/aws_byte_buf_append_with_lookup_harness.c
@@ -38,7 +38,7 @@ void aws_byte_buf_append_with_lookup_harness() {
      * be at least 256 bytes.
      */
     uint8_t *lookup_table[256];
-    if (aws_byte_buf_append_with_lookup(&to, &from, lookup_table) == AWS_OP_SUCCESS) {
+    if (aws_byte_buf_append_with_lookup(&to, &from, lookup_table) == AWS_OP_SUCC) {
         assert(to.len == to_old.len + from.len);
     } else {
         /* if the operation return an error, to must not change */

--- a/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/aws_byte_buf_init_copy_from_cursor_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_init_copy_from_cursor/aws_byte_buf_init_copy_from_cursor_harness.c
@@ -32,7 +32,7 @@ void aws_byte_buf_init_copy_from_cursor_harness() {
 
     ASSUME_CAN_FAIL_ALLOCATOR(allocator);
 
-    if (aws_byte_buf_init_copy_from_cursor(&buf, allocator, cursor) == AWS_OP_SUCCESS) {
+    if (aws_byte_buf_init_copy_from_cursor(&buf, allocator, cursor) == AWS_OP_SUCC) {
         /* assertions */
         assert(aws_byte_buf_is_valid(&buf));
         assert(aws_byte_cursor_is_valid(&cursor));

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
@@ -24,7 +24,7 @@ void aws_byte_buf_reserve_harness() {
     struct aws_byte_buf old = buf;
     size_t requested_capacity;
 
-    if (aws_byte_buf_reserve(&buf, requested_capacity) == AWS_OP_SUCCESS) {
+    if (aws_byte_buf_reserve(&buf, requested_capacity) == AWS_OP_SUCC) {
         assert(buf.capacity >= requested_capacity);
         assert(aws_byte_buf_has_allocator(&buf));
     }

--- a/.cbmc-batch/jobs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
+++ b/.cbmc-batch/jobs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
@@ -25,7 +25,7 @@ void aws_byte_buf_reserve_relative_harness() {
     size_t requested_capacity;
     int rval = aws_byte_buf_reserve_relative(&buf, requested_capacity);
 
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         assert(buf.capacity >= (old.len + requested_capacity));
         assert(aws_byte_buf_has_allocator(&buf));
     }

--- a/.cbmc-batch/jobs/aws_hash_table_create/aws_hash_table_create_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_create/aws_hash_table_create_harness.c
@@ -40,7 +40,7 @@ void aws_hash_table_create_harness() {
 
     int rval = aws_hash_table_create(&map, key, get_p_elem ? &p_elem : NULL, track_was_created ? &was_created : NULL);
     assert(aws_hash_table_is_valid(&map));
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         if (track_was_created) {
             assert(map.p_impl->entry_count == old_state.entry_count + was_created);
         } else {

--- a/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_find/aws_hash_table_find_harness.c
@@ -35,7 +35,7 @@ void aws_hash_table_find_harness() {
     void *key;
     struct aws_hash_element *p_elem;
     int rval = aws_hash_table_find(&map, key, nondet_bool() ? &p_elem : NULL);
-    assert(rval == AWS_OP_SUCCESS);
+    assert(rval == AWS_OP_SUCC);
     if (p_elem) {
         assert(AWS_OBJECT_PTR_IS_READABLE(p_elem));
         assert(p_elem->key == key || uninterpreted_equals(p_elem->key, key));

--- a/.cbmc-batch/jobs/aws_hash_table_init-bounded/aws_hash_table_init_bounded_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_init-bounded/aws_hash_table_init_bounded_harness.c
@@ -34,7 +34,7 @@ void aws_hash_table_init_bounded_harness() {
     aws_hash_callback_destroy_fn *destroy_value_fn;
     struct aws_hash_table map;
     int rval = aws_hash_table_init(&map, allocator, size, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn);
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         assert(aws_hash_table_is_valid(&map));
         struct hash_table_state *impl = map.p_impl;
         assert_all_zeroes(&impl->slots[0], impl->size * sizeof(impl->slots[0]));

--- a/.cbmc-batch/jobs/aws_hash_table_init-unbounded/aws_hash_table_init_unbounded_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_init-unbounded/aws_hash_table_init_unbounded_harness.c
@@ -34,7 +34,7 @@ void aws_hash_table_init_unbounded_harness() {
     aws_hash_callback_destroy_fn *destroy_value_fn;
     struct aws_hash_table map;
     int rval = aws_hash_table_init(&map, allocator, size, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn);
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         assert(aws_hash_table_is_valid(&map));
     }
 }

--- a/.cbmc-batch/jobs/aws_hash_table_put/aws_hash_table_put_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_put/aws_hash_table_put_harness.c
@@ -40,7 +40,7 @@ void aws_hash_table_put_harness() {
     struct hash_table_state old_state = *map.p_impl;
 
     int rval = aws_hash_table_put(&map, key, value, track_was_created ? &was_created : NULL);
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         if (track_was_created) {
             assert(map.p_impl->entry_count == old_state.entry_count + was_created);
         } else {

--- a/.cbmc-batch/jobs/aws_hash_table_remove/aws_hash_table_remove_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_remove/aws_hash_table_remove_harness.c
@@ -41,7 +41,7 @@ void aws_hash_table_remove_harness() {
 
     int rval = aws_hash_table_remove(&map, key, get_p_elem ? &p_elem : NULL, track_was_present ? &was_present : NULL);
     assert(aws_hash_table_is_valid(&map));
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         if (track_was_present) {
             assert(map.p_impl->entry_count == old_state.entry_count - was_present);
         } else {

--- a/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/.cbmc-batch/jobs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -10,7 +10,7 @@
  *
  * Assertions:
  *     - r does not overflow, if aws_mul_u32_checked or
- *       aws_mul_u64_checked functions return AWS_OP_SUCCESS
+ *       aws_mul_u64_checked functions return AWS_OP_SUCC
  */
 void aws_mul_size_checked_harness() {
     if (nondet_bool()) {

--- a/.cbmc-batch/jobs/aws_round_up_to_power_of_two/aws_round_up_to_power_of_two_harness.c
+++ b/.cbmc-batch/jobs/aws_round_up_to_power_of_two/aws_round_up_to_power_of_two_harness.c
@@ -27,7 +27,7 @@ void aws_round_up_to_power_of_two_harness() {
 #else
 #    error
 #endif
-    if (rval == AWS_OP_SUCCESS) {
+    if (rval == AWS_OP_SUCC) {
         assert(popcount == 1);
         assert(test_val <= result);
         assert(test_val >= result >> 1);

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -61,7 +61,7 @@ static struct aws_allocator s_can_fail_allocator_static = {
 
 void *bounded_calloc(size_t num, size_t size) {
     size_t required_bytes;
-    __CPROVER_assume(aws_mul_size_checked(num, size, &required_bytes) == AWS_OP_SUCCESS);
+    __CPROVER_assume(aws_mul_size_checked(num, size, &required_bytes) == AWS_OP_SUCC);
     __CPROVER_assume(required_bytes <= MAX_MALLOC);
     return calloc(num, size);
 }

--- a/.cbmc-batch/source/utils.c
+++ b/.cbmc-batch/source/utils.c
@@ -104,7 +104,7 @@ void assert_byte_cursor_equivalence(
 void save_byte_from_hash_table(const struct aws_hash_table *map, struct store_byte_from_buffer *storage) {
     struct hash_table_state *state = map->p_impl;
     size_t size_in_bytes;
-    __CPROVER_assume(hash_table_state_required_bytes(state->size, &size_in_bytes) == AWS_OP_SUCCESS);
+    __CPROVER_assume(hash_table_state_required_bytes(state->size, &size_in_bytes) == AWS_OP_SUCC);
     save_byte_from_array((uint8_t *)state, size_in_bytes, storage);
 }
 

--- a/.cbmc-batch/stubs/aws_hash_table_find_override.c
+++ b/.cbmc-batch/stubs/aws_hash_table_find_override.c
@@ -26,5 +26,5 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
         *p_elem = &entry->element;
     }
     AWS_POSTCONDITION(aws_hash_table_is_valid(map));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/.cbmc-batch/stubs/s_emplace_item_override.c
+++ b/.cbmc-batch/stubs/s_emplace_item_override.c
@@ -17,7 +17,7 @@
  * If was_created is non-NULL, *was_created is set to 0 if an existing
  * element was found, or 1 is a new element was created.
  *
- * Returns AWS_OP_SUCCESS if an item was found or created.
+ * Returns AWS_OP_SUCC if an item was found or created.
  * Raises AWS_ERROR_OOM if hash table expansion was required and memory
  * allocation failed.
  */

--- a/.cbmc-batch/stubs/s_expand_table_override.c
+++ b/.cbmc-batch/stubs/s_expand_table_override.c
@@ -13,7 +13,7 @@ int __CPROVER_file_local_hash_table_c_s_expand_table(struct aws_hash_table *map)
     struct hash_table_state *old_state = map->p_impl;
     struct hash_table_state template = *old_state;
 
-    if (__CPROVER_file_local_hash_table_c_s_update_template_size(&template, template.size * 2) != AWS_OP_SUCCESS) {
+    if (__CPROVER_file_local_hash_table_c_s_update_template_size(&template, template.size * 2) != AWS_OP_SUCC) {
         return AWS_OP_ERR;
     }
 
@@ -37,5 +37,5 @@ int __CPROVER_file_local_hash_table_c_s_expand_table(struct aws_hash_table *map)
     __CPROVER_assume(aws_hash_table_is_valid(map));
     size_t empty_slot_idx;
     __CPROVER_assume(aws_hash_table_has_an_empty_slot(map, &empty_slot_idx));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Every API has a specific set of styles and conventions. We'll outline them here.
 library in the AWS C SDK ecosystem.
 
 #### Error handling
-Every function that returns an `int` type, returns `AWS_OP_SUCCESS` ( 0 ) or `AWS_OP_ERR` (-1) on failure. To retrieve
+Every function that returns an `int` type, returns `AWS_OP_SUCC` ( 0 ) or `AWS_OP_ERR` (-1) on failure. To retrieve
 the error code, use the function `aws_last_error()`. Each error code also has a corresponding error string that can be
 accessed via the `aws_error_str()` function.
 
@@ -67,7 +67,7 @@ functions are available, the variants should be named like `new_x` or `destroy_x
 
 Any function that initializes an existing object will be suffixed with `init`. These objects will have a corresponding
 `clean_up` function if necessary. In these cases, you are responsible for making the decisions for how your object is
-allocated. The `init` functions return `AWS_OP_SUCCESS` ( 0 ) or `AWS_OP_ERR` (-1) on failure. If several `init` or
+allocated. The `init` functions return `AWS_OP_SUCC` ( 0 ) or `AWS_OP_ERR` (-1) on failure. If several `init` or
 `clean_up` functions are available, they should be named like `init_x` or `clean_up_x` (e.g. `init_static` or
 `clean_up_secure`).
 
@@ -95,7 +95,7 @@ a thread barrier it should be a complete ownership hand-off. Bias towards, "if I
 * Do not expose blocking APIs.
 
 ### Error Handling
-* For APIs returning an `int` error code. The only acceptable return types are `AWS_OP_SUCCESS` and `AWS_OP_ERR`. Before
+* For APIs returning an `int` error code. The only acceptable return types are `AWS_OP_SUCC` and `AWS_OP_ERR`. Before
 returning control to the caller, if you have an error to raise, use the `aws_raise_error()` function.
 * For APIs returning an allocated instance of an object, return the memory on success, and `NULL` on failure. Before
 returning control to the caller, if you have an error to raise, use the `aws_raise_error()` function.

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -53,7 +53,7 @@ int aws_array_list_init_dynamic(
     AWS_FATAL_ASSERT(list->current_size == 0 || list->data);
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_STATIC_IMPL
@@ -83,7 +83,7 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
         return false;
     }
     size_t required_size = 0;
-    bool required_size_is_valid = (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS);
+    bool required_size_is_valid = (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCC);
     bool current_size_is_valid = (list->current_size >= required_size);
     bool data_is_valid = ((list->current_size == 0 && list->data == NULL) || AWS_MEM_IS_WRITABLE(list->data, list->current_size));
     return required_size_is_valid && current_size_is_valid && data_is_valid;
@@ -126,7 +126,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -139,7 +139,7 @@ int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list) {
     if (aws_array_list_length(list) > 0) {
         aws_array_list_pop_front_n(list, 1);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -177,7 +177,7 @@ int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *va
 
         memcpy(val, (void *)((uint8_t *)list->data + last_item_offset), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -196,7 +196,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
         memset((void *)((uint8_t *)list->data + last_item_offset), 0, list->item_size);
         list->length--;
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -262,7 +262,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
@@ -275,7 +275,7 @@ int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, vo
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return aws_raise_error(AWS_ERROR_INVALID_INDEX);
@@ -295,14 +295,14 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
         return AWS_OP_ERR;
     }
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size));
-    
+
     if (aws_array_list_ensure_capacity(list, index)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_ERR;
@@ -324,7 +324,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_STATIC_IMPL

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -148,7 +148,7 @@ bool aws_byte_cursor_is_valid(const struct aws_byte_cursor *cursor);
  * aws_byte_buf_clean_up(dest).
  * Dest capacity and len will be equal to the src len. Allocator of the dest will be identical with parameter allocator.
  * If src buffer is null the dest will have a null buffer with a len and a capacity of 0
- * Returns AWS_OP_SUCCESS in case of success or AWS_OP_ERR when memory can't be allocated.
+ * Returns AWS_OP_SUCC in case of success or AWS_OP_ERR when memory can't be allocated.
  */
 AWS_COMMON_API
 int aws_byte_buf_init_copy_from_cursor(

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -251,7 +251,7 @@ AWS_STATIC_ASSERT(sizeof(int64_t) >= sizeof(aws_off_t));
  * Due to the recursive inclusion of error.h and common.h, we need to define these
  * before including error.h
  */
-#define AWS_OP_SUCCESS (0)
+#define AWS_OP_SUCC (0)
 #define AWS_OP_ERR (-1)
 
 #include <aws/common/error.h>
@@ -307,7 +307,7 @@ AWS_COMMON_API
 void *aws_mem_acquire(struct aws_allocator *allocator, size_t size);
 
 /**
- * Allocates a block of memory for an array of num elements, each of them size bytes long, and initializes all its bits to zero. 
+ * Allocates a block of memory for an array of num elements, each of them size bytes long, and initializes all its bits to zero.
  * Returns null on failure.
  */
 AWS_COMMON_API

--- a/include/aws/common/date_time.h
+++ b/include/aws/common/date_time.h
@@ -82,7 +82,7 @@ AWS_COMMON_API void aws_date_time_init_epoch_millis(struct aws_date_time *dt, ui
 AWS_COMMON_API void aws_date_time_init_epoch_secs(struct aws_date_time *dt, double sec_ms);
 
 /**
- * Initializes dt to be the time represented by date_str in format 'fmt'. Returns AWS_OP_SUCCESS if the
+ * Initializes dt to be the time represented by date_str in format 'fmt'. Returns AWS_OP_SUCC if the
  * string was successfully parsed, returns  AWS_OP_ERR if parsing failed.
  *
  * Notes for AWS_DATE_FORMAT_RFC822:

--- a/include/aws/common/error.h
+++ b/include/aws/common/error.h
@@ -86,7 +86,7 @@ AWS_STATIC_IMPL
 int aws_raise_error(int err) {
     /*
      * Certain static analyzers can't see through the out-of-line call to aws_raise_error,
-     * and assume that this might return AWS_OP_SUCCESS. We'll put the return inline just
+     * and assume that this might return AWS_OP_SUCC. We'll put the return inline just
      * to help with their assumptions.
      */
 

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -236,7 +236,7 @@ void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents);
 /**
  * Attempts to locate an element at key.  If the element is found, a
  * pointer to the value is placed in *p_elem; if it is not found,
- * *pElem is set to NULL. Either way, AWS_OP_SUCCESS is returned.
+ * *pElem is set to NULL. Either way, AWS_OP_SUCC is returned.
  *
  * This method does not change the state of the hash table. Therefore, it
  * is safe to call _find from multiple threads on the same hash table,
@@ -259,7 +259,7 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
  * If was_created is non-NULL, *was_created is set to 0 if an existing
  * element was found, or 1 is a new element was created.
  *
- * Returns AWS_OP_SUCCESS if an item was found or created.
+ * Returns AWS_OP_SUCC if an item was found or created.
  * Raises AWS_ERROR_OOM if hash table expansion was required and memory
  * allocation failed.
  */
@@ -278,14 +278,14 @@ int aws_hash_table_create(
  * If was_created is non-NULL, *was_created is set to 0 if an existing
  * element was found, or 1 is a new element was created.
  *
- * Returns AWS_OP_SUCCESS if an item was found or created.
+ * Returns AWS_OP_SUCC if an item was found or created.
  * Raises AWS_ERROR_OOM if hash table expansion was required and memory
  */
 AWS_COMMON_API
 int aws_hash_table_put(struct aws_hash_table *map, const void *key, void *value, int *was_created);
 
 /**
- * Removes element at key. Always returns AWS_OP_SUCCESS.
+ * Removes element at key. Always returns AWS_OP_SUCC.
  *
  * If pValue is non-NULL, the existing value (if any) is moved into
  * (*value) before removing from the table, and destroy_fn is _not_

--- a/include/aws/common/lru_cache.h
+++ b/include/aws/common/lru_cache.h
@@ -58,8 +58,8 @@ void aws_lru_cache_clean_up(struct aws_lru_cache *cache);
 
 /**
  * Finds element in the cache by key. If found, it will become most-recently
- * used, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
- * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be
+ * used, *p_value will hold the stored value, and AWS_OP_SUCC will be
+ * returned. If not found, AWS_OP_SUCC will be returned and *p_value will be
  * NULL.
  *
  * If any errors occur AWS_OP_ERR will be returned.

--- a/include/aws/common/math.cbmc.inl
+++ b/include/aws/common/math.cbmc.inl
@@ -38,13 +38,13 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (__CPROVER_overflow_mult(a, b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -58,13 +58,13 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (__CPROVER_overflow_mult(a, b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -78,13 +78,13 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (__CPROVER_overflow_plus(a, b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -98,13 +98,13 @@ AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (__CPROVER_overflow_plus(a, b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 #pragma CPROVER check pop

--- a/include/aws/common/math.fallback.inl
+++ b/include/aws/common/math.fallback.inl
@@ -30,13 +30,13 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (a > 0 && b >0 && a > (UINT64_MAX / b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -50,13 +50,13 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (a > 0 && b > 0 && a > (UINT32_MAX / b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -70,13 +70,13 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if ((b > 0) && (a > (UINT64_MAX - b)))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -90,11 +90,11 @@ AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if ((b > 0) && (a > (UINT32_MAX - b)))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a + b;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/include/aws/common/math.gcc_overflow.inl
+++ b/include/aws/common/math.gcc_overflow.inl
@@ -34,13 +34,13 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (__builtin_mul_overflow(a, b, r)) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -58,24 +58,24 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (__builtin_mul_overflow(a, b, r)) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (__builtin_add_overflow(a, b, r)) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -93,13 +93,13 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (__builtin_add_overflow(a, b, r)) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**

--- a/include/aws/common/math.gcc_x64_asm.inl
+++ b/include/aws/common/math.gcc_x64_asm.inl
@@ -41,7 +41,7 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     /* We can use inline assembly to do this efficiently on x86-64 and x86. */
@@ -58,7 +58,7 @@ AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (flag) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -84,7 +84,7 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     /* We can use inline assembly to do this efficiently on x86-64 and x86. */
@@ -104,12 +104,12 @@ AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (flag) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     /* We can use inline assembly to do this efficiently on x86-64 and x86. */
@@ -124,7 +124,7 @@ AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (flag) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -144,7 +144,7 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     /* We can use inline assembly to do this efficiently on x86-64 and x86. */
@@ -159,7 +159,7 @@ AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (flag) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -70,7 +70,7 @@ AWS_COMMON_API uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_COMMON_API int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
 
@@ -81,7 +81,7 @@ AWS_COMMON_API uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_COMMON_API int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
 
@@ -92,7 +92,7 @@ AWS_COMMON_API uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_COMMON_API int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
 
@@ -103,7 +103,7 @@ AWS_COMMON_API uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_COMMON_API int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
 
@@ -130,7 +130,7 @@ AWS_STATIC_IMPL size_t aws_mul_size_saturating(size_t a, size_t b) {
 
 /**
  * Multiplies a * b and returns the result in *r. If the result
- * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCCESS.
+ * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_size_checked(size_t a, size_t b, size_t *r) {
 #if SIZE_BITS == 32
@@ -157,7 +157,7 @@ AWS_STATIC_IMPL size_t aws_add_size_saturating(size_t a, size_t b) {
 
 /**
  * Adds a + b and returns the result in *r. If the result
- * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCCESS.
+ * overflows, returns AWS_OP_ERR; otherwise returns AWS_OP_SUCC.
  */
 
 AWS_STATIC_IMPL int aws_add_size_checked(size_t a, size_t b, size_t *r) {
@@ -185,7 +185,7 @@ AWS_STATIC_IMPL bool aws_is_power_of_two(const size_t x) {
 AWS_STATIC_IMPL int aws_round_up_to_power_of_two(size_t n, size_t *result) {
     if (n == 0) {
         *result = 1;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
     if (n > SIZE_MAX_POWER_OF_TWO) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
@@ -202,7 +202,7 @@ AWS_STATIC_IMPL int aws_round_up_to_power_of_two(size_t n, size_t *result) {
 #endif
     n++;
     *result = n;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 #if _MSC_VER

--- a/include/aws/common/math.msvc.inl
+++ b/include/aws/common/math.msvc.inl
@@ -33,7 +33,7 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     uint64_t out;
@@ -42,7 +42,7 @@ AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     if (out != 0) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -56,7 +56,7 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a * b overflows, returns AWS_OP_ERR; otherwise multiplies
- * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a * b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     uint32_t out;
@@ -65,18 +65,18 @@ AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (out != 0) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u64_checked(uint32_t a, uint32_t b, uint32_t *r) {
     if (_addcarry_u64(0, a, b, *r)) {
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -94,13 +94,13 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint32_t a, uint32_t b) {
 
 /**
  * If a + b overflows, returns AWS_OP_ERR; otherwise adds
- * a + b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ * a + b, returns the result in *r, and returns AWS_OP_SUCC.
  */
 AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
   if(_addcarry_u32(0, a, b, *r){
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**

--- a/include/aws/common/posix/common.inl
+++ b/include/aws/common/posix/common.inl
@@ -25,7 +25,7 @@ AWS_EXTERN_C_BEGIN
 static inline int aws_private_convert_and_raise_error_code(int error_code) {
     switch (error_code) {
         case 0:
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         case EINVAL:
             return aws_raise_error(AWS_ERROR_MUTEX_NOT_INIT);
         case EBUSY:

--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -127,7 +127,7 @@ bool aws_hash_iter_is_valid(const struct aws_hash_iter *iter) {
 /**
  * Determine the total number of bytes needed for a hash-table with
  * "size" slots. If the result would overflow a size_t, return
- * AWS_OP_ERR; otherwise, return AWS_OP_SUCCESS with the result in
+ * AWS_OP_ERR; otherwise, return AWS_OP_SUCC with the result in
  * "required_bytes".
  */
 AWS_STATIC_IMPL
@@ -142,7 +142,7 @@ int hash_table_state_required_bytes(size_t size, size_t *required_bytes) {
         return AWS_OP_ERR;
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 #endif /* AWS_COMMON_PRIVATE_HASH_TABLE_IMPL_H */

--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -38,7 +38,7 @@ struct aws_byte_buf;
 AWS_EXTERN_C_BEGIN
 
 /**
- * Initializes a ring buffer with an allocation of size `size`. Returns AWS_OP_SUCCESS on a successful initialization,
+ * Initializes a ring buffer with an allocation of size `size`. Returns AWS_OP_SUCC on a successful initialization,
  * AWS_OP_ERR otherwise.
  */
 AWS_COMMON_API int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct aws_allocator *allocator, size_t size);
@@ -49,7 +49,7 @@ AWS_COMMON_API int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct
 AWS_COMMON_API void aws_ring_buffer_clean_up(struct aws_ring_buffer *ring_buf);
 
 /**
- * Attempts to acquire `requested_size` buffer and stores the result in `dest` if successful. Returns AWS_OP_SUCCESS if
+ * Attempts to acquire `requested_size` buffer and stores the result in `dest` if successful. Returns AWS_OP_SUCC if
  * the requested size was available for use, AWS_OP_ERR otherwise.
  */
 AWS_COMMON_API int aws_ring_buffer_acquire(
@@ -59,7 +59,7 @@ AWS_COMMON_API int aws_ring_buffer_acquire(
 
 /**
  * Attempts to acquire `requested_size` buffer and stores the result in `dest` if successful. If not available, it will
- * attempt to acquire anywhere from 1 byte to `requested_size`. Returns AWS_OP_SUCCESS if some buffer space is available
+ * attempt to acquire anywhere from 1 byte to `requested_size`. Returns AWS_OP_SUCC if some buffer space is available
  * for use, AWS_OP_ERR otherwise.
  */
 AWS_COMMON_API int aws_ring_buffer_acquire_up_to(

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -160,7 +160,7 @@ static int total_failures;
 #define ASSERT_SUCCESS(condition, ...)                                                                                 \
     do {                                                                                                               \
         int assert_rv = (condition);                                                                                   \
-        if (assert_rv != AWS_OP_SUCCESS) {                                                                             \
+        if (assert_rv != AWS_OP_SUCC) {                                                                             \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0(                                                                                  \
                     "Expected success at %s; got return value %d with last error 0x%04x\n",                            \
@@ -433,7 +433,7 @@ static inline int enable_vt_mode(void) {
     if (!SetConsoleMode(hOut, dwMode)) {
         return AWS_OP_ERR;
     }
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 #else

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -43,7 +43,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
             list->current_size = ideal_size;
         }
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -70,7 +70,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         to->length = from->length;
         AWS_POSTCONDITION(aws_array_list_is_valid(from));
         AWS_POSTCONDITION(aws_array_list_is_valid(to));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
     /* if to is in dynamic mode, we can just reallocate it and copy */
     if (to->alloc != NULL) {
@@ -92,7 +92,7 @@ int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct a
         to->current_size = copy_size;
         AWS_POSTCONDITION(aws_array_list_is_valid(from));
         AWS_POSTCONDITION(aws_array_list_is_valid(to));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
@@ -156,7 +156,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
     }
 
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT item2, size_t item_size) {

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -37,7 +37,7 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
     buf->capacity = capacity;
     buf->allocator = allocator;
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allocator, const struct aws_byte_buf *src) {
@@ -49,7 +49,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
         AWS_ZERO_STRUCT(*dest);
         dest->allocator = allocator;
         AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     *dest = *src;
@@ -61,7 +61,7 @@ int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allo
     }
     memcpy(dest->buffer, src->buffer, src->len);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 bool aws_byte_buf_is_valid(const struct aws_byte_buf *const buf) {
@@ -158,7 +158,7 @@ int aws_byte_buf_init_copy_from_cursor(
         memcpy(dest->buffer, src.ptr, src.len);
     }
     AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 bool aws_byte_cursor_next_split(
@@ -240,7 +240,7 @@ int aws_byte_cursor_split_on_char_n(
         ++split_count;
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_byte_cursor_split_on_char(
@@ -268,7 +268,7 @@ int aws_byte_buf_cat(struct aws_byte_buf *dest, size_t number_of_args, ...) {
     }
 
     va_end(ap);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 bool aws_byte_cursor_eq(const struct aws_byte_cursor *a, const struct aws_byte_cursor *b) {
@@ -466,7 +466,7 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
     AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_byte_buf_append_with_lookup(
@@ -493,7 +493,7 @@ int aws_byte_buf_append_with_lookup(
 
     AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
@@ -588,7 +588,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 
     AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(from));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity) {
@@ -598,7 +598,7 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
 
     if (requested_capacity <= buffer->capacity) {
         AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     if (aws_mem_realloc(buffer->allocator, (void **)&buffer->buffer, buffer->capacity, requested_capacity)) {
@@ -609,7 +609,7 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
     buffer->capacity = requested_capacity;
 
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional_length) {

--- a/source/common.c
+++ b/source/common.c
@@ -166,13 +166,13 @@ int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize,
             return aws_raise_error(AWS_ERROR_OOM);
         }
         *ptr = newptr;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     /* Since the allocator doesn't support realloc, we'll need to emulate it
      * (inefficiently). */
     if (oldsize >= newsize) {
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     void *newptr = aws_mem_acquire(allocator, newsize);
@@ -188,7 +188,7 @@ int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize,
 
     *ptr = newptr;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /* Wraps a CFAllocator around aws_allocator. For Mac only. */

--- a/source/date_time.c
+++ b/source/date_time.c
@@ -314,7 +314,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
     }
 
     /* ISO8601 supports date only with no time portion. state ==ON_MONTH_DAY catches this case. */
-    return (state == FINISHED || state == ON_MONTH_DAY) && !error ? AWS_OP_SUCCESS : AWS_OP_ERR;
+    return (state == FINISHED || state == ON_MONTH_DAY) && !error ? AWS_OP_SUCC : AWS_OP_ERR;
 }
 
 static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struct tm *parsed_time) {
@@ -434,7 +434,7 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
     }
 
     /* ISO8601 supports date only with no time portion. state ==ON_MONTH_DAY catches this case. */
-    return (state == FINISHED || state == ON_MONTH_DAY) && !error ? AWS_OP_SUCCESS : AWS_OP_ERR;
+    return (state == FINISHED || state == ON_MONTH_DAY) && !error ? AWS_OP_SUCC : AWS_OP_ERR;
 }
 
 static int s_parse_rfc_822(
@@ -569,7 +569,7 @@ static int s_parse_rfc_822(
         }
     }
 
-    return error || state != ON_TZ ? AWS_OP_ERR : AWS_OP_SUCCESS;
+    return error || state != ON_TZ ? AWS_OP_ERR : AWS_OP_SUCC;
 }
 
 int aws_date_time_init_from_str_cursor(
@@ -644,7 +644,7 @@ int aws_date_time_init_from_str_cursor(
     dt->gmt_time = s_get_time_struct(dt, false);
     dt->local_time = s_get_time_struct(dt, true);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_date_time_init_from_str(
@@ -669,7 +669,7 @@ static inline int s_date_to_str(const struct tm *tm, const char *format_str, str
 
     output_buf->len += bytes_written;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_date_time_to_local_time_str(

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -84,7 +84,7 @@ int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length) {
 
     *encoded_length = temp;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
@@ -111,7 +111,7 @@ int aws_hex_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct 
     output->buffer[written] = '\0';
     output->len = encoded_len;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hex_encode_append_dynamic(
@@ -138,7 +138,7 @@ int aws_hex_encode_append_dynamic(
 
     output->len += encoded_len;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static int s_hex_decode_char_to_int(char character, uint8_t *int_val) {
@@ -170,7 +170,7 @@ int aws_hex_compute_decoded_len(size_t to_decode_len, size_t *decoded_len) {
     }
 
     *decoded_len = temp >> 1;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
@@ -216,7 +216,7 @@ int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct 
 
     output->len = decoded_length;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_base64_compute_encoded_len(size_t to_encode_len, size_t *encoded_len) {
@@ -238,7 +238,7 @@ int aws_base64_compute_encoded_len(size_t to_encode_len, size_t *encoded_len) {
 
     *encoded_len = tmp;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_base64_compute_decoded_len(const struct aws_byte_cursor *AWS_RESTRICT to_decode, size_t *decoded_len) {
@@ -250,7 +250,7 @@ int aws_base64_compute_decoded_len(const struct aws_byte_cursor *AWS_RESTRICT to
 
     if (len == 0) {
         *decoded_len = 0;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     if (AWS_UNLIKELY(len & 0x03)) {
@@ -272,7 +272,7 @@ int aws_base64_compute_decoded_len(const struct aws_byte_cursor *AWS_RESTRICT to
     }
 
     *decoded_len = (tmp / 4 - padding);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output) {
@@ -300,7 +300,7 @@ int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, stru
         output->len = encoded_length;
         aws_common_private_base64_encode_sse41(to_encode->ptr, output->buffer, to_encode->len);
         output->buffer[encoded_length] = 0;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     size_t buffer_length = to_encode->len;
@@ -338,7 +338,7 @@ int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, stru
     output->buffer[encoded_length] = 0;
 
     output->len = encoded_length;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static inline int s_base64_get_decoded_value(unsigned char to_decode, uint8_t *value, int8_t allow_sentinal) {
@@ -346,7 +346,7 @@ static inline int s_base64_get_decoded_value(unsigned char to_decode, uint8_t *v
     uint8_t decode_value = BASE64_DECODING_TABLE[(size_t)to_decode];
     if (decode_value != 0xDD && (decode_value != BASE64_SENTIANAL_VALUE || allow_sentinal)) {
         *value = decode_value;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return AWS_OP_ERR;
@@ -370,7 +370,7 @@ int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, stru
         }
 
         output->len = result;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     int64_t block_count = (int64_t)to_decode->len / 4;
@@ -413,5 +413,5 @@ int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, stru
         }
     }
     output->len = decoded_length;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -221,7 +221,7 @@ static int s_update_template_size(struct hash_table_state *template, size_t expe
     /* Since size is a power of 2: (index & (size - 1)) == (index % size) */
     template->mask = size - 1;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hash_table_init(
@@ -254,7 +254,7 @@ int aws_hash_table_init(
     }
 
     AWS_POSTCONDITION(aws_hash_table_is_valid(map));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void aws_hash_table_clean_up(struct aws_hash_table *map) {
@@ -327,7 +327,7 @@ static int inline s_find_entry(
             *p_probe_idx = 0;
         }
         *p_entry = entry;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return s_find_entry1(state, hash_code, key, p_entry, p_probe_idx);
@@ -409,7 +409,7 @@ int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struc
         *p_elem = NULL;
     }
     AWS_POSTCONDITION(aws_hash_table_is_valid(map));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /**
@@ -496,7 +496,7 @@ static int s_expand_table(struct aws_hash_table *map) {
     map->p_impl = new_state;
     aws_mem_release(new_state->alloc, old_state);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hash_table_create(
@@ -521,7 +521,7 @@ int aws_hash_table_create(
             *p_elem = &entry->element;
         }
         *was_created = 0;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     /* Okay, we need to add an entry. Check the load factor first. */
@@ -531,7 +531,7 @@ int aws_hash_table_create(
     }
     if (incr_entry_count > state->max_load) {
         rv = s_expand_table(map);
-        if (rv != AWS_OP_SUCCESS) {
+        if (rv != AWS_OP_SUCC) {
             /* Any error was already raised in expand_table */
             return rv;
         }
@@ -560,7 +560,7 @@ int aws_hash_table_create(
 
     *was_created = 1;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_COMMON_API
@@ -595,7 +595,7 @@ int aws_hash_table_put(struct aws_hash_table *map, const void *key, void *value,
     p_elem->key = key;
     p_elem->value = value;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /* Clears an entry. Does _not_ invoke destructor callbacks.
@@ -665,7 +665,7 @@ int aws_hash_table_remove(
     if (rv != AWS_ERROR_SUCCESS) {
         *was_present = 0;
         AWS_POSTCONDITION(aws_hash_table_is_valid(map));
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     *was_present = 1;
@@ -683,7 +683,7 @@ int aws_hash_table_remove(
     s_remove_entry(state, entry);
 
     AWS_POSTCONDITION(aws_hash_table_is_valid(map));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value) {
@@ -696,7 +696,7 @@ int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_el
     s_remove_entry(state, entry);
 
     AWS_POSTCONDITION(aws_hash_table_is_valid(map));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_hash_table_foreach(
@@ -716,7 +716,7 @@ int aws_hash_table_foreach(
         }
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 bool aws_hash_table_eq(

--- a/source/lru_cache.c
+++ b/source/lru_cache.c
@@ -76,7 +76,7 @@ int aws_lru_cache_find(struct aws_lru_cache *cache, const void *key, void **p_va
     aws_linked_list_remove(&cache_node->node);
     aws_linked_list_push_front(&cache->list, &cache_node->node);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_value) {
@@ -119,7 +119,7 @@ int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_valu
         aws_hash_table_remove(&cache->table, entry_to_remove->key, NULL, NULL);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_lru_cache_remove(struct aws_lru_cache *cache, const void *key) {

--- a/source/posix/clock.c
+++ b/source/posix/clock.c
@@ -46,7 +46,7 @@ static int s_legacy_get_time(uint64_t *timestamp) {
     }
 
     *timestamp = tv.tv_sec * NS_PER_SEC + tv.tv_usec * 1000;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 #    if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
@@ -70,7 +70,7 @@ int aws_high_res_clock_get_ticks(uint64_t *timestamp) {
         }
 
         *timestamp = (uint64_t)((ts.tv_sec * NS_PER_SEC) + ts.tv_nsec);
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return s_legacy_get_time(timestamp);
@@ -88,7 +88,7 @@ int aws_sys_clock_get_ticks(uint64_t *timestamp) {
         }
 
         *timestamp = (uint64_t)((ts.tv_sec * NS_PER_SEC) + ts.tv_nsec);
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
     return s_legacy_get_time(timestamp);
 }
@@ -116,7 +116,7 @@ int aws_high_res_clock_get_ticks(uint64_t *timestamp) {
     }
 
     *timestamp = (uint64_t)((ts.tv_sec * NS_PER_SEC) + ts.tv_nsec);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_sys_clock_get_ticks(uint64_t *timestamp) {
@@ -129,6 +129,6 @@ int aws_sys_clock_get_ticks(uint64_t *timestamp) {
     }
 
     *timestamp = (uint64_t)((ts.tv_sec * NS_PER_SEC) + ts.tv_nsec);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 #endif /* defined(__MACH__) */

--- a/source/posix/condition_variable.c
+++ b/source/posix/condition_variable.c
@@ -36,7 +36,7 @@ int aws_condition_variable_init(struct aws_condition_variable *condition_variabl
         return aws_raise_error(AWS_ERROR_COND_VARIABLE_INIT_FAILED);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void aws_condition_variable_clean_up(struct aws_condition_variable *condition_variable) {
@@ -50,7 +50,7 @@ int aws_condition_variable_notify_one(struct aws_condition_variable *condition_v
         return process_error_code(err_code);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_condition_variable_notify_all(struct aws_condition_variable *condition_variable) {
@@ -60,7 +60,7 @@ int aws_condition_variable_notify_all(struct aws_condition_variable *condition_v
         return process_error_code(err_code);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_condition_variable_wait(struct aws_condition_variable *condition_variable, struct aws_mutex *mutex) {
@@ -70,7 +70,7 @@ int aws_condition_variable_wait(struct aws_condition_variable *condition_variabl
         return process_error_code(err_code);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_condition_variable_wait_for(
@@ -97,5 +97,5 @@ int aws_condition_variable_wait_for(
         return process_error_code(err_code);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/posix/device_random.c
+++ b/source/posix/device_random.c
@@ -58,7 +58,7 @@ static int s_fallback_device_random_buffer(struct aws_byte_buf *output) {
 
     output->len += diff;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_device_random_buffer(struct aws_byte_buf *output) {

--- a/source/posix/environment.c
+++ b/source/posix/environment.c
@@ -26,7 +26,7 @@ int aws_get_environment_value(
     const char *value = getenv((const char *)variable_name->bytes);
     if (value == NULL) {
         *value_out = NULL;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     *value_out = aws_string_new_from_c_str(allocator, value);
@@ -34,7 +34,7 @@ int aws_get_environment_value(
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_GET);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value) {
@@ -43,7 +43,7 @@ int aws_set_environment_value(const struct aws_string *variable_name, const stru
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_SET);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_unset_environment_value(const struct aws_string *variable_name) {
@@ -51,5 +51,5 @@ int aws_unset_environment_value(const struct aws_string *variable_name) {
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_UNSET);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/posix/mutex.c
+++ b/source/posix/mutex.c
@@ -25,7 +25,7 @@ void aws_mutex_clean_up(struct aws_mutex *mutex) {
 int aws_mutex_init(struct aws_mutex *mutex) {
     pthread_mutexattr_t attr;
     int err_code = pthread_mutexattr_init(&attr);
-    int return_code = AWS_OP_SUCCESS;
+    int return_code = AWS_OP_SUCC;
 
     if (!err_code) {
         if ((err_code = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL)) ||

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -156,7 +156,7 @@ int s_parse_symbol(const char *symbol, void *addr, struct aws_stack_frame_info *
     dladdr(addr, &addr_info);
     snprintf(frame->base, sizeof(frame->base), "0x%p", addr_info.dli_fbase);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void s_resolve_cmd(char *cmd, size_t len, struct aws_stack_frame_info *frame) {
@@ -194,7 +194,7 @@ int s_parse_symbol(const char *symbol, void *addr, struct aws_stack_frame_info *
         strncpy(frame->function, open_paren + 1, function_len);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 void s_resolve_cmd(char *cmd, size_t len, struct aws_stack_frame_info *frame) {
     snprintf(cmd, len, "addr2line -afips -e %s %s", frame->exe, frame->addr);

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -58,7 +58,7 @@ int aws_thread_init(struct aws_thread *thread, struct aws_allocator *allocator) 
     thread->thread_id = 0;
     thread->detach_state = AWS_THREAD_NOT_CREATED;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_thread_launch(
@@ -130,7 +130,7 @@ cleanup:
         return aws_raise_error(AWS_ERROR_OOM);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 uint64_t aws_thread_get_id(struct aws_thread *thread) {
@@ -160,7 +160,7 @@ int aws_thread_join(struct aws_thread *thread) {
         thread->detach_state = AWS_THREAD_JOIN_COMPLETED;
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 uint64_t aws_thread_current_thread_id(void) {

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -159,7 +159,7 @@ int aws_priority_queue_init_dynamic(
     AWS_ZERO_STRUCT(queue->backpointers);
 
     int ret = aws_array_list_init_dynamic(&queue->container, alloc, default_size, item_size);
-    if (ret == AWS_OP_SUCCESS) {
+    if (ret == AWS_OP_SUCC) {
         AWS_POSTCONDITION(aws_priority_queue_is_valid(queue));
     }
     return ret;
@@ -258,7 +258,7 @@ int aws_priority_queue_push_ref(
 
     s_sift_up(queue, aws_array_list_length(&queue->container) - 1);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 
 backpointer_update_failed:
     /* Failed to initialize or grow the backpointer array, back out the node addition */
@@ -291,7 +291,7 @@ static int s_remove_node(struct aws_priority_queue *queue, void *item, size_t it
         s_sift_either(queue, item_index);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_priority_queue_remove(

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -31,7 +31,7 @@ int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct aws_allocator 
     aws_atomic_init_ptr(&ring_buf->tail, ring_buf->allocation);
     ring_buf->allocation_end = ring_buf->allocation + size;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void aws_ring_buffer_clean_up(struct aws_ring_buffer *ring_buf) {
@@ -61,7 +61,7 @@ int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_s
         aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
         aws_atomic_store_ptr(&ring_buf->tail, ring_buf->allocation);
         *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     /* you'll constantly bounce between the next two branches as the ring buffer is traversed. */
@@ -72,7 +72,7 @@ int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_s
         if (space >= requested_size) {
             aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
             *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
         /* After N wraps */
     } else if (tail_cpy < head_cpy) {
@@ -80,13 +80,13 @@ int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_s
         if ((size_t)(ring_buf->allocation_end - head_cpy) >= requested_size) {
             aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
             *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
 
         if ((size_t)(tail_cpy - ring_buf->allocation) > requested_size) {
             aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
             *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
     }
 
@@ -122,7 +122,7 @@ int aws_ring_buffer_acquire_up_to(
         aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + allocation_size);
         aws_atomic_store_ptr(&ring_buf->tail, ring_buf->allocation);
         *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, allocation_size);
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
     /* you'll constantly bounce between the next two branches as the ring buffer is traversed. */
     /* after N + 1 wraps */
@@ -137,7 +137,7 @@ int aws_ring_buffer_acquire_up_to(
         if (returnable_size >= minimum_size) {
             aws_atomic_store_ptr(&ring_buf->head, head_cpy + returnable_size);
             *dest = aws_byte_buf_from_empty_array(head_cpy, returnable_size);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
         /* after N wraps */
     } else if (tail_cpy < head_cpy) {
@@ -148,26 +148,26 @@ int aws_ring_buffer_acquire_up_to(
         if (head_space >= requested_size) {
             aws_atomic_store_ptr(&ring_buf->head, head_cpy + requested_size);
             *dest = aws_byte_buf_from_empty_array(head_cpy, requested_size);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
 
         if (tail_space > requested_size) {
             aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + requested_size);
             *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, requested_size);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
 
         /* now vend as much as possible, once again preferring head space. */
         if (head_space >= minimum_size && head_space >= tail_space) {
             aws_atomic_store_ptr(&ring_buf->head, head_cpy + head_space);
             *dest = aws_byte_buf_from_empty_array(head_cpy, head_space);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
 
         if (tail_space > minimum_size) {
             aws_atomic_store_ptr(&ring_buf->head, ring_buf->allocation + tail_space - 1);
             *dest = aws_byte_buf_from_empty_array(ring_buf->allocation, tail_space - 1);
-            return AWS_OP_SUCCESS;
+            return AWS_OP_SUCC;
         }
     }
 

--- a/source/task_scheduler.c
+++ b/source/task_scheduler.c
@@ -68,7 +68,7 @@ bool aws_task_scheduler_has_tasks(const struct aws_task_scheduler *scheduler, ui
         }
 
         struct aws_task **task_ptrptr = NULL;
-        if (aws_priority_queue_top(&scheduler->timed_queue, (void **)&task_ptrptr) == AWS_OP_SUCCESS) {
+        if (aws_priority_queue_top(&scheduler->timed_queue, (void **)&task_ptrptr) == AWS_OP_SUCC) {
             if ((*task_ptrptr)->timestamp < timestamp) {
                 timestamp = (*task_ptrptr)->timestamp;
             }
@@ -156,7 +156,7 @@ static void s_run_all(struct aws_task_scheduler *scheduler, uint64_t current_tim
 
         /* Check if timed_queue has a task which is sooner */
         struct aws_task **timed_queue_task_ptrptr = NULL;
-        if (aws_priority_queue_top(&scheduler->timed_queue, (void **)&timed_queue_task_ptrptr) == AWS_OP_SUCCESS) {
+        if (aws_priority_queue_top(&scheduler->timed_queue, (void **)&timed_queue_task_ptrptr) == AWS_OP_SUCC) {
             if ((*timed_queue_task_ptrptr)->timestamp <= current_time) {
                 if ((*timed_queue_task_ptrptr)->timestamp < timed_list_task->timestamp) {
                     /* Take task from timed_queue */
@@ -175,7 +175,7 @@ static void s_run_all(struct aws_task_scheduler *scheduler, uint64_t current_tim
 
     /* Simpler loop that moves remaining valid tasks from timed_queue */
     struct aws_task **timed_queue_task_ptrptr = NULL;
-    while (aws_priority_queue_top(&scheduler->timed_queue, (void **)&timed_queue_task_ptrptr) == AWS_OP_SUCCESS) {
+    while (aws_priority_queue_top(&scheduler->timed_queue, (void **)&timed_queue_task_ptrptr) == AWS_OP_SUCC) {
         if ((*timed_queue_task_ptrptr)->timestamp > current_time) {
             break;
         }

--- a/source/uuid.c
+++ b/source/uuid.c
@@ -75,7 +75,7 @@ int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output) {
@@ -105,7 +105,7 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output) {
 
     output->len += AWS_UUID_STR_LEN - 1;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b) {

--- a/source/windows/clock.c
+++ b/source/windows/clock.c
@@ -61,7 +61,7 @@ int aws_high_res_clock_get_ticks(uint64_t *timestamp) {
                      (uint64_t)frequency.QuadPart;
 
         *timestamp = aws_timestamp_convert(*timestamp, AWS_TIMESTAMP_MICROS, AWS_TIMESTAMP_NANOS, NULL);
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_CLOCK_FAILURE);
@@ -81,5 +81,5 @@ int aws_sys_clock_get_ticks(uint64_t *timestamp) {
     int_conv.HighPart = ticks.dwHighDateTime;
 
     *timestamp = (int_conv.QuadPart - (WINDOWS_TICK * EC_TO_UNIX_EPOCH)) * FILE_TIME_TO_NS;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/windows/condition_variable.c
+++ b/source/windows/condition_variable.c
@@ -28,7 +28,7 @@ AWS_STATIC_ASSERT(sizeof(CONDITION_VARIABLE) == sizeof(struct aws_condition_vari
 int aws_condition_variable_init(struct aws_condition_variable *condition_variable) {
 
     InitializeConditionVariable(AWSCV_TO_WINDOWS(condition_variable));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void aws_condition_variable_clean_up(struct aws_condition_variable *condition_variable) {
@@ -39,19 +39,19 @@ void aws_condition_variable_clean_up(struct aws_condition_variable *condition_va
 int aws_condition_variable_notify_one(struct aws_condition_variable *condition_variable) {
 
     WakeConditionVariable(AWSCV_TO_WINDOWS(condition_variable));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_condition_variable_notify_all(struct aws_condition_variable *condition_variable) {
 
     WakeAllConditionVariable(AWSCV_TO_WINDOWS(condition_variable));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_condition_variable_wait(struct aws_condition_variable *condition_variable, struct aws_mutex *mutex) {
 
     if (SleepConditionVariableSRW(AWSCV_TO_WINDOWS(condition_variable), AWSMUTEX_TO_WINDOWS(mutex), INFINITE, 0)) {
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_COND_VARIABLE_ERROR_UNKNOWN);
@@ -65,7 +65,7 @@ int aws_condition_variable_wait_for(
     DWORD time_ms = (DWORD)aws_timestamp_convert(time_to_wait, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, NULL);
 
     if (SleepConditionVariableSRW(AWSCV_TO_WINDOWS(condition_variable), AWSMUTEX_TO_WINDOWS(mutex), time_ms, 0)) {
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_COND_VARIABLE_TIMED_OUT);

--- a/source/windows/device_random.c
+++ b/source/windows/device_random.c
@@ -44,5 +44,5 @@ int aws_device_random_buffer(struct aws_byte_buf *output) {
     }
 
     output->len += offset;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/windows/environment.c
+++ b/source/windows/environment.c
@@ -32,7 +32,7 @@ int aws_get_environment_value(
 
     if (value == NULL) {
         *value_out = NULL;
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     *value_out = aws_string_new_from_c_str(allocator, value);
@@ -40,7 +40,7 @@ int aws_get_environment_value(
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_GET);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value) {
@@ -48,7 +48,7 @@ int aws_set_environment_value(const struct aws_string *variable_name, const stru
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_SET);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_STATIC_STRING_FROM_LITERAL(s_empty_string, "");
@@ -58,5 +58,5 @@ int aws_unset_environment_value(const struct aws_string *variable_name) {
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_UNSET);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/windows/mutex.c
+++ b/source/windows/mutex.c
@@ -22,7 +22,7 @@ AWS_STATIC_ASSERT(sizeof(SRWLOCK) == sizeof(struct aws_mutex));
 
 int aws_mutex_init(struct aws_mutex *mutex) {
     InitializeSRWLock(AWSMUTEX_TO_WINDOWS(mutex));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /* turn off unused named parameter warning on msvc.*/
@@ -35,14 +35,14 @@ void aws_mutex_clean_up(struct aws_mutex *mutex) {}
 
 int aws_mutex_lock(struct aws_mutex *mutex) {
     AcquireSRWLockExclusive(AWSMUTEX_TO_WINDOWS(mutex));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_mutex_try_lock(struct aws_mutex *mutex) {
     BOOL res = TryAcquireSRWLockExclusive(AWSMUTEX_TO_WINDOWS(mutex));
 
     if (!res) {
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_MUTEX_TIMEOUT);
@@ -50,7 +50,7 @@ int aws_mutex_try_lock(struct aws_mutex *mutex) {
 
 int aws_mutex_unlock(struct aws_mutex *mutex) {
     ReleaseSRWLockExclusive(AWSMUTEX_TO_WINDOWS(mutex));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 #ifdef _MSC_VER

--- a/source/windows/rw_lock.c
+++ b/source/windows/rw_lock.c
@@ -24,7 +24,7 @@ AWS_STATIC_ASSERT(sizeof(SRWLOCK) == sizeof(struct aws_rw_lock));
 int aws_rw_lock_init(struct aws_rw_lock *lock) {
 
     InitializeSRWLock(AWSSRW_TO_WINDOWS(lock));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void aws_rw_lock_clean_up(struct aws_rw_lock *lock) {
@@ -35,19 +35,19 @@ void aws_rw_lock_clean_up(struct aws_rw_lock *lock) {
 int aws_rw_lock_rlock(struct aws_rw_lock *lock) {
 
     AcquireSRWLockShared(AWSSRW_TO_WINDOWS(lock));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_rw_lock_wlock(struct aws_rw_lock *lock) {
 
     AcquireSRWLockExclusive(AWSSRW_TO_WINDOWS(lock));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_rw_lock_try_rlock(struct aws_rw_lock *lock) {
 
     if (TryAcquireSRWLockShared(AWSSRW_TO_WINDOWS(lock))) {
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_MUTEX_TIMEOUT);
@@ -56,7 +56,7 @@ int aws_rw_lock_try_rlock(struct aws_rw_lock *lock) {
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock) {
 
     if (TryAcquireSRWLockExclusive(AWSSRW_TO_WINDOWS(lock))) {
-        return AWS_OP_SUCCESS;
+        return AWS_OP_SUCC;
     }
 
     return aws_raise_error(AWS_ERROR_MUTEX_TIMEOUT);
@@ -66,12 +66,12 @@ int aws_rw_lock_runlock(struct aws_rw_lock *lock) {
 
     ReleaseSRWLockShared(AWSSRW_TO_WINDOWS(lock));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock) {
 
     ReleaseSRWLockExclusive(AWSSRW_TO_WINDOWS(lock));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }

--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -65,7 +65,7 @@ int aws_thread_init(struct aws_thread *thread, struct aws_allocator *allocator) 
     thread->allocator = allocator;
     thread->detach_state = AWS_THREAD_NOT_CREATED;
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 int aws_thread_launch(
@@ -93,7 +93,7 @@ int aws_thread_launch(
     }
 
     thread->detach_state = AWS_THREAD_JOINABLE;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 uint64_t aws_thread_get_id(struct aws_thread *thread) {
@@ -110,7 +110,7 @@ int aws_thread_join(struct aws_thread *thread) {
         thread->detach_state = AWS_THREAD_JOIN_COMPLETED;
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 void aws_thread_clean_up(struct aws_thread *thread) {

--- a/tests/assert_test.c
+++ b/tests/assert_test.c
@@ -81,13 +81,13 @@ int test_asserts(int *index) {
     TEST_SUCCESS(assert_bool) { ASSERT_TRUE(1); }
     TEST_SUCCESS(assert_bool) { ASSERT_TRUE(2); }
     TEST_SUCCESS(assert_bool) { ASSERT_FALSE(0); }
-    TEST_SUCCESS(assert_success) { ASSERT_SUCCESS(AWS_OP_SUCCESS); }
-    TEST_SUCCESS(assert_success) { ASSERT_SUCCESS(AWS_OP_SUCCESS, "foo"); }
+    TEST_SUCCESS(assert_success) { ASSERT_SUCCESS(AWS_OP_SUCC); }
+    TEST_SUCCESS(assert_success) { ASSERT_SUCCESS(AWS_OP_SUCC, "foo"); }
     TEST_FAILURE(assert_success) { ASSERT_SUCCESS(aws_raise_error(AWS_ERROR_OOM), "foo"); }
 
     TEST_SUCCESS(assert_fails) { ASSERT_FAILS(aws_raise_error(AWS_ERROR_OOM)); }
     TEST_SUCCESS(assert_fails) { ASSERT_FAILS(aws_raise_error(AWS_ERROR_OOM), "foo"); }
-    TEST_FAILURE(assert_fails) { ASSERT_FAILS(AWS_OP_SUCCESS, "foo"); }
+    TEST_FAILURE(assert_fails) { ASSERT_FAILS(AWS_OP_SUCC, "foo"); }
 
     TEST_SUCCESS(assert_error) { ASSERT_ERROR(AWS_ERROR_OOM, aws_raise_error(AWS_ERROR_OOM)); }
     TEST_SUCCESS(assert_error_side_effect) {
@@ -99,7 +99,7 @@ int test_asserts(int *index) {
     TEST_SUCCESS(assert_error) { ASSERT_ERROR(AWS_ERROR_OOM, aws_raise_error(AWS_ERROR_OOM), "foo"); }
     TEST_FAILURE(assert_error) { ASSERT_ERROR(AWS_ERROR_CLOCK_FAILURE, aws_raise_error(AWS_ERROR_OOM), "foo"); }
     aws_raise_error(AWS_ERROR_CLOCK_FAILURE); // set last error
-    TEST_FAILURE(assert_error) { ASSERT_ERROR(AWS_ERROR_CLOCK_FAILURE, AWS_OP_SUCCESS, "foo"); }
+    TEST_FAILURE(assert_error) { ASSERT_ERROR(AWS_ERROR_CLOCK_FAILURE, AWS_OP_SUCC, "foo"); }
 
     TEST_SUCCESS(assert_null) { ASSERT_NULL(NULL); }
     {

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -292,7 +292,7 @@ static int s_test_buffer_printf(struct aws_allocator *allocator, void *ctx) {
     ASSERT_UINT_EQUALS('b', dst[1]);
     ASSERT_UINT_EQUALS(0, dst[2]);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(test_array_eq, s_test_array_eq)
@@ -522,7 +522,7 @@ static int s_do_append_dynamic_test(
         memset(accum_buf.buffer, 0, accum_buf.capacity);
 
         size_t before_size = accum_buf.len;
-        ASSERT_TRUE(aws_byte_buf_append_dynamic(&accum_buf, &append_cursor) == AWS_OP_SUCCESS);
+        ASSERT_TRUE(aws_byte_buf_append_dynamic(&accum_buf, &append_cursor) == AWS_OP_SUCC);
         size_t after_size = accum_buf.len;
 
         size_t expected_len = starting_size + (i + 1) * append_size;
@@ -547,7 +547,7 @@ static int s_do_append_dynamic_test(
     aws_byte_buf_clean_up(&accum_buf);
     aws_byte_buf_clean_up(&append_buf);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static int s_test_byte_buf_append_dynamic(struct aws_allocator *allocator, void *ctx) {
@@ -556,10 +556,10 @@ static int s_test_byte_buf_append_dynamic(struct aws_allocator *allocator, void 
     /*
      * Throw a small sample of different growth request profiles at the function
      */
-    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 1, 10000, 1) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 1, 1, 1000) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 10000, 1, 2) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 100, 10, 100) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 1, 10000, 1) == AWS_OP_SUCC);
+    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 1, 1, 1000) == AWS_OP_SUCC);
+    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 10000, 1, 2) == AWS_OP_SUCC);
+    ASSERT_TRUE(s_do_append_dynamic_test(allocator, 100, 10, 100) == AWS_OP_SUCC);
 
     return 0;
 }
@@ -576,7 +576,7 @@ static int s_test_byte_buf_append_lookup_success(struct aws_allocator *allocator
     struct aws_byte_cursor to_lower_cursor = aws_byte_cursor_from_c_str((char *)s_to_lower_test->bytes);
 
     ASSERT_TRUE(
-        aws_byte_buf_append_with_lookup(&buffer, &to_lower_cursor, aws_lookup_table_to_lower_get()) == AWS_OP_SUCCESS);
+        aws_byte_buf_append_with_lookup(&buffer, &to_lower_cursor, aws_lookup_table_to_lower_get()) == AWS_OP_SUCC);
     ASSERT_TRUE(buffer.len == s_to_lower_test->len);
     for (size_t i = 0; i < s_to_lower_test->len; ++i) {
         uint8_t value = buffer.buffer[i];
@@ -593,7 +593,7 @@ static int s_test_reset_body(struct aws_byte_buf *buffer) {
     struct aws_byte_cursor to_lower_cursor = aws_byte_cursor_from_c_str((char *)s_to_lower_test->bytes);
 
     ASSERT_TRUE(
-        aws_byte_buf_append_with_lookup(buffer, &to_lower_cursor, aws_lookup_table_to_lower_get()) == AWS_OP_SUCCESS);
+        aws_byte_buf_append_with_lookup(buffer, &to_lower_cursor, aws_lookup_table_to_lower_get()) == AWS_OP_SUCC);
     ASSERT_TRUE(buffer->len == s_to_lower_test->len);
     for (size_t i = 0; i < s_to_lower_test->len; ++i) {
         uint8_t value = buffer->buffer[i];
@@ -659,13 +659,13 @@ static int s_test_byte_buf_reserve(struct aws_allocator *allocator, void *ctx) {
     aws_byte_buf_init(&buffer, allocator, s_reserve_test_prefix->len);
 
     struct aws_byte_cursor prefix_cursor = aws_byte_cursor_from_string(s_reserve_test_prefix);
-    ASSERT_TRUE(aws_byte_buf_append(&buffer, &prefix_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_byte_buf_append(&buffer, &prefix_cursor) == AWS_OP_SUCC);
 
     struct aws_byte_cursor suffix_cursor = aws_byte_cursor_from_string(s_reserve_test_suffix);
     ASSERT_TRUE(aws_byte_buf_append(&buffer, &suffix_cursor) == AWS_OP_ERR);
 
     aws_byte_buf_reserve(&buffer, s_reserve_test_prefix_concatenated->len);
-    ASSERT_TRUE(aws_byte_buf_append(&buffer, &suffix_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_byte_buf_append(&buffer, &suffix_cursor) == AWS_OP_SUCC);
 
     ASSERT_TRUE(aws_byte_buf_eq_c_str(&buffer, (char *)s_reserve_test_prefix_concatenated->bytes));
 
@@ -684,12 +684,12 @@ static int s_test_byte_buf_reserve_relative(struct aws_allocator *allocator, voi
 
     struct aws_byte_cursor prefix_cursor = aws_byte_cursor_from_string(s_reserve_test_prefix);
 
-    ASSERT_TRUE(aws_byte_buf_reserve_relative(&buffer, prefix_cursor.len) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(aws_byte_buf_append(&buffer, &prefix_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_byte_buf_reserve_relative(&buffer, prefix_cursor.len) == AWS_OP_SUCC);
+    ASSERT_TRUE(aws_byte_buf_append(&buffer, &prefix_cursor) == AWS_OP_SUCC);
 
     struct aws_byte_cursor suffix_cursor = aws_byte_cursor_from_string(s_reserve_test_suffix);
-    ASSERT_TRUE(aws_byte_buf_reserve_relative(&buffer, suffix_cursor.len) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(aws_byte_buf_append(&buffer, &suffix_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_byte_buf_reserve_relative(&buffer, suffix_cursor.len) == AWS_OP_SUCC);
+    ASSERT_TRUE(aws_byte_buf_append(&buffer, &suffix_cursor) == AWS_OP_SUCC);
 
     ASSERT_TRUE(aws_byte_buf_eq_c_str(&buffer, (char *)s_reserve_test_prefix_concatenated->bytes));
 

--- a/tests/command_line_parser_test.c
+++ b/tests/command_line_parser_test.c
@@ -48,7 +48,7 @@ static int s_test_short_argument_parse_fn(struct aws_allocator *allocator, void 
     ASSERT_INT_EQUALS(2, longindex);
     ASSERT_INT_EQUALS(-1, aws_cli_getopt_long(argc, args, "ab:c", options, &longindex));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(short_argument_parse, s_test_short_argument_parse_fn)
@@ -87,7 +87,7 @@ static int s_test_long_argument_parse_fn(struct aws_allocator *allocator, void *
 
     ASSERT_INT_EQUALS(-1, aws_cli_getopt_long(argc, args, "ab:c", options, &longindex));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(long_argument_parse, s_test_long_argument_parse_fn)
@@ -122,7 +122,7 @@ static int s_test_unqualified_argument_parse_fn(struct aws_allocator *allocator,
     ASSERT_TRUE(aws_cli_optind < argc);
     ASSERT_STR_EQUALS("operand", args[aws_cli_optind++]);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(unqualified_argument_parse, s_test_unqualified_argument_parse_fn)
@@ -157,7 +157,7 @@ static int s_test_unknown_argument_parse_fn(struct aws_allocator *allocator, voi
     ASSERT_TRUE(aws_cli_optind < argc);
     ASSERT_STR_EQUALS("operand", args[aws_cli_optind++]);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(unknown_argument_parse, s_test_unknown_argument_parse_fn)

--- a/tests/condition_variable_test.c
+++ b/tests/condition_variable_test.c
@@ -103,7 +103,7 @@ static int s_test_conditional_notify_one_fn(struct aws_allocator *allocator, voi
     aws_thread_clean_up(&thread);
     ASSERT_TRUE(predicate_args.call_count >= 2);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(conditional_notify_one, s_test_conditional_notify_one_fn)
@@ -148,7 +148,7 @@ static int s_test_conditional_notify_all_fn(struct aws_allocator *allocator, voi
 
     ASSERT_TRUE(predicate_args.call_count >= 2);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(conditional_notify_all, s_test_conditional_notify_all_fn)

--- a/tests/date_time_test.c
+++ b/tests/date_time_test.c
@@ -64,7 +64,7 @@ static int s_test_rfc822_utc_parsing_fn(struct aws_allocator *allocator, void *c
         ASSERT_BIN_ARRAYS_EQUALS(expected_short_buf.buffer, expected_short_buf.len, str_output.buffer, str_output.len);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_utc_parsing, s_test_rfc822_utc_parsing_fn)
@@ -94,7 +94,7 @@ static int s_test_rfc822_utc_parsing_auto_detect_fn(struct aws_allocator *alloca
 
     ASSERT_BIN_ARRAYS_EQUALS(date_buf.buffer, date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_utc_parsing_auto_detect, s_test_rfc822_utc_parsing_auto_detect_fn)
@@ -127,7 +127,7 @@ static int s_test_rfc822_local_time_east_of_gmt_parsing_fn(struct aws_allocator 
 
     ASSERT_BIN_ARRAYS_EQUALS(expected_buf.buffer, expected_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_local_time_east_of_gmt_parsing, s_test_rfc822_local_time_east_of_gmt_parsing_fn)
@@ -160,7 +160,7 @@ static int s_test_rfc822_local_time_west_of_gmt_parsing_fn(struct aws_allocator 
 
     ASSERT_BIN_ARRAYS_EQUALS(expected_buf.buffer, expected_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_local_time_west_of_gmt_parsing, s_test_rfc822_local_time_west_of_gmt_parsing_fn)
@@ -192,7 +192,7 @@ static int s_test_rfc822_utc_two_digit_year_parsing_fn(struct aws_allocator *all
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_utc_two_digit_year_parsing, s_test_rfc822_utc_two_digit_year_parsing_fn)
@@ -224,7 +224,7 @@ static int s_test_rfc822_utc_no_dow_parsing_fn(struct aws_allocator *allocator, 
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_utc_no_dow_parsing, s_test_rfc822_utc_no_dow_parsing_fn)
@@ -241,7 +241,7 @@ static int s_test_rfc822_utc_dos_prevented_fn(struct aws_allocator *allocator, v
     ASSERT_ERROR(
         AWS_ERROR_OVERFLOW_DETECTED, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_RFC822));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_utc_dos_prevented, s_test_rfc822_utc_dos_prevented_fn)
@@ -257,7 +257,7 @@ static int s_test_rfc822_invalid_format_fn(struct aws_allocator *allocator, void
     ASSERT_ERROR(
         AWS_ERROR_INVALID_DATE_STR, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_RFC822));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_invalid_format, s_test_rfc822_invalid_format_fn)
@@ -273,7 +273,7 @@ static int s_test_rfc822_invalid_tz_fn(struct aws_allocator *allocator, void *ct
     ASSERT_ERROR(
         AWS_ERROR_INVALID_DATE_STR, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_RFC822));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_invalid_tz, s_test_rfc822_invalid_tz_fn)
@@ -289,7 +289,7 @@ static int s_test_rfc822_invalid_auto_format_fn(struct aws_allocator *allocator,
     ASSERT_ERROR(
         AWS_ERROR_INVALID_DATE_STR, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_AUTO_DETECT));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(rfc822_invalid_auto_format, s_test_rfc822_invalid_auto_format_fn)
@@ -329,7 +329,7 @@ static int s_test_iso8601_utc_parsing_fn(struct aws_allocator *allocator, void *
     struct aws_byte_buf expected_short_buf = aws_byte_buf_from_c_str(expected_short_str);
 
     ASSERT_BIN_ARRAYS_EQUALS(expected_short_buf.buffer, expected_short_buf.len, str_output.buffer, str_output.len);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_utc_parsing, s_test_iso8601_utc_parsing_fn)
@@ -369,7 +369,7 @@ static int s_test_iso8601_basic_utc_parsing_fn(struct aws_allocator *allocator, 
     struct aws_byte_buf expected_short_buf = aws_byte_buf_from_c_str(expected_short_str);
 
     ASSERT_BIN_ARRAYS_EQUALS(expected_short_buf.buffer, expected_short_buf.len, str_output.buffer, str_output.len);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_basic_utc_parsing, s_test_iso8601_basic_utc_parsing_fn)
@@ -401,7 +401,7 @@ static int s_test_iso8601_utc_parsing_auto_detect_fn(struct aws_allocator *alloc
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_utc_parsing_auto_detect, s_test_iso8601_utc_parsing_auto_detect_fn)
@@ -433,7 +433,7 @@ static int s_test_iso8601_basic_utc_parsing_auto_detect_fn(struct aws_allocator 
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_basic_utc_parsing_auto_detect, s_test_iso8601_basic_utc_parsing_auto_detect_fn)
@@ -465,7 +465,7 @@ static int s_test_iso8601_utc_no_colon_parsing_fn(struct aws_allocator *allocato
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_utc_no_colon_parsing, s_test_iso8601_utc_no_colon_parsing_fn)
@@ -497,7 +497,7 @@ static int s_test_iso8601_date_only_parsing_fn(struct aws_allocator *allocator, 
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_date_only_parsing, s_test_iso8601_date_only_parsing_fn)
@@ -529,7 +529,7 @@ static int s_test_iso8601_basic_date_only_parsing_fn(struct aws_allocator *alloc
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_basic_date_only_parsing, s_test_iso8601_basic_date_only_parsing_fn)
@@ -546,7 +546,7 @@ static int s_test_iso8601_utc_dos_prevented_fn(struct aws_allocator *allocator, 
     ASSERT_ERROR(
         AWS_ERROR_OVERFLOW_DETECTED, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_ISO_8601));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_utc_dos_prevented, s_test_iso8601_utc_dos_prevented_fn)
@@ -562,7 +562,7 @@ static int s_test_iso8601_invalid_format_fn(struct aws_allocator *allocator, voi
     ASSERT_ERROR(
         AWS_ERROR_INVALID_DATE_STR, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_ISO_8601));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_invalid_format, s_test_iso8601_invalid_format_fn)
@@ -578,7 +578,7 @@ static int s_test_iso8601_invalid_auto_format_fn(struct aws_allocator *allocator
     ASSERT_ERROR(
         AWS_ERROR_INVALID_DATE_STR, aws_date_time_init_from_str(&date_time, &date_buf, AWS_DATE_FORMAT_AUTO_DETECT));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(iso8601_invalid_auto_format, s_test_iso8601_invalid_auto_format_fn)
@@ -608,7 +608,7 @@ static int s_test_unix_epoch_parsing_fn(struct aws_allocator *allocator, void *c
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(unix_epoch_parsing, s_test_unix_epoch_parsing_fn)
@@ -638,7 +638,7 @@ static int s_test_millis_parsing_fn(struct aws_allocator *allocator, void *ctx) 
     struct aws_byte_buf expected_date_buf = aws_byte_buf_from_c_str(expected_date_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected_date_buf.buffer, expected_date_buf.len, str_output.buffer, str_output.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(millis_parsing, s_test_millis_parsing_fn)

--- a/tests/device_random_test.c
+++ b/tests/device_random_test.c
@@ -46,7 +46,7 @@ static int s_distribution_tester_put(struct distribution_tester *tester, uint64_
     ASSERT_TRUE(bucket_idx < DISTRIBUTION_BUCKET_COUNT);
     tester->buckets[bucket_idx]++;
     tester->num_puts++;
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static int s_distribution_tester_check_results(const struct distribution_tester *tester) {
@@ -66,7 +66,7 @@ static int s_distribution_tester_check_results(const struct distribution_tester 
         ASSERT_TRUE(numbers_in_bucket >= min_acceptable_numbers_per_bucket);
     }
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static int s_device_rand_u64_distribution_fn(struct aws_allocator *allocator, void *ctx) {
@@ -81,7 +81,7 @@ static int s_device_rand_u64_distribution_fn(struct aws_allocator *allocator, vo
     }
 
     ASSERT_SUCCESS(s_distribution_tester_check_results(&tester));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(device_rand_u64_distribution, s_device_rand_u64_distribution_fn)
@@ -98,7 +98,7 @@ static int s_device_rand_u32_distribution_fn(struct aws_allocator *allocator, vo
     }
 
     ASSERT_SUCCESS(s_distribution_tester_check_results(&tester));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(device_rand_u32_distribution, s_device_rand_u32_distribution_fn)
@@ -115,7 +115,7 @@ static int s_device_rand_u16_distribution_fn(struct aws_allocator *allocator, vo
     }
 
     ASSERT_SUCCESS(s_distribution_tester_check_results(&tester));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(device_rand_u16_distribution, s_device_rand_u16_distribution_fn)
@@ -136,7 +136,7 @@ static int s_device_rand_buffer_distribution_fn(struct aws_allocator *allocator,
     }
 
     ASSERT_SUCCESS(s_distribution_tester_check_results(&tester));
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(device_rand_buffer_distribution, s_device_rand_buffer_distribution_fn)

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -944,8 +944,8 @@ static int s_hex_encoding_append_dynamic_test_case_fooba(struct aws_allocator *a
     char test_data[] = "fooba";
     char expected[] = "666f6f6261";
 
-    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 5, 3) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 50, 3) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 5, 3) == AWS_OP_SUCC);
+    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 50, 3) == AWS_OP_SUCC);
 
     return 0;
 }
@@ -958,8 +958,8 @@ static int s_hex_encoding_append_dynamic_test_case_empty(struct aws_allocator *a
     char test_data[] = "";
     char expected[] = "";
 
-    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 5, 3) == AWS_OP_SUCCESS);
-    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 50, 3) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 5, 3) == AWS_OP_SUCC);
+    ASSERT_TRUE(s_run_hex_encoding_append_dynamic_test_case(allocator, test_data, expected, 50, 3) == AWS_OP_SUCC);
 
     return 0;
 }

--- a/tests/environment_test.c
+++ b/tests/environment_test.c
@@ -29,26 +29,26 @@ static int s_test_environment_functions_fn(struct aws_allocator *allocator, void
     struct aws_string *value;
 
     int result = aws_get_environment_value(allocator, s_test_variable, &value);
-    ASSERT_TRUE(result == AWS_OP_SUCCESS);
+    ASSERT_TRUE(result == AWS_OP_SUCC);
     ASSERT_TRUE(value == NULL);
 
     result = aws_set_environment_value(s_test_variable, (struct aws_string *)s_test_value);
-    ASSERT_TRUE(result == AWS_OP_SUCCESS);
+    ASSERT_TRUE(result == AWS_OP_SUCC);
 
     result = aws_get_environment_value(allocator, s_test_variable, &value);
-    ASSERT_TRUE(result == AWS_OP_SUCCESS);
+    ASSERT_TRUE(result == AWS_OP_SUCC);
     ASSERT_TRUE(aws_string_compare(value, s_test_value) == 0);
 
     aws_string_destroy(value);
 
     result = aws_unset_environment_value(s_test_variable);
-    ASSERT_TRUE(result == AWS_OP_SUCCESS);
+    ASSERT_TRUE(result == AWS_OP_SUCC);
 
     result = aws_get_environment_value(allocator, s_test_variable, &value);
-    ASSERT_TRUE(result == AWS_OP_SUCCESS);
+    ASSERT_TRUE(result == AWS_OP_SUCC);
     ASSERT_TRUE(value == NULL);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(test_environment_functions, s_test_environment_functions_fn)

--- a/tests/fuzz/base64_encoding_transitive.c
+++ b/tests/fuzz/base64_encoding_transitive.c
@@ -22,28 +22,28 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     size_t output_size = 0;
     int result = aws_base64_compute_encoded_len(size, &output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     struct aws_byte_cursor to_encode = aws_byte_cursor_from_array(data, size);
 
     struct aws_byte_buf encode_output;
     result = aws_byte_buf_init(&encode_output, allocator, output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     result = aws_base64_encode(&to_encode, &encode_output);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     struct aws_byte_cursor to_decode = aws_byte_cursor_from_buf(&encode_output);
     result = aws_base64_compute_decoded_len(&to_decode, &output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
     AWS_ASSERT(output_size == size);
 
     struct aws_byte_buf decode_output;
     result = aws_byte_buf_init(&decode_output, allocator, output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     result = aws_base64_decode(&to_decode, &decode_output);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
     AWS_ASSERT(output_size == decode_output.len);
     AWS_ASSERT(memcmp(decode_output.buffer, data, size) == 0);
 

--- a/tests/fuzz/hex_encoding_transitive.c
+++ b/tests/fuzz/hex_encoding_transitive.c
@@ -22,29 +22,29 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     size_t output_size = 0;
     int result = aws_hex_compute_encoded_len(size, &output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     struct aws_byte_cursor to_encode = aws_byte_cursor_from_array(data, size);
 
     struct aws_byte_buf encode_output;
     result = aws_byte_buf_init(&encode_output, allocator, output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     result = aws_hex_encode(&to_encode, &encode_output);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
     --encode_output.len; /* Remove null terminator */
 
     result = aws_hex_compute_decoded_len(encode_output.len, &output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
     AWS_ASSERT(output_size == size);
 
     struct aws_byte_buf decode_output;
     result = aws_byte_buf_init(&decode_output, allocator, output_size);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
 
     struct aws_byte_cursor decode_input = aws_byte_cursor_from_buf(&encode_output);
     result = aws_hex_decode(&decode_input, &decode_output);
-    AWS_ASSERT(result == AWS_OP_SUCCESS);
+    AWS_ASSERT(result == AWS_OP_SUCC);
     AWS_ASSERT(output_size == decode_output.len);
     AWS_ASSERT(memcmp(decode_output.buffer, data, size) == 0);
 

--- a/tests/linked_list_test.c
+++ b/tests/linked_list_test.c
@@ -264,7 +264,7 @@ static int s_test_linked_list_swap_contents(struct aws_allocator *allocator, voi
     ASSERT_TRUE(aws_linked_list_empty(&a));
     ASSERT_TRUE(aws_linked_list_empty(&b));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(linked_list_push_back_pop_front, s_test_linked_list_order_push_back_pop_front)

--- a/tests/priority_queue_test.c
+++ b/tests/priority_queue_test.c
@@ -193,7 +193,7 @@ static int s_test_priority_queue_size_and_capacity(struct aws_allocator *allocat
         size_t CHECK_ORDER_count = sizeof(CHECK_ORDER_elems) / sizeof(*CHECK_ORDER_elems);                             \
         size_t CHECK_ORDER_i = 0;                                                                                      \
         int CHECK_ORDER_val;                                                                                           \
-        while (aws_priority_queue_pop(&(pq), &CHECK_ORDER_val) == AWS_OP_SUCCESS) {                                    \
+        while (aws_priority_queue_pop(&(pq), &CHECK_ORDER_val) == AWS_OP_SUCC) {                                    \
             ASSERT_TRUE(CHECK_ORDER_i < CHECK_ORDER_count);                                                            \
             ASSERT_INT_EQUALS(CHECK_ORDER_val, CHECK_ORDER_elems[CHECK_ORDER_i]);                                      \
             CHECK_ORDER_i++;                                                                                           \

--- a/tests/ring_buffer_test.c
+++ b/tests/ring_buffer_test.c
@@ -62,7 +62,7 @@ static int s_test_1_to_1_acquire_release_wraps(struct aws_allocator *allocator, 
 
     aws_ring_buffer_clean_up(&ring_buffer);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(ring_buffer_1_to_1_acquire_release_wraps_test, s_test_1_to_1_acquire_release_wraps)
@@ -100,7 +100,7 @@ static int s_test_release_after_full(struct aws_allocator *allocator, void *ctx)
 
     aws_ring_buffer_clean_up(&ring_buffer);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(ring_buffer_release_after_full_test, s_test_release_after_full)
@@ -150,7 +150,7 @@ static int s_test_acquire_up_to(struct aws_allocator *allocator, void *ctx) {
 
     aws_ring_buffer_clean_up(&ring_buffer);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(ring_buffer_acquire_up_to_test, s_test_acquire_up_to)
@@ -214,7 +214,7 @@ static int s_test_acquire_tail_always_chases_head(struct aws_allocator *allocato
     ASSERT_TRUE(aws_ring_buffer_buf_belongs_to_pool(&ring_buffer, &vended_buffer_2));
     aws_ring_buffer_clean_up(&ring_buffer);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(ring_buffer_acquire_tail_always_chases_head_test, s_test_acquire_tail_always_chases_head)
@@ -380,7 +380,7 @@ static int s_test_acquire_any_muti_threaded(
 
     ASSERT_FALSE(test_data.match_failed);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 static int s_test_acquire_multi_threaded(struct aws_allocator *allocator, void *ctx) {

--- a/tests/task_scheduler_test.c
+++ b/tests/task_scheduler_test.c
@@ -295,7 +295,7 @@ static int s_test_scheduler_cleanup_reentrants(struct aws_allocator *allocator, 
     ASSERT_INT_EQUALS(AWS_TASK_STATUS_CANCELED, future_task1_args.status);
     ASSERT_INT_EQUALS(AWS_TASK_STATUS_CANCELED, future_task2_args.status);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 /* Allocator that only works N times. Not at all thread safe. */
@@ -441,7 +441,7 @@ static int s_test_scheduler_oom_still_works(struct aws_allocator *allocator, voi
     ASSERT_UINT_EQUALS(scheduled_task_count, done_task_count);
 
     s_oom_allocator_destroy(oom_allocator);
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 struct task_cancelling_task_data {

--- a/tests/uuid_test.c
+++ b/tests/uuid_test.c
@@ -34,7 +34,7 @@ static int s_uuid_string_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_UINT_EQUALS(AWS_UUID_STR_LEN - 1, uuid_buf.len);
     ASSERT_FALSE(0 == memcmp(zerod_buf, uuid_array, sizeof(uuid_array)));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(uuid_string, s_uuid_string_fn)
@@ -57,7 +57,7 @@ static int s_prefilled_uuid_string_fn(struct aws_allocator *allocator, void *ctx
     struct aws_byte_buf expected = aws_byte_buf_from_c_str(expected_str);
     ASSERT_BIN_ARRAYS_EQUALS(expected.buffer, expected.len, uuid_buf.buffer, uuid_buf.len);
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(prefilled_uuid_string, s_prefilled_uuid_string_fn)
@@ -75,7 +75,7 @@ static int s_uuid_string_short_buffer_fn(struct aws_allocator *allocator, void *
 
     ASSERT_ERROR(AWS_ERROR_SHORT_BUFFER, aws_uuid_to_str(&uuid, &uuid_buf));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(uuid_string_short_buffer, s_uuid_string_short_buffer_fn)
@@ -95,7 +95,7 @@ static int s_uuid_string_parse_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_SUCCESS(aws_uuid_init_from_str(&uuid, &uuid_cur));
     ASSERT_BIN_ARRAYS_EQUALS(expected_uuid, sizeof(expected_uuid), uuid.uuid_data, sizeof(uuid.uuid_data));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(uuid_string_parse, s_uuid_string_parse_fn)
@@ -111,7 +111,7 @@ static int s_uuid_string_parse_too_short_fn(struct aws_allocator *allocator, voi
     struct aws_uuid uuid;
     ASSERT_ERROR(AWS_ERROR_INVALID_BUFFER_SIZE, aws_uuid_init_from_str(&uuid, &uuid_cur));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(uuid_string_parse_too_short, s_uuid_string_parse_too_short_fn)
@@ -127,7 +127,7 @@ static int s_uuid_string_parse_malformed_fn(struct aws_allocator *allocator, voi
     struct aws_uuid uuid;
     ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_uuid_init_from_str(&uuid, &uuid_cur));
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_SUCC;
 }
 
 AWS_TEST_CASE(uuid_string_parse_malformed, s_uuid_string_parse_malformed_fn)


### PR DESCRIPTION
Why abbreviate one when we can abbreviate both?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*edit*: this PR is a joke