### PR TITLE
Enable -Wunreachable-code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*,-readability-magic-numbers,-readability-non-const-parameter,-readability-isolate-declaration,-readability-uppercase-literal-suffix'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*(?<!lookup3.c)$'
+HeaderFilterRegex: '.*\.[h|inl]'
 FormatStyle: 'file'
 CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -35,7 +35,7 @@ function(aws_set_common_properties target)
         # /volatile:iso relaxes some implicit memory barriers that MSVC normally applies for volatile accesses
         # Since we want to be compatible with user builds using /volatile:iso, use it for the tests.
         list(APPEND AWS_C_FLAGS /volatile:iso)
-        
+
         string(TOUPPER "${CMAKE_BUILD_TYPE}" _CMAKE_BUILD_TYPE)
         if(STATIC_CRT)
             string(REPLACE "/MD" "/MT" _FLAGS "${CMAKE_C_FLAGS_${_CMAKE_BUILD_TYPE}}")
@@ -55,6 +55,8 @@ function(aws_set_common_properties target)
         if(NOT SET_PROPERTIES_NO_PEDANTIC)
             list(APPEND AWS_C_FLAGS -pedantic)
         endif()
+
+        list(APPEND AWS_C_FLAGS -Wunreachable-code)
 
         # Warning disables always go last to avoid future flags re-enabling them
         list(APPEND AWS_C_FLAGS -Wno-long-long)
@@ -124,7 +126,7 @@ function(aws_set_common_properties target)
             list(APPEND AWS_C_FLAGS "-fvisibility=hidden")
         endif()
     endif()
-    
+
     target_compile_options(${target} PRIVATE ${AWS_C_FLAGS})
     target_compile_definitions(${target} PRIVATE ${AWS_C_DEFINES_PRIVATE} PUBLIC ${AWS_C_DEFINES_PUBLIC})
     set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -319,6 +319,11 @@ COMPILERS = {
                     'generator_postfix': " Win64",
                 },
             },
+            'arm': {
+                'variables': {
+                    'generator_postfix': " ARM",
+                },
+            },
         },
     },
     'ndk': {
@@ -588,6 +593,10 @@ def run_build(build_spec, is_dryrun):
 # CODEBUILD
 ########################################################################################################################
 
+CODEBUILD_PROJECTS = [
+    'windows-msvc-2017-windows-arm',
+]
+
 CODEBUILD_OVERRIDES = {
     'linux-clang3-x64': 'linux-clang-3-linux-x64',
     'linux-clang6-x64': 'linux-clang-6-linux-x64',
@@ -720,6 +729,11 @@ if __name__ == '__main__':
             new_projects_response = codebuild.batch_get_projects(names=new_project_names)
             existing_projects += [project['name'] for project in new_projects_response['projects']]
             new_projects += new_projects_response['projectsNotFound']
+
+        # Check for projects that don't have overrides
+        fresh_projects_response = codebuild.batch_get_projects(names=CODEBUILD_PROJECTS)
+        existing_projects += [project['name'] for project in fresh_projects_response['projects']]
+        new_projects += fresh_projects_response['projectsNotFound']
 
         # Update all existing projects
         for cb_spec in existing_projects:

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -33,7 +33,6 @@ static inline size_t aws_common_private_base64_decode_sse41(const unsigned char 
     (void)out;
     (void)len;
     AWS_ASSERT(false);
-    return (size_t)-1; /* unreachable */
 }
 static inline void aws_common_private_base64_encode_sse41(const unsigned char *in, unsigned char *out, size_t len) {
     (void)in;


### PR DESCRIPTION
MSVC checks this, so it's probably worth turning on for clang/gcc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
