### PR TITLE
Timebomb allocator

### DIFF
--- a/include/aws/testing/aws_test_allocators.h
+++ b/include/aws/testing/aws_test_allocators.h
@@ -1,0 +1,97 @@
+#ifndef AWS_TESTING_AWS_TEST_ALLOCATORS_H
+#define AWS_TESTING_AWS_TEST_ALLOCATORS_H
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/testing/aws_test_harness.h>
+
+/** \file
+ * Alternate allocators for use in testing.
+ */
+
+/**
+ * Timebomb allocator fakes running out of memory after then Nth allocation.
+ * Once this allocator starts failing, it never succeeds, even if memory is released.
+ * Wraps an existing allocator.
+ */
+struct aws_timebomb_impl {
+    size_t fail_after_n_allocations;
+    size_t allocation_tally;
+    struct aws_mutex mutex;
+    struct aws_allocator *wrapped_allocator;
+};
+
+static void *s_timebomb_mem_acquire(struct aws_allocator *timebomb_alloc, size_t size) {
+    struct aws_timebomb_impl *timebomb_impl = timebomb_alloc->impl;
+    void *ptr = NULL;
+
+    aws_mutex_lock(&timebomb_impl->mutex);
+
+    if (timebomb_impl->allocation_tally < timebomb_impl->fail_after_n_allocations) {
+        timebomb_impl->allocation_tally++;
+        ptr = timebomb_impl->wrapped_allocator->mem_acquire(timebomb_impl->wrapped_allocator, size);
+    }
+
+    aws_mutex_unlock(&timebomb_impl->mutex);
+
+    return ptr;
+}
+
+static void s_timebomb_mem_release(struct aws_allocator *timebomb_alloc, void *ptr) {
+    struct aws_timebomb_impl *timebomb_impl = timebomb_alloc->impl;
+
+    aws_mutex_lock(&timebomb_impl->mutex);
+    timebomb_impl->wrapped_allocator->mem_release(timebomb_impl->wrapped_allocator, ptr);
+    aws_mutex_unlock(&timebomb_impl->mutex);
+}
+
+static int aws_timebomb_allocator_init(
+    struct aws_allocator *timebomb_allocator,
+    struct aws_allocator *wrapped_allocator,
+    size_t fail_after_n_allocations) {
+
+    AWS_ZERO_STRUCT(*timebomb_allocator);
+
+    struct aws_timebomb_impl *timebomb_impl = aws_mem_calloc(wrapped_allocator, 1, sizeof(struct aws_timebomb_impl));
+    ASSERT_NOT_NULL(timebomb_impl);
+
+    timebomb_allocator->mem_acquire = s_timebomb_mem_acquire;
+    timebomb_allocator->mem_release = s_timebomb_mem_release;
+    timebomb_allocator->impl = timebomb_impl;
+
+    timebomb_impl->fail_after_n_allocations = fail_after_n_allocations;
+    ASSERT_SUCCESS(aws_mutex_init(&timebomb_impl->mutex));
+    timebomb_impl->wrapped_allocator = wrapped_allocator;
+
+    return AWS_OP_SUCCESS;
+}
+
+static void aws_timebomb_allocator_clean_up(struct aws_allocator *timebomb_alloc) {
+    if (timebomb_alloc) {
+        struct aws_timebomb_impl *timebomb_impl = timebomb_alloc->impl;
+        aws_mutex_clean_up(&timebomb_impl->mutex);
+        aws_mem_release(timebomb_impl->wrapped_allocator, timebomb_impl);
+    }
+}
+
+static void aws_timebomb_allocator_reset(struct aws_allocator *timebomb_alloc, size_t fail_after_n_allocations) {
+    struct aws_timebomb_impl *timebomb_impl = timebomb_alloc->impl;
+    aws_mutex_lock(&timebomb_impl->mutex);
+    timebomb_impl->allocation_tally = 0;
+    timebomb_impl->fail_after_n_allocations = fail_after_n_allocations;
+    aws_mutex_unlock(&timebomb_impl->mutex);
+}
+
+#endif /* AWS_TESTING_AWS_TEST_ALLOCATORS_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -248,6 +248,8 @@ add_test_case(test_calloc_fallback_from_given)
 add_test_case(test_calloc_from_default_allocator)
 add_test_case(test_calloc_from_given_allocator)
 
+add_test_case(timebomb_allocator)
+
 add_test_case(test_lru_cache_overflow_static_members)
 add_test_case(test_lru_cache_lru_ness_static_members)
 add_test_case(test_lru_cache_entries_cleanup)

--- a/tests/timebomb_test.c
+++ b/tests/timebomb_test.c
@@ -35,7 +35,7 @@ static int s_test_timebomb_allocator(struct aws_allocator *allocator, void *ctx)
     ASSERT_NULL(aws_mem_acquire(&timebomb, 1));
 
     /* Reset should allow allocations to succeed again (until bomb goes off). */
-    aws_timebomb_allocator_reset(&timebomb, 1);
+    aws_timebomb_allocator_reset_countdown(&timebomb, 1);
     one = aws_mem_acquire(&timebomb, 1);
     ASSERT_NOT_NULL(one);
 

--- a/tests/timebomb_test.c
+++ b/tests/timebomb_test.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/testing/aws_test_allocators.h>
+
+static int s_test_timebomb_allocator(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_allocator timebomb;
+    ASSERT_SUCCESS(aws_timebomb_allocator_init(&timebomb, allocator, 2));
+
+    /* Should have two successful allocations, then failures. */
+    void *one = aws_mem_acquire(&timebomb, 1);
+    ASSERT_NOT_NULL(one);
+
+    void *two = aws_mem_calloc(&timebomb, 1, 1);
+    ASSERT_NOT_NULL(two);
+
+    ASSERT_NULL(aws_mem_acquire(&timebomb, 1));
+    ASSERT_NULL(aws_mem_acquire(&timebomb, 1));
+
+    /* Releasing memory should not stop the allocations from failing. */
+    aws_mem_release(&timebomb, one);
+    ASSERT_NULL(aws_mem_acquire(&timebomb, 1));
+
+    /* Reset should allow allocations to succeed again (until bomb goes off). */
+    aws_timebomb_allocator_reset(&timebomb, 1);
+    one = aws_mem_acquire(&timebomb, 1);
+    ASSERT_NOT_NULL(one);
+
+    ASSERT_NULL(aws_mem_acquire(&timebomb, 1));
+
+    /* Clean up */
+    aws_mem_release(&timebomb, one);
+    aws_mem_release(&timebomb, two);
+    aws_timebomb_allocator_clean_up(&timebomb);
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(timebomb_allocator, s_test_timebomb_allocator);


### PR DESCRIPTION
Timebomb allocator fakes running out of memory after then Nth allocation.

This is for use in tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
