### PR TITLE
Ensure error list stays in sync

### DIFF
--- a/source/error.c
+++ b/source/error.c
@@ -167,8 +167,13 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
     /* Assert that error info entries are in the right order. */
     for (int i = 1; i < error_info->count; ++i) {
         int expected_code = min_range + i;
-        if (error_info->error_list[i].error_code != expected_code) {
-            fprintf(stderr, "Error %s is at wrong index of error info list.\n", error_info->error_list[i].literal_name);
+        const struct aws_error_info *info = &error_info->error_list[i];
+        if (info->error_code != expected_code) {
+            if (info->error_code) {
+                fprintf(stderr, "Error %s is at wrong index of error info list.\n", info->literal_name);
+            } else {
+                fprintf(stderr, "Error %d is missing from error info list.\n", expected_code);
+            }
             abort();
         }
     }

--- a/source/error.c
+++ b/source/error.c
@@ -179,7 +179,7 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
 
 static int8_t s_error_strings_loaded = 0;
 
-#define AWS_DEFINE_ERROR_INFO_COMMON(C, ES) [C - AWS_ERROR_SUCCESS] = AWS_DEFINE_ERROR_INFO(C, ES, "libaws-c-common")
+#define AWS_DEFINE_ERROR_INFO_COMMON(C, ES) [C - 0x0000] = AWS_DEFINE_ERROR_INFO(C, ES, "libaws-c-common")
 
 /* clang-format off */
 static struct aws_error_info errors[] = {

--- a/source/error.c
+++ b/source/error.c
@@ -159,14 +159,14 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
     if (slot_index >= AWS_MAX_ERROR_SLOTS || slot_index < 0) {
         /* This is an NDEBUG build apparently. Kill the process rather than
          * corrupting heap. */
-        fprintf(stderr, "Bad error slot index 0x%016x\n", slot_index);
-        abort();
+        fprintf(stderr, "Bad error slot index %d\n", slot_index);
+        AWS_FATAL_ASSERT(0);
     }
 
 #if DEBUG_BUILD
     /* Assert that error info entries are in the right order. */
     for (int i = 1; i < error_info->count; ++i) {
-        int expected_code = min_range + i;
+        const int expected_code = min_range + i;
         const struct aws_error_info *info = &error_info->error_list[i];
         if (info->error_code != expected_code) {
             if (info->error_code) {
@@ -174,7 +174,7 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
             } else {
                 fprintf(stderr, "Error %d is missing from error info list.\n", expected_code);
             }
-            abort();
+            AWS_FATAL_ASSERT(0);
         }
     }
 #endif /* DEBUG_BUILD */

--- a/source/error.c
+++ b/source/error.c
@@ -179,7 +179,7 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
 
 static int8_t s_error_strings_loaded = 0;
 
-#define AWS_DEFINE_ERROR_INFO_COMMON(C, ES) [C - 0x0000] = AWS_DEFINE_ERROR_INFO(C, ES, "libaws-c-common")
+#define AWS_DEFINE_ERROR_INFO_COMMON(C, ES) [(C)-0x0000] = AWS_DEFINE_ERROR_INFO(C, ES, "libaws-c-common")
 
 /* clang-format off */
 static struct aws_error_info errors[] = {

--- a/source/error.c
+++ b/source/error.c
@@ -163,12 +163,23 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
         abort();
     }
 
+#if DEBUG_BUILD
+    /* Assert that error info entries are in the right order. */
+    for (int i = 1; i < error_info->count; ++i) {
+        int expected_code = min_range + i;
+        if (error_info->error_list[i].error_code != expected_code) {
+            fprintf(stderr, "Error %s is at wrong index of error info list.\n", error_info->error_list[i].literal_name);
+            abort();
+        }
+    }
+#endif /* DEBUG_BUILD */
+
     ERROR_SLOTS[slot_index] = error_info;
 }
 
 static int8_t s_error_strings_loaded = 0;
 
-#define AWS_DEFINE_ERROR_INFO_COMMON(C, ES) AWS_DEFINE_ERROR_INFO(C, ES, "libaws-c-common")
+#define AWS_DEFINE_ERROR_INFO_COMMON(C, ES) [C - AWS_ERROR_SUCCESS] = AWS_DEFINE_ERROR_INFO(C, ES, "libaws-c-common")
 
 /* clang-format off */
 static struct aws_error_info errors[] = {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_test_case(error_callback_test)
 add_test_case(unknown_error_code_in_slot_test)
 add_test_case(unknown_error_code_no_slot_test)
 add_test_case(unknown_error_code_range_too_large_test)
+add_test_case(aws_load_error_strings_test)
 
 add_test_case(thread_creation_join_test)
 

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -444,6 +444,13 @@ static int s_error_code_cross_thread_test_fn(struct aws_allocator *allocator, vo
     return 0;
 }
 
+static int s_aws_load_error_strings_test(struct aws_allocator *allocator, void *ctx) {
+    /* Load aws-c-common's actual error info.
+     * This will fail if the error info list is out of sync with the error enums. */
+    aws_load_error_strings();
+    return AWS_OP_SUCCESS;
+}
+
 AWS_TEST_CASE_FIXTURE(
     raise_errors_test,
     s_setup_errors_test_fn,
@@ -486,3 +493,4 @@ AWS_TEST_CASE_FIXTURE(
     s_error_code_cross_thread_test_fn,
     s_teardown_errors_test_fn,
     NULL)
+AWS_TEST_CASE(aws_load_error_strings_test, s_aws_load_error_strings_test)

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -445,6 +445,9 @@ static int s_error_code_cross_thread_test_fn(struct aws_allocator *allocator, vo
 }
 
 static int s_aws_load_error_strings_test(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
     /* Load aws-c-common's actual error info.
      * This will fail if the error info list is out of sync with the error enums. */
     aws_load_error_strings();


### PR DESCRIPTION
- Abort with helpful message if **any** library registers an error list that's out of sync.
- Add unit test that loads aws-c-common's error list, so we can freak out if it's out of sync.
- Modify MACRO used to defin aws-c-common's error list, so it can't actually get out of sync anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
