### PR TITLE
Fixed typo that broke osx build.

### DIFF
--- a/source/posix/clock.c
+++ b/source/posix/clock.c
@@ -45,8 +45,8 @@ static int s_legacy_get_time(uint64_t *timestamp) {
         return aws_raise_error(AWS_ERROR_CLOCK_FAILURE);
     }
 
-    uint64_t secs = (uint64_t)ts.tv_sec;
-    uint64_t u_secs = (uint64_t)ts.tv_usec;
+    uint64_t secs = (uint64_t)tv.tv_sec;
+    uint64_t u_secs = (uint64_t)tv.tv_usec;
     *timestamp = (secs * NS_PER_SEC) + (u_secs * 1000);
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
