### PR TITLE
Add HASH_ITER_ELEMENT_GENERATOR to the iterator stubs 

### DIFF
--- a/.cbmc-batch/stubs/aws_hash_iter_overrides.c
+++ b/.cbmc-batch/stubs/aws_hash_iter_overrides.c
@@ -13,7 +13,7 @@
  * This is sound, as it gives you a totally nondet value every time you call the iterator, and is the default behaviour
  * of CBMC. But if it is used, we need a way for the harness to specify valid values for the element, for example if
  * they are copying values out of the table. They can do this by defining
- * -DHASH_ITER_ELEMENT_GENERATOR=the_generator_fn, wher the_generator_fn has signature:
+ * -DHASH_ITER_ELEMENT_GENERATOR=the_generator_fn, where the_generator_fn has signature:
  *   the_generator_fn(struct aws_hash_iter *new_iter, const struct aws_hash_iter* old_iter).
  *
  * [new_iter] is a pointer to the iterator that will be returned from this function, and the generator function can


### PR DESCRIPTION
*Description of changes:*
For some proofs, we need a stub for the hash-iterator.  Until now, we had left the element nondet.  This is sound, but can lead to spurious proof failures.  Instead, give a mechanism to allow constraints to be put on the iterator elements.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
