### PR TITLE
Apply clang-format to .inl files

### DIFF
--- a/format-check.sh
+++ b/format-check.sh
@@ -10,7 +10,7 @@ if NOT type $CLANG_FORMAT 2> /dev/null ; then
 fi
 
 FAIL=0
-SOURCE_FILES=`find source include tests .cbmc-batch -type f \( -name '*.h' -o -name '*.c' \) -not -name "lookup3.c"`
+SOURCE_FILES=`find source include tests .cbmc-batch -type f \( -name '*.h' -o -name '*.c' -o -name '*.inl' \) -not -name "lookup3.c"`
 for i in $SOURCE_FILES
 do
     $CLANG_FORMAT -output-replacements-xml $i | grep -c "<replacement " > /dev/null

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -79,13 +79,15 @@ void aws_array_list_init_static(
 
 AWS_STATIC_IMPL
 bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
-    if(!list) {
+    if (!list) {
         return false;
     }
     size_t required_size = 0;
-    bool required_size_is_valid = (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS);
+    bool required_size_is_valid =
+        (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS);
     bool current_size_is_valid = (list->current_size >= required_size);
-    bool data_is_valid = ((list->current_size == 0 && list->data == NULL) || AWS_MEM_IS_WRITABLE(list->data, list->current_size));
+    bool data_is_valid =
+        ((list->current_size == 0 && list->data == NULL) || AWS_MEM_IS_WRITABLE(list->data, list->current_size));
     return required_size_is_valid && current_size_is_valid && data_is_valid;
 }
 
@@ -107,7 +109,9 @@ void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list) {
 AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
+    AWS_PRECONDITION(
+        val && AWS_MEM_IS_READABLE(val, list->item_size),
+        "Input pointer [val] must point writable memory of [list->item_size] bytes.");
 
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
 
@@ -123,7 +127,9 @@ int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const voi
 AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
+    AWS_PRECONDITION(
+        val && AWS_MEM_IS_WRITABLE(val, list->item_size),
+        "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -172,7 +178,7 @@ void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t
 int aws_array_list_erase(struct aws_array_list *AWS_RESTRICT list, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
 
-    const size_t length  = aws_array_list_length(list);
+    const size_t length = aws_array_list_length(list);
 
     if (index >= length) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -203,7 +209,9 @@ int aws_array_list_erase(struct aws_array_list *AWS_RESTRICT list, size_t index)
 AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
+    AWS_PRECONDITION(
+        val && AWS_MEM_IS_WRITABLE(val, list->item_size),
+        "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -290,7 +298,9 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
 AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_WRITABLE(val, list->item_size), "Input pointer [val] must point writable memory of [list->item_size] bytes.");
+    AWS_PRECONDITION(
+        val && AWS_MEM_IS_WRITABLE(val, list->item_size),
+        "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -333,7 +343,9 @@ int aws_array_list_calc_necessary_size(struct aws_array_list *AWS_RESTRICT list,
 AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val && AWS_MEM_IS_READABLE(val, list->item_size), "Input pointer [val] must point readable memory of [list->item_size] bytes.");
+    AWS_PRECONDITION(
+        val && AWS_MEM_IS_READABLE(val, list->item_size),
+        "Input pointer [val] must point readable memory of [list->item_size] bytes.");
 
     if (aws_array_list_ensure_capacity(list, index)) {
         AWS_POSTCONDITION(aws_array_list_is_valid(list));

--- a/include/aws/common/math.fallback.inl
+++ b/include/aws/common/math.fallback.inl
@@ -1,17 +1,17 @@
 /*
-* Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
-*
-*  http://aws.amazon.com/apache2.0
-*
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*/
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 
 /*
  * This header is already included, but include it again to make editor
@@ -33,7 +33,7 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
  * a * b, returns the result in *r, and returns AWS_OP_SUCCESS.
  */
 AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
-    if (a > 0 && b >0 && a > (UINT64_MAX / b))
+    if (a > 0 && b > 0 && a > (UINT64_MAX / b))
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     *r = a * b;
     return AWS_OP_SUCCESS;

--- a/include/aws/common/math.gcc_x64_asm.inl
+++ b/include/aws/common/math.gcc_x64_asm.inl
@@ -32,8 +32,8 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
     __asm__("mulq %q[arg2]\n" /* rax * b, result is in RDX:RAX, OF=CF=(RDX != 0) */
             "cmovc %q[saturate], %%rax\n"
             : /* in/out: %rax = a, out: rdx (ignored) */ "+&a"(a), "=&d"(rdx)
-            : /* in: register only */ [arg2] "r"(b),
-              /* in: saturation value (reg/memory) */ [saturate] "rm"(~0LL)
+            : /* in: register only */[ arg2 ] "r"(b),
+              /* in: saturation value (reg/memory) */[ saturate ] "rm"(~0LL)
             : /* clobbers: cc */ "cc");
     (void)rdx; /* suppress unused warnings */
     return a;
@@ -50,9 +50,9 @@ AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     uint64_t result = a;
     __asm__("mulq %q[arg2]\n" /* rax * b, result is in RDX:RAX, OF=CF=(RDX != 0) */
             "seto %[flag]\n"  /* flag = overflow_bit */
-            : /* in/out: %rax (first arg & result), %d (flag) */ "+&a"(result), [flag] "=&d"(flag)
+            : /* in/out: %rax (first arg & result), %d (flag) */ "+&a"(result), [ flag ] "=&d"(flag)
             : /* in: reg for 2nd operand */
-            [arg2] "r"(b)
+            [ arg2 ] "r"(b)
             : /* clobbers: cc (d is used for flag so no need to clobber)*/ "cc");
     *r = result;
     if (flag) {
@@ -76,7 +76,7 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
             "mov $0xFFFFFFFF, %%eax\n"
             ".1f%=:"
             : /* in/out: %eax = result/a, out: edx (ignored) */ "+&a"(a), "=&d"(edx)
-            : /* in: operand 2 in reg */ [arg2] "r"(b)
+            : /* in: operand 2 in reg */[ arg2 ] "r"(b)
             : /* clobbers: cc */ "cc");
     (void)edx; /* suppress unused warnings */
     return a;
@@ -96,9 +96,9 @@ AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
      */
     __asm__("mull %k[arg2]\n" /* eax * b, result is in EDX:EAX, OF=CF=(EDX != 0) */
             "seto %[flag]\n"  /* flag = overflow_bit */
-            : /* in/out: %eax (first arg & result), %d (flag) */ "+&a"(result), [flag] "=&d"(flag)
+            : /* in/out: %eax (first arg & result), %d (flag) */ "+&a"(result), [ flag ] "=&d"(flag)
             : /* in: reg for 2nd operand */
-            [arg2] "r"(b)
+            [ arg2 ] "r"(b)
             : /* clobbers: cc (d is used for flag so no need to clobber)*/ "cc");
     *r = result;
     if (flag) {
@@ -117,8 +117,8 @@ AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     char flag;
     __asm__("addq %[argb], %[arga]\n" /* [arga] = [arga] + [argb] */
             "setc %[flag]\n"          /* [flag] = 1 if overflow, 0 otherwise */
-            : /* in/out: */ [arga] "+r"(a), [flag] "=&r"(flag)
-            : /* in: */ [argb] "r"(b)
+            : /* in/out: */[ arga ] "+r"(a), [ flag ] "=&r"(flag)
+            : /* in: */[ argb ] "r"(b)
             : /* clobbers: */ "cc");
     *r = a;
     if (flag) {
@@ -136,8 +136,8 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
     uint64_t result = UINT64_MAX;
     __asm__("addq %[argb], %[arga]\n"      /* [arga] = [arga] + [argb] */
             "cmovncq %[arga], %[result]\n" /* [result] = UINT64_MAX if overflow, a+b otherwise*/
-            : /* in/out: */ [result] "+r"(result)
-            : /* in: */ [arga] "r"(a), [argb] "r"(b)
+            : /* in/out: */[ result ] "+r"(result)
+            : /* in: */[ arga ] "r"(a), [ argb ] "r"(b)
             : /* clobbers: */ "cc");
     return result;
 }
@@ -152,8 +152,8 @@ AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     char flag;
     __asm__("addl %[argb], %[arga]\n" /* [arga] = [arga] + [argb] */
             "setc %[flag]\n"          /* [flag] = 1 if overflow, 0 otherwise */
-            : /* in/out: */ [arga] "+r"(a), [flag] "=&r"(flag)
-            : /* in: */ [argb] "r"(b)
+            : /* in/out: */[ arga ] "+r"(a), [ flag ] "=&r"(flag)
+            : /* in: */[ argb ] "r"(b)
             : /* clobbers: */ "cc");
     *r = a;
     if (flag) {
@@ -171,8 +171,8 @@ AWS_STATIC_IMPL uint64_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
     uint32_t result = UINT32_MAX;
     __asm__("addl %[argb], %[arga]\n"      /* [arga] = [arga] + [argb] */
             "cmovncl %[arga], %[result]\n" /* [result] = UINT32_MAX if overflow, a+b otherwise*/
-            : /* in/out: */ [result] "+r"(result)
-            : /* in: */ [arga] "r"(a), [argb] "r"(b)
+            : /* in/out: */[ result ] "+r"(result)
+            : /* in: */[ arga ] "r"(a), [ argb ] "r"(b)
             : /* clobbers: */ "cc");
     return result;
 }

--- a/include/aws/common/math.gcc_x64_asm.inl
+++ b/include/aws/common/math.gcc_x64_asm.inl
@@ -32,8 +32,8 @@ AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
     __asm__("mulq %q[arg2]\n" /* rax * b, result is in RDX:RAX, OF=CF=(RDX != 0) */
             "cmovc %q[saturate], %%rax\n"
             : /* in/out: %rax = a, out: rdx (ignored) */ "+&a"(a), "=&d"(rdx)
-            : /* in: register only */[ arg2 ] "r"(b),
-              /* in: saturation value (reg/memory) */[ saturate ] "rm"(~0LL)
+            : /* in: register only */ [arg2] "r"(b),
+              /* in: saturation value (reg/memory) */ [saturate] "rm"(~0LL)
             : /* clobbers: cc */ "cc");
     (void)rdx; /* suppress unused warnings */
     return a;
@@ -50,9 +50,9 @@ AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     uint64_t result = a;
     __asm__("mulq %q[arg2]\n" /* rax * b, result is in RDX:RAX, OF=CF=(RDX != 0) */
             "seto %[flag]\n"  /* flag = overflow_bit */
-            : /* in/out: %rax (first arg & result), %d (flag) */ "+&a"(result), [ flag ] "=&d"(flag)
+            : /* in/out: %rax (first arg & result), %d (flag) */ "+&a"(result), [flag] "=&d"(flag)
             : /* in: reg for 2nd operand */
-            [ arg2 ] "r"(b)
+            [arg2] "r"(b)
             : /* clobbers: cc (d is used for flag so no need to clobber)*/ "cc");
     *r = result;
     if (flag) {
@@ -76,7 +76,7 @@ AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b) {
             "mov $0xFFFFFFFF, %%eax\n"
             ".1f%=:"
             : /* in/out: %eax = result/a, out: edx (ignored) */ "+&a"(a), "=&d"(edx)
-            : /* in: operand 2 in reg */[ arg2 ] "r"(b)
+            : /* in: operand 2 in reg */ [arg2] "r"(b)
             : /* clobbers: cc */ "cc");
     (void)edx; /* suppress unused warnings */
     return a;
@@ -96,9 +96,9 @@ AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
      */
     __asm__("mull %k[arg2]\n" /* eax * b, result is in EDX:EAX, OF=CF=(EDX != 0) */
             "seto %[flag]\n"  /* flag = overflow_bit */
-            : /* in/out: %eax (first arg & result), %d (flag) */ "+&a"(result), [ flag ] "=&d"(flag)
+            : /* in/out: %eax (first arg & result), %d (flag) */ "+&a"(result), [flag] "=&d"(flag)
             : /* in: reg for 2nd operand */
-            [ arg2 ] "r"(b)
+            [arg2] "r"(b)
             : /* clobbers: cc (d is used for flag so no need to clobber)*/ "cc");
     *r = result;
     if (flag) {
@@ -117,8 +117,8 @@ AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
     char flag;
     __asm__("addq %[argb], %[arga]\n" /* [arga] = [arga] + [argb] */
             "setc %[flag]\n"          /* [flag] = 1 if overflow, 0 otherwise */
-            : /* in/out: */[ arga ] "+r"(a), [ flag ] "=&r"(flag)
-            : /* in: */[ argb ] "r"(b)
+            : /* in/out: */ [arga] "+r"(a), [flag] "=&r"(flag)
+            : /* in: */ [argb] "r"(b)
             : /* clobbers: */ "cc");
     *r = a;
     if (flag) {
@@ -136,8 +136,8 @@ AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b) {
     uint64_t result = UINT64_MAX;
     __asm__("addq %[argb], %[arga]\n"      /* [arga] = [arga] + [argb] */
             "cmovncq %[arga], %[result]\n" /* [result] = UINT64_MAX if overflow, a+b otherwise*/
-            : /* in/out: */[ result ] "+r"(result)
-            : /* in: */[ arga ] "r"(a), [ argb ] "r"(b)
+            : /* in/out: */ [result] "+r"(result)
+            : /* in: */ [arga] "r"(a), [argb] "r"(b)
             : /* clobbers: */ "cc");
     return result;
 }
@@ -152,8 +152,8 @@ AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     char flag;
     __asm__("addl %[argb], %[arga]\n" /* [arga] = [arga] + [argb] */
             "setc %[flag]\n"          /* [flag] = 1 if overflow, 0 otherwise */
-            : /* in/out: */[ arga ] "+r"(a), [ flag ] "=&r"(flag)
-            : /* in: */[ argb ] "r"(b)
+            : /* in/out: */ [arga] "+r"(a), [flag] "=&r"(flag)
+            : /* in: */ [argb] "r"(b)
             : /* clobbers: */ "cc");
     *r = a;
     if (flag) {
@@ -171,8 +171,8 @@ AWS_STATIC_IMPL uint64_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
     uint32_t result = UINT32_MAX;
     __asm__("addl %[argb], %[arga]\n"      /* [arga] = [arga] + [argb] */
             "cmovncl %[arga], %[result]\n" /* [result] = UINT32_MAX if overflow, a+b otherwise*/
-            : /* in/out: */[ result ] "+r"(result)
-            : /* in: */[ arga ] "r"(a), [ argb ] "r"(b)
+            : /* in/out: */ [result] "+r"(result)
+            : /* in: */ [arga] "r"(a), [argb] "r"(b)
             : /* clobbers: */ "cc");
     return result;
 }


### PR DESCRIPTION
*Description of changes:*
turns out we weren't running clang-format on .inl files. Fix that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
