### PR TITLE
Parse (<function>+<addr>) backtrace format on POSIX systems

### DIFF
--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -197,8 +197,7 @@ int s_parse_symbol(const char *symbol, void *addr, struct aws_stack_frame_info *
         const char *function_end = (plus) ? plus : close_paren;
         if (function_end > function_start) {
             strncpy(frame->function, function_start, function_end - function_start);
-        }
-        else if (plus) {
+        } else if (plus) {
             strncpy(frame->addr, plus + 1, close_paren - plus - 1);
         }
     }

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -195,7 +195,7 @@ int s_parse_symbol(const char *symbol, void *addr, struct aws_stack_frame_info *
             long addr_len = close_paren - plus - 1;
             strncpy(frame->addr, plus + 1, addr_len);
         }
-    } 
+    }
     if (frame->addr[0] == 0) {
         /* use the address in []'s, since it's all we have */
         const char *addr_start = strstr(exe_end, "[") + 1;


### PR DESCRIPTION
Fixes #356

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
