### PR TITLE
Extend the postconditions of aws_array_list_front with bytes_eq check

### DIFF
--- a/.cbmc-batch/jobs/aws_array_list_front/Makefile
+++ b/.cbmc-batch/jobs/aws_array_list_front/Makefile
@@ -14,6 +14,9 @@
 ###########
 include ../Makefile.aws_array_list
 
+# Set deep checks to enable the AWS_BYTES_EQ
+AWS_DEEP_CHECKS = 1
+
 # This bound allows us to reach 100% coverage rate
 UNWINDSET += memcpy_impl.0:$(shell echo $$(($(MAX_ITEM_SIZE) + 1)))
 

--- a/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
@@ -43,6 +43,7 @@ void aws_array_list_front_harness() {
     /* perform operation under verification */
     if (!aws_array_list_front(&list, val)) {
         /* In the case aws_array_list_front is successful, we can ensure the list isn't empty */
+        assert(AWS_BYTES_EQ(val, list.data, list.item_size));
         assert(list.data);
         assert(list.length);
     }

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -147,6 +147,7 @@ int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *v
         "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
+        AWS_POSTCONDITION(AWS_BYTES_EQ(val, list->data, list->item_size));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
         return AWS_OP_SUCCESS;
     }

--- a/include/aws/common/common.h
+++ b/include/aws/common/common.h
@@ -23,6 +23,7 @@
 #include <aws/common/assert.h>
 #include <aws/common/error.h>
 #include <aws/common/macros.h>
+#include <aws/common/predicates.h>
 #include <aws/common/stdbool.h>
 #include <aws/common/stdint.h>
 #include <aws/common/zero.h>

--- a/include/aws/common/predicates.h
+++ b/include/aws/common/predicates.h
@@ -1,0 +1,33 @@
+#ifndef AWS_COMMON_PREDICATES_H
+#define AWS_COMMON_PREDICATES_H
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * Returns whether all bytes of the two byte arrays match.
+ */
+#ifdef CBMC
+/* clang-format off */
+#    define AWS_BYTES_EQ(arr1, arr2, len)                                                                              \
+        __CPROVER_forall {                                                                                             \
+            int i;                                                                                                     \
+            (i >= 0 && i < len) ==> ((const uint8_t *)&arr1)[i] == ((const uint8_t *)&arr2)[i]                         \
+        }
+/* clang-format on */
+#else
+#    define AWS_BYTES_EQ(arr1, arr2, len) (memcmp(arr1, arr2, len) == 0)
+#endif
+
+#endif /* AWS_PREDICATES_MACROS_H */

--- a/include/aws/common/predicates.h
+++ b/include/aws/common/predicates.h
@@ -18,16 +18,20 @@
 /**
  * Returns whether all bytes of the two byte arrays match.
  */
-#ifdef CBMC
+#if (AWS_DEEP_CHECKS == 1)
+#    ifdef CBMC
 /* clang-format off */
-#    define AWS_BYTES_EQ(arr1, arr2, len)                                                                              \
-        __CPROVER_forall {                                                                                             \
-            int i;                                                                                                     \
-            (i >= 0 && i < len) ==> ((const uint8_t *)&arr1)[i] == ((const uint8_t *)&arr2)[i]                         \
-        }
+#        define AWS_BYTES_EQ(arr1, arr2, len)                                                                              \
+            __CPROVER_forall {                                                                                             \
+                int i;                                                                                                     \
+                (i >= 0 && i < len) ==> ((const uint8_t *)&arr1)[i] == ((const uint8_t *)&arr2)[i]                         \
+            }
 /* clang-format on */
+#    else
+#        define AWS_BYTES_EQ(arr1, arr2, len) (memcmp(arr1, arr2, len) == 0)
+#    endif /* CBMC */
 #else
-#    define AWS_BYTES_EQ(arr1, arr2, len) (memcmp(arr1, arr2, len) == 0)
-#endif
+#    define AWS_BYTES_EQ(arr1, arr2, len) (1)
+#endif /* (AWS_DEEP_CHECKS == 1) */
 
-#endif /* AWS_PREDICATES_MACROS_H */
+#endif /* AWS_COMMON_PREDICATES_H */


### PR DESCRIPTION
This PR introduces a new assertion predicate that checks whether the bytes in two byte arrays match. It extends the postcondition of `aws_array_list_front` with that check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
