### PR TITLE
Update ring buffer proofs

### DIFF
--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -59,14 +59,11 @@ void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, 
 bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, const size_t max_size);
 
 /*
- * Ensures aws_ring_buffer has valid data
- */
-void ensure_ring_buffer_is_not_empty(struct aws_ring_buffer *ring_buf);
-
-/*
  * Ensure a byte_buf is allocated within a ring_buf (a relational invariant)
  */
-void ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(struct aws_byte_buf *buf, struct aws_ring_buffer *ring_buf);
+void ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(
+    struct aws_byte_buf *buf,
+    struct aws_ring_buffer *ring_buf);
 
 /*
  * Ensures aws_byte_cursor has a proper allocated buffer member

--- a/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
+++ b/.cbmc-batch/include/proof_helpers/make_common_data_structures.h
@@ -59,6 +59,16 @@ void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, 
 bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, const size_t max_size);
 
 /*
+ * Ensures aws_ring_buffer has valid data
+ */
+void ensure_ring_buffer_is_not_empty(struct aws_ring_buffer *ring_buf);
+
+/*
+ * Ensure a byte_buf is allocated within a ring_buf (a relational invariant)
+ */
+void ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(struct aws_byte_buf *buf, struct aws_ring_buffer *ring_buf);
+
+/*
  * Ensures aws_byte_cursor has a proper allocated buffer member
  */
 void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *const cursor);

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -31,13 +31,35 @@ void aws_ring_buffer_acquire_harness() {
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 
-    if (aws_ring_buffer_acquire(&ring_buf, requested_size, &buf) == AWS_OP_SUCCESS) {
-        /* assertions */
+    /* copy of pre-state */
+    struct aws_ring_buffer ring_buf_pre = ring_buf;
+
+    int result = aws_ring_buffer_acquire(&ring_buf, requested_size, &buf);
+
+    /* assertions */
+    uint8_t *old_head = aws_atomic_load_ptr(&ring_buf_pre.head);
+    uint8_t *old_tail = aws_atomic_load_ptr(&ring_buf_pre.tail);
+    uint8_t *new_head = aws_atomic_load_ptr(&ring_buf.head);
+    uint8_t *new_tail = aws_atomic_load_ptr(&ring_buf.tail);
+    if (result == AWS_OP_SUCCESS) {
         assert(aws_byte_buf_is_valid(&buf));
         assert(buf.capacity == requested_size);
         assert(AWS_MEM_IS_WRITABLE(buf.buffer, buf.capacity));
         assert(buf.len == 0); /* aws_byte_buf always created with aws_byte_buf_from_empty_array */
         assert(aws_ring_buffer_buf_belongs_to_pool(&ring_buf, &buf));
+        if (aws_ring_buffer_is_empty(&ring_buf_pre)) {
+            assert(new_head == ring_buf_pre.allocation + requested_size);
+            assert(new_tail == ring_buf_pre.allocation);
+        } else {
+            assert(new_head == ring_buf_pre.allocation + requested_size || new_head == old_head + requested_size);
+            assert(new_tail == old_tail);
+        }
+    } else {
+        assert(new_head == old_head);
+        assert(new_tail == old_tail);
     }
     assert(aws_ring_buffer_is_valid(&ring_buf));
+    assert(ring_buf.allocator == ring_buf_pre.allocator);
+    assert(ring_buf.allocation == ring_buf_pre.allocation);
+    assert(ring_buf.allocation_end == ring_buf_pre.allocation_end);
 }

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -33,11 +33,11 @@ void aws_ring_buffer_acquire_harness() {
 
     if (aws_ring_buffer_acquire(&ring_buf, requested_size, &buf) == AWS_OP_SUCCESS) {
         /* assertions */
-        assert(aws_ring_buffer_is_valid(&ring_buf));
         assert(aws_byte_buf_is_valid(&buf));
         assert(buf.capacity == requested_size);
         assert(AWS_MEM_IS_WRITABLE(buf.buffer, buf.capacity));
         assert(buf.len == 0); /* aws_byte_buf always created with aws_byte_buf_from_empty_array */
         assert(aws_ring_buffer_buf_belongs_to_pool(&ring_buf, &buf));
     }
+    assert(aws_ring_buffer_is_valid(&ring_buf));
 }

--- a/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
@@ -35,10 +35,10 @@ void aws_ring_buffer_acquire_up_to_harness() {
 
     if (aws_ring_buffer_acquire_up_to(&ring_buf, minimum_size, requested_size, &buf) == AWS_OP_SUCCESS) {
         /* assertions */
-        assert(aws_ring_buffer_is_valid(&ring_buf));
         assert(aws_byte_buf_is_valid(&buf));
         assert(buf.capacity >= minimum_size && buf.capacity <= requested_size);
         assert(buf.len == 0); /* aws_byte_buf always created with aws_byte_buf_from_empty_array */
         assert(aws_ring_buffer_buf_belongs_to_pool(&ring_buf, &buf));
     }
+    assert(aws_ring_buffer_is_valid(&ring_buf));
 }

--- a/.cbmc-batch/jobs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
@@ -26,14 +26,19 @@ void aws_ring_buffer_buf_belongs_to_pool_harness() {
 
     /* assumptions */
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
+    ensure_ring_buffer_is_not_empty(&ring_buf);
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
-    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(&buf, &ring_buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    __CPROVER_assume(__CPROVER_POINTER_OBJECT(buf.buffer) == __CPROVER_POINTER_OBJECT(ring_buf.allocation));
+
+    struct aws_ring_buffer ring_buf_pre = ring_buf;
+    struct aws_byte_buf buf_pre = buf;
 
     assert(aws_ring_buffer_buf_belongs_to_pool(&ring_buf, &buf));
 
     /* assertions */
     assert(aws_ring_buffer_is_valid(&ring_buf));
     assert(aws_byte_buf_is_valid(&buf));
+    assert(ring_buf_pre == ring_buf);
+    assert(buf_pre == buf);
 }

--- a/.cbmc-batch/jobs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
@@ -26,17 +26,24 @@ void aws_ring_buffer_buf_belongs_to_pool_harness() {
 
     /* assumptions */
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
-    ensure_ring_buffer_is_not_empty(&ring_buf);
+    bool is_member = nondet_bool(); /* nondet assignment required to force true/false */
+    if (is_member) {
+        __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
+        ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(&buf, &ring_buf);
+    } else {
+        /* we will fail the same-object check */
+        ensure_byte_buf_has_allocated_buffer_member(&buf);
+    }
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
-    ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(&buf, &ring_buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 
     struct aws_ring_buffer ring_buf_pre = ring_buf;
     struct aws_byte_buf buf_pre = buf;
 
-    assert(aws_ring_buffer_buf_belongs_to_pool(&ring_buf, &buf));
+    bool result = aws_ring_buffer_buf_belongs_to_pool(&ring_buf, &buf);
 
     /* assertions */
+    assert(is_member == result);
     assert(aws_ring_buffer_is_valid(&ring_buf));
     assert(aws_byte_buf_is_valid(&buf));
     assert(ring_buf_pre == ring_buf);

--- a/.cbmc-batch/jobs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
+++ b/.cbmc-batch/jobs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
@@ -26,14 +26,18 @@ void aws_ring_buffer_release_harness() {
 
     /* assumptions */
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
+    ensure_ring_buffer_is_not_empty(&ring_buf);
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
-    ensure_byte_buf_has_allocated_buffer_member(&buf);
+    ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(&buf, &ring_buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    __CPROVER_assume(__CPROVER_POINTER_OBJECT(buf.buffer) == __CPROVER_POINTER_OBJECT(ring_buf.allocation));
+
+    struct aws_ring_buffer ring_buf_pre = ring_buf;
 
     aws_ring_buffer_release(&ring_buf, &buf);
 
     /* assertions */
+    assert(aws_ring_buffer_is_valid(&ring_buf));
+    assert(aws_atomic_load_ptr(&ring_buf.head) == aws_atomic_load_ptr(&ring_buf_pre.head));
     assert(buf.allocator == NULL);
     assert(buf.buffer == NULL);
     assert(buf.len == 0);

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -33,16 +33,49 @@ void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf)
     buf->buffer = bounded_malloc(sizeof(*(buf->buffer)) * buf->capacity);
 }
 
+void ensure_ring_buffer_is_not_empty(struct aws_ring_buffer *ring_buf) {
+    void *head = aws_atomic_load_ptr(&ring_buf->head);
+    void *tail = aws_atomic_load_ptr(&ring_buf->tail);
+    __CPROVER_assume(head != tail);
+}
+
 void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, const size_t size) {
     ring_buf->allocator = can_fail_allocator();
     ring_buf->allocation = bounded_malloc(sizeof(*(ring_buf->allocation)) * size);
     size_t position_head;
     size_t position_tail;
-    __CPROVER_assume(position_head < size);
-    __CPROVER_assume(position_tail < size);
+    __CPROVER_assume(position_head <= size);
+    __CPROVER_assume(position_tail <= size);
     aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
     aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
     ring_buf->allocation_end = ring_buf->allocation + size;
+}
+
+void ensure_byte_buf_has_allocated_buffer_member_in_range(struct aws_byte_buf *buf, uint8_t *lo, uint8_t *hi) {
+    assert(lo < hi);
+    size_t space = hi - lo;
+    size_t pos = nondet_sizet();
+    __CPROVER_assume(pos < space);
+    buf->buffer = lo + pos;
+    size_t max_capacity = hi - buf->buffer;
+    assert(0 < max_capacity);
+    __CPROVER_assume(0 < buf->capacity && buf->capacity <= max_capacity);
+}
+
+void ensure_byte_buf_has_allocated_buffer_member_in_ring_buf(struct aws_byte_buf *buf, struct aws_ring_buffer *ring_buf) {
+    buf->allocator = (nondet_bool()) ? NULL : can_fail_allocator();
+    void *head = aws_atomic_load_ptr(&ring_buf->head);
+    void *tail = aws_atomic_load_ptr(&ring_buf->tail);
+    if (head < tail) { // [....H    T....]
+        if (nondet_bool()) {
+            __CPROVER_assume(tail < ring_buf->allocation_end);
+            ensure_byte_buf_has_allocated_buffer_member_in_range(buf, tail, ring_buf->allocation_end);
+        } else {
+            ensure_byte_buf_has_allocated_buffer_member_in_range(buf, ring_buf->allocation, head);
+        }
+    } else {           // [    T....H    ]
+        ensure_byte_buf_has_allocated_buffer_member_in_range(buf, tail, head);
+    }
 }
 
 bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, const size_t max_size) {

--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -56,6 +56,15 @@ AWS_EXTERN_C_BEGIN
  */
 AWS_COMMON_API int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct aws_allocator *allocator, size_t size);
 
+/*
+ * Checks whether atomic_ptr correctly points to a memory location within the bounds of the aws_ring_buffer
+ */
+AWS_STATIC_IMPL bool aws_ring_buffer_check_atomic_ptr(
+    const struct aws_ring_buffer *ring_buf,
+    const uint8_t *atomic_ptr) {
+    return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
+}
+
 /**
  * Evaluates the set of properties that define the shape of all valid aws_ring_buffer structures.
  * It is also a cheap check, in the sense it run in constant time (i.e., no loops or recursion).
@@ -66,15 +75,6 @@ AWS_STATIC_IMPL bool aws_ring_buffer_is_valid(const struct aws_ring_buffer *ring
            aws_ring_buffer_check_atomic_ptr(ring_buf, aws_atomic_load_ptr(&ring_buf->tail)) &&
            (aws_atomic_load_ptr(&ring_buf->head) != ring_buf->allocation || aws_atomic_load_ptr(&ring_buf->tail) == ring_buf->allocation) &&
            (ring_buf->allocator != NULL);
-}
-
-/*
- * Checks whether atomic_ptr correctly points to a memory location within the bounds of the aws_ring_buffer
- */
-AWS_STATIC_IMPL bool aws_ring_buffer_check_atomic_ptr(
-    const struct aws_ring_buffer *ring_buf,
-    const uint8_t *atomic_ptr) {
-    return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
 }
 
 /**

--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -62,6 +62,9 @@ AWS_COMMON_API int aws_ring_buffer_init(struct aws_ring_buffer *ring_buf, struct
  */
 AWS_STATIC_IMPL bool aws_ring_buffer_is_valid(const struct aws_ring_buffer *ring_buf) {
     return ring_buf && AWS_MEM_IS_READABLE(ring_buf->allocation, ring_buf->allocation_end - ring_buf->allocation) &&
+           aws_ring_buffer_check_atomic_ptr(ring_buf, aws_atomic_load_ptr(&ring_buf->head)) &&
+           aws_ring_buffer_check_atomic_ptr(ring_buf, aws_atomic_load_ptr(&ring_buf->tail)) &&
+           (aws_atomic_load_ptr(&ring_buf->head) != ring_buf->allocation || aws_atomic_load_ptr(&ring_buf->tail) == ring_buf->allocation) &&
            (ring_buf->allocator != NULL);
 }
 


### PR DESCRIPTION
* Fix proofs for aws_ring_buffer_buf_belongs_to_pool_harness and
aws_ring_buffer_release

* More precise aws_ring_buffer_is_valid() test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.