### PR TITLE
moved byte buf functions to the .c where they belong

### DIFF
--- a/.cbmc-batch/jobs/Makefile.cbmc_batch
+++ b/.cbmc-batch/jobs/Makefile.cbmc_batch
@@ -51,24 +51,24 @@ define yaml_encode_options
 endef
 
 $(ENTRY).yaml: $(ENTRY).goto Makefile
-	echo 'batchpkg: $(BATCHPKG)' >> $@
+	echo 'batchpkg: $(BATCHPKG)' > $@
 	echo 'build: true' >> $@
 	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
 	echo 'cbmcpkg: $(CBMCPKG)' >> $@
 	echo 'coverage_memory: $(COVMEM)' >> $@
 	echo 'expected: "SUCCESSFUL"' >> $@
 	echo 'goto: $(ENTRY).goto' >> $@
-	echo 'jobos: ubuntu16' > $@
+	echo 'jobos: ubuntu16' >> $@
 	echo 'property_memory: $(PROPMEM)' >> $@
 	echo 'viewerpkg: $(VIEWERPKG)' >> $@
 
 batch-yaml: $(ENTRY).yaml
 
 cbmc-batch.yaml: $(ENTRY).goto Makefile
-	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' > $@
 	echo 'expected: "SUCCESSFUL"' >> $@
 	echo 'goto: $(ENTRY).goto' >> $@
-	echo 'jobos: ubuntu16' > $@
+	echo 'jobos: ubuntu16' >> $@
 
 ci-yaml: cbmc-batch.yaml
 

--- a/.cbmc-batch/jobs/aws_nospec_mask/aws_nospec_mask_harness.c
+++ b/.cbmc-batch/jobs/aws_nospec_mask/aws_nospec_mask_harness.c
@@ -14,6 +14,7 @@
  */
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/private/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 

--- a/.cbmc-batch/jobs/aws_nospec_mask/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_nospec_mask/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--unwind;1"
-goto: aws_nospec_mask_harness.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 expected: "SUCCESSFUL"
+goto: aws_nospec_mask_harness.goto
+jobos: ubuntu16

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -66,6 +66,12 @@ struct aws_byte_cursor {
 #define AWS_BYTE_BUF_PRI(B) ((int)(B).len < 0 ? 0 : (int)(B).len), (const char *)(B).buffer
 
 /**
+ * Helper Macro for inititilizing a byte cursor from a string literal
+ */
+#define AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(literal)                                                                 \
+    { .ptr = (uint8_t *)(const char *)(literal), .len = sizeof(literal) - 1 }
+
+/**
  * Signature for function argument to trim APIs
  */
 typedef bool(aws_byte_predicate_fn)(uint8_t value);
@@ -464,146 +470,28 @@ int aws_byte_cursor_compare_lookup(
     const struct aws_byte_cursor *rhs,
     const uint8_t *lookup_table);
 
-AWS_EXTERN_C_END
-
-/**
- */
-#define AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(literal)                                                                 \
-    { .ptr = (uint8_t *)(const char *)(literal), .len = sizeof(literal) - 1 }
-
 /**
  * For creating a byte buffer from a null-terminated string literal.
  */
-AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
-    struct aws_byte_buf buf;
-    buf.len = (!c_str) ? 0 : strlen(c_str);
-    buf.capacity = buf.len;
-    buf.buffer = (buf.capacity == 0) ? NULL : (uint8_t *)c_str;
-    buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
-    return buf;
-}
+AWS_COMMON_API struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str);
 
-AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len) {
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len), "Input array [bytes] must be writable up to [len] bytes.");
-    struct aws_byte_buf buf;
-    buf.buffer = (len > 0) ? (uint8_t *)bytes : NULL;
-    buf.len = len;
-    buf.capacity = len;
-    buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
-    return buf;
-}
+AWS_COMMON_API struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
 
-AWS_STATIC_IMPL struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity) {
-    AWS_PRECONDITION(
-        AWS_MEM_IS_WRITABLE(bytes, capacity), "Input array [bytes] must be writable up to [capacity] bytes.");
-    struct aws_byte_buf buf;
-    buf.buffer = (capacity > 0) ? (uint8_t *)bytes : NULL;
-    buf.len = 0;
-    buf.capacity = capacity;
-    buf.allocator = NULL;
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
-    return buf;
-}
+AWS_COMMON_API struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
 
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    struct aws_byte_cursor cur;
-    cur.ptr = buf->buffer;
-    cur.len = buf->len;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
-    return cur;
-}
+AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
 
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str) {
-    struct aws_byte_cursor cur;
-    cur.ptr = (uint8_t *)c_str;
-    cur.len = (cur.ptr) ? strlen(c_str) : 0;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
-    return cur;
-}
+AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
 
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len) {
-    AWS_PRECONDITION(len == 0 || AWS_MEM_IS_READABLE(bytes, len), "Input array [bytes] must be readable up to [len].");
-    struct aws_byte_cursor cur;
-    cur.ptr = (uint8_t *)bytes;
-    cur.len = len;
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
-    return cur;
-}
+AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
 
-#ifdef CBMC
-#    pragma CPROVER check push
-#    pragma CPROVER check disable "unsigned-overflow"
-#endif
 /**
  * If index >= bound, bound > (SIZE_MAX / 2), or index > (SIZE_MAX / 2), returns
  * 0. Otherwise, returns UINTPTR_MAX.  This function is designed to return the correct
  * value even under CPU speculation conditions, and is intended to be used for
  * SPECTRE mitigation purposes.
  */
-AWS_STATIC_IMPL size_t aws_nospec_mask(size_t index, size_t bound) {
-    /*
-     * SPECTRE mitigation - we compute a mask that will be zero if len < 0
-     * or len >= buf->len, and all-ones otherwise, and AND it into the index.
-     * It is critical that we avoid any branches in this logic.
-     */
-
-    /*
-     * Hide the index value from the optimizer. This helps ensure that all this
-     * logic doesn't get eliminated.
-     */
-#if defined(__GNUC__) || defined(__clang__)
-    __asm__ __volatile__("" : "+r"(index));
-#endif
-#if defined(_MSVC_LANG)
-    /*
-     * MSVC doesn't have a good way for us to blind the optimizer, and doesn't
-     * even have inline asm on x64. Some experimentation indicates that this
-     * hack seems to confuse it sufficiently for our needs.
-     */
-    *((volatile uint8_t *)&index) += 0;
-#endif
-
-    /*
-     * If len > (SIZE_MAX / 2), then we can end up with len - buf->len being
-     * positive simply because the sign bit got inverted away. So we also check
-     * that the sign bit isn't set from the start.
-     *
-     * We also check that bound <= (SIZE_MAX / 2) to catch cases where the
-     * buffer is _already_ out of bounds.
-     */
-    size_t negative_mask = index | bound;
-    size_t toobig_mask = bound - index - (uintptr_t)1;
-    size_t combined_mask = negative_mask | toobig_mask;
-
-    /*
-     * combined_mask needs to have its sign bit OFF for us to be in range.
-     * We'd like to expand this to a mask we can AND into our index, so flip
-     * that bit (and everything else), shift it over so it's the only bit in the
-     * ones position, and multiply across the entire register.
-     *
-     * First, extract the (inverse) top bit and move it to the lowest bit.
-     * Because there's no standard SIZE_BIT in C99, we'll divide by a mask with
-     * just the top bit set instead.
-     */
-
-    combined_mask = (~combined_mask) / (SIZE_MAX - (SIZE_MAX >> 1));
-
-    /*
-     * Now multiply it to replicate it across all bits.
-     *
-     * Note that GCC is smart enough to optimize the divide-and-multiply into
-     * an arithmetic right shift operation on x86.
-     */
-    combined_mask = combined_mask * UINTPTR_MAX;
-
-    return combined_mask;
-}
-#ifdef CBMC
-#    pragma CPROVER check pop
-#endif
+AWS_COMMON_API size_t aws_nospec_mask(size_t index, size_t bound);
 
 /**
  * Tests if the given aws_byte_cursor has at least len bytes remaining. If so,
@@ -615,23 +503,7 @@ AWS_STATIC_IMPL size_t aws_nospec_mask(size_t index, size_t bound) {
  * Note that if len is above (SIZE_MAX / 2), this function will also treat it as
  * a buffer overflow, and return NULL without changing *buf.
  */
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cursor, const size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
-    struct aws_byte_cursor rv;
-    if (cursor->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || len > cursor->len) {
-        rv.ptr = NULL;
-        rv.len = 0;
-    } else {
-        rv.ptr = cursor->ptr;
-        rv.len = len;
-
-        cursor->ptr += len;
-        cursor->len -= len;
-    }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
-    return rv;
-}
+AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cursor, const size_t len);
 
 /**
  * Behaves identically to aws_byte_cursor_advance, but avoids speculative
@@ -643,42 +515,7 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_c
  * cursor->ptr points outside the true ptr length.
  */
 
-AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
-    struct aws_byte_cursor *const cursor,
-    size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
-
-    struct aws_byte_cursor rv;
-
-    if (len <= cursor->len && len <= (SIZE_MAX >> 1) && cursor->len <= (SIZE_MAX >> 1)) {
-        /*
-         * If we're speculating past a failed bounds check, null out the pointer. This ensures
-         * that we don't try to read past the end of the buffer and leak information about other
-         * memory through timing side-channels.
-         */
-        uintptr_t mask = aws_nospec_mask(len, cursor->len + 1);
-
-        /* Make sure we don't speculate-underflow len either */
-        len = len & mask;
-        cursor->ptr = (uint8_t *)((uintptr_t)cursor->ptr & mask);
-        /* Make sure subsequent nospec accesses don't advance ptr past NULL */
-        cursor->len = cursor->len & mask;
-
-        rv.ptr = cursor->ptr;
-        /* Make sure anything acting upon the returned cursor _also_ doesn't advance past NULL */
-        rv.len = len & mask;
-
-        cursor->ptr += len;
-        cursor->len -= len;
-    } else {
-        rv.ptr = NULL;
-        rv.len = 0;
-    }
-
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
-    return rv;
-}
+AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_advance_nospec(struct aws_byte_cursor *const cursor, size_t len);
 
 /**
  * Reads specified length of data from byte cursor and copies it to the
@@ -688,23 +525,10 @@ AWS_STATIC_IMPL struct aws_byte_cursor aws_byte_cursor_advance_nospec(
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read(
+AWS_COMMON_API bool aws_byte_cursor_read(
     struct aws_byte_cursor *AWS_RESTRICT cur,
     void *AWS_RESTRICT dest,
-    const size_t len) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(dest, len));
-    struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
-
-    if (slice.ptr) {
-        memcpy(dest, slice.ptr, len);
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-        AWS_POSTCONDITION(AWS_MEM_IS_READABLE(dest, len));
-        return true;
-    }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return false;
-}
+    const size_t len);
 
 /**
  * Reads as many bytes from cursor as size of buffer, and copies them to buffer.
@@ -713,21 +537,9 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read(
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
+AWS_COMMON_API bool aws_byte_cursor_read_and_fill_buffer(
     struct aws_byte_cursor *AWS_RESTRICT cur,
-    struct aws_byte_buf *AWS_RESTRICT dest) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(dest));
-    if (aws_byte_cursor_read(cur, dest->buffer, dest->capacity)) {
-        dest->len = dest->capacity;
-        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
-        return true;
-    }
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
-    return false;
-}
+    struct aws_byte_buf *AWS_RESTRICT dest);
 
 /**
  * Reads a single byte from cursor, placing it in *var.
@@ -736,12 +548,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_and_fill_buffer(
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRICT cur, uint8_t *AWS_RESTRICT var) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    bool rv = aws_byte_cursor_read(cur, var, 1);
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return rv;
-}
+AWS_COMMON_API bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRICT cur, uint8_t *AWS_RESTRICT var);
 
 /**
  * Reads a 16-bit value in network byte order from cur, and places it in host
@@ -751,18 +558,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRIC
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint16_t *var) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
-    bool rv = aws_byte_cursor_read(cur, var, 2);
-
-    if (AWS_LIKELY(rv)) {
-        *var = aws_ntoh16(*var);
-    }
-
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return rv;
-}
+AWS_COMMON_API bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint16_t *var);
 
 /**
  * Reads a 32-bit value in network byte order from cur, and places it in host
@@ -772,18 +568,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
-    bool rv = aws_byte_cursor_read(cur, var, 4);
-
-    if (AWS_LIKELY(rv)) {
-        *var = aws_ntoh32(*var);
-    }
-
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return rv;
-}
+AWS_COMMON_API bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var);
 
 /**
  * Reads a 32-bit value in network byte order from cur, and places it in host
@@ -793,18 +578,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_float_be32(struct aws_byte_cursor *cur, float *var) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
-    bool rv = aws_byte_cursor_read(cur, var, sizeof(float));
-
-    if (AWS_LIKELY(rv)) {
-        *var = aws_ntohf32(*var);
-    }
-
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return rv;
-}
+AWS_COMMON_API bool aws_byte_cursor_read_float_be32(struct aws_byte_cursor *cur, float *var);
 
 /**
  * Reads a 64-bit value in network byte order from cur, and places it in host
@@ -814,18 +588,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_float_be32(struct aws_byte_cursor *cur
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_float_be64(struct aws_byte_cursor *cur, double *var) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
-    bool rv = aws_byte_cursor_read(cur, var, sizeof(double));
-
-    if (AWS_LIKELY(rv)) {
-        *var = aws_ntohf64(*var);
-    }
-
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return rv;
-}
+AWS_COMMON_API bool aws_byte_cursor_read_float_be64(struct aws_byte_cursor *cur, double *var);
 
 /**
  * Reads a 64-bit value in network byte order from cur, and places it in host
@@ -835,18 +598,7 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_float_be64(struct aws_byte_cursor *cur
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_cursor_read_be64(struct aws_byte_cursor *cur, uint64_t *var) {
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
-    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
-    bool rv = aws_byte_cursor_read(cur, var, sizeof(*var));
-
-    if (AWS_LIKELY(rv)) {
-        *var = aws_ntoh64(*var);
-    }
-
-    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
-    return rv;
-}
+AWS_COMMON_API bool aws_byte_cursor_read_be64(struct aws_byte_cursor *cur, uint64_t *var);
 
 /**
  * Appends a sub-buffer to the specified buffer.
@@ -859,26 +611,10 @@ AWS_STATIC_IMPL bool aws_byte_cursor_read_be64(struct aws_byte_cursor *cur, uint
  * If there is insufficient space, then this function nulls all fields in *output and returns
  * false.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_advance(
+AWS_COMMON_API bool aws_byte_buf_advance(
     struct aws_byte_buf *const AWS_RESTRICT buffer,
     struct aws_byte_buf *const AWS_RESTRICT output,
-    const size_t len) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
-    if (buffer->capacity - buffer->len >= len) {
-        *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
-        buffer->len += len;
-        output->len = 0;
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(output));
-        return true;
-    } else {
-        AWS_ZERO_STRUCT(*output);
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(output));
-        return false;
-    }
-}
+    const size_t len);
 
 /**
  * Write specified number of bytes from array to byte buffer.
@@ -887,24 +623,10 @@ AWS_STATIC_IMPL bool aws_byte_buf_advance(
  * If there is insufficient space in the buffer, returns false, leaving the
  * buffer unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write(
+AWS_COMMON_API bool aws_byte_buf_write(
     struct aws_byte_buf *AWS_RESTRICT buf,
     const uint8_t *AWS_RESTRICT src,
-    size_t len) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(src, len), "Input array [src] must be readable up to [len] bytes.");
-
-    if (buf->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || buf->len + len > buf->capacity) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
-        return false;
-    }
-
-    memcpy(buf->buffer + buf->len, src, len);
-    buf->len += len;
-
-    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
-    return true;
-}
+    size_t len);
 
 /**
  * Copies all bytes from buffer to buffer.
@@ -913,13 +635,9 @@ AWS_STATIC_IMPL bool aws_byte_buf_write(
  * If there is insufficient space in the buffer, returns false, leaving the
  * buffer unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
+AWS_COMMON_API bool aws_byte_buf_write_from_whole_buffer(
     struct aws_byte_buf *AWS_RESTRICT buf,
-    struct aws_byte_buf src) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(&src));
-    return aws_byte_buf_write(buf, src.buffer, src.len);
-}
+    struct aws_byte_buf src);
 
 /**
  * Copies all bytes from buffer to buffer.
@@ -928,13 +646,9 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_buffer(
  * If there is insufficient space in the buffer, returns false, leaving the
  * buffer unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
+AWS_COMMON_API bool aws_byte_buf_write_from_whole_cursor(
     struct aws_byte_buf *AWS_RESTRICT buf,
-    struct aws_byte_cursor src) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(aws_byte_cursor_is_valid(&src));
-    return aws_byte_buf_write(buf, src.ptr, src.len);
-}
+    struct aws_byte_cursor src);
 
 /**
  * Copies one byte to buffer.
@@ -945,10 +659,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_from_whole_cursor(
  * If there is insufficient space in the cursor, returns false, leaving the
  cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf, uint8_t c) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    return aws_byte_buf_write(buf, &c, 1);
-}
+AWS_COMMON_API bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf, uint8_t c);
 
 /**
  * Writes a 16-bit integer in network byte order (big endian) to buffer.
@@ -957,11 +668,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    x = aws_hton16(x);
-    return aws_byte_buf_write(buf, (uint8_t *)&x, 2);
-}
+AWS_COMMON_API bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t x);
 
 /**
  * Writes a 32-bit integer in network byte order (big endian) to buffer.
@@ -970,11 +677,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t 
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    x = aws_hton32(x);
-    return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
-}
+AWS_COMMON_API bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t x);
 
 /**
  * Writes a 32-bit float in network byte order (big endian) to buffer.
@@ -983,11 +686,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t 
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_float_be32(struct aws_byte_buf *buf, float x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    x = aws_htonf32(x);
-    return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
-}
+AWS_COMMON_API bool aws_byte_buf_write_float_be32(struct aws_byte_buf *buf, float x);
 
 /**
  * Writes a 64-bit integer in network byte order (big endian) to buffer.
@@ -996,11 +695,7 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_float_be32(struct aws_byte_buf *buf, flo
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    x = aws_hton64(x);
-    return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
-}
+AWS_COMMON_API bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x);
 
 /**
  * Writes a 64-bit float in network byte order (big endian) to buffer.
@@ -1009,10 +704,8 @@ AWS_STATIC_IMPL bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t 
  * If there is insufficient space in the cursor, returns false, leaving the
  * cursor unchanged.
  */
-AWS_STATIC_IMPL bool aws_byte_buf_write_float_be64(struct aws_byte_buf *buf, double x) {
-    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    x = aws_htonf64(x);
-    return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
-}
+AWS_COMMON_API bool aws_byte_buf_write_float_be64(struct aws_byte_buf *buf, double x);
+
+AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_BYTE_BUF_H */

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -486,14 +486,6 @@ AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_s
 AWS_COMMON_API struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
 
 /**
- * If index >= bound, bound > (SIZE_MAX / 2), or index > (SIZE_MAX / 2), returns
- * 0. Otherwise, returns UINTPTR_MAX.  This function is designed to return the correct
- * value even under CPU speculation conditions, and is intended to be used for
- * SPECTRE mitigation purposes.
- */
-AWS_COMMON_API size_t aws_nospec_mask(size_t index, size_t bound);
-
-/**
  * Tests if the given aws_byte_cursor has at least len bytes remaining. If so,
  * *buf is advanced by len bytes (incrementing ->ptr and decrementing ->len),
  * and an aws_byte_cursor referring to the first len bytes of the original *buf

--- a/include/aws/common/private/byte_buf.h
+++ b/include/aws/common/private/byte_buf.h
@@ -1,0 +1,28 @@
+#ifndef AWS_COMMON_PRIVATE_BYTE_BUF_H
+#define AWS_COMMON_PRIVATE_BYTE_BUF_H
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+
+/**
+ * If index >= bound, bound > (SIZE_MAX / 2), or index > (SIZE_MAX / 2), returns
+ * 0. Otherwise, returns UINTPTR_MAX.  This function is designed to return the correct
+ * value even under CPU speculation conditions, and is intended to be used for
+ * SPECTRE mitigation purposes.
+ */
+size_t aws_nospec_mask(size_t index, size_t bound);
+
+#endif /* AWS_COMMON_PRIVATE_BYTE_BUF_H */

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -14,6 +14,7 @@
  */
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/private/byte_buf.h>
 
 #include <stdarg.h>
 

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -778,3 +778,535 @@ int aws_byte_cursor_compare_lookup(
 
     return 0;
 }
+
+/**
+ * For creating a byte buffer from a null-terminated string literal.
+ */
+struct aws_byte_buf aws_byte_buf_from_c_str(const char *c_str) {
+    struct aws_byte_buf buf;
+    buf.len = (!c_str) ? 0 : strlen(c_str);
+    buf.capacity = buf.len;
+    buf.buffer = (buf.capacity == 0) ? NULL : (uint8_t *)c_str;
+    buf.allocator = NULL;
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
+    return buf;
+}
+
+struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len) {
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(bytes, len), "Input array [bytes] must be writable up to [len] bytes.");
+    struct aws_byte_buf buf;
+    buf.buffer = (len > 0) ? (uint8_t *)bytes : NULL;
+    buf.len = len;
+    buf.capacity = len;
+    buf.allocator = NULL;
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
+    return buf;
+}
+
+struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity) {
+    AWS_PRECONDITION(
+        AWS_MEM_IS_WRITABLE(bytes, capacity), "Input array [bytes] must be writable up to [capacity] bytes.");
+    struct aws_byte_buf buf;
+    buf.buffer = (capacity > 0) ? (uint8_t *)bytes : NULL;
+    buf.len = 0;
+    buf.capacity = capacity;
+    buf.allocator = NULL;
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(&buf));
+    return buf;
+}
+
+struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    struct aws_byte_cursor cur;
+    cur.ptr = buf->buffer;
+    cur.len = buf->len;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    return cur;
+}
+
+struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str) {
+    struct aws_byte_cursor cur;
+    cur.ptr = (uint8_t *)c_str;
+    cur.len = (cur.ptr) ? strlen(c_str) : 0;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    return cur;
+}
+
+struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len) {
+    AWS_PRECONDITION(len == 0 || AWS_MEM_IS_READABLE(bytes, len), "Input array [bytes] must be readable up to [len].");
+    struct aws_byte_cursor cur;
+    cur.ptr = (uint8_t *)bytes;
+    cur.len = len;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cur));
+    return cur;
+}
+
+#ifdef CBMC
+#    pragma CPROVER check push
+#    pragma CPROVER check disable "unsigned-overflow"
+#endif
+/**
+ * If index >= bound, bound > (SIZE_MAX / 2), or index > (SIZE_MAX / 2), returns
+ * 0. Otherwise, returns UINTPTR_MAX.  This function is designed to return the correct
+ * value even under CPU speculation conditions, and is intended to be used for
+ * SPECTRE mitigation purposes.
+ */
+size_t aws_nospec_mask(size_t index, size_t bound) {
+    /*
+     * SPECTRE mitigation - we compute a mask that will be zero if len < 0
+     * or len >= buf->len, and all-ones otherwise, and AND it into the index.
+     * It is critical that we avoid any branches in this logic.
+     */
+
+    /*
+     * Hide the index value from the optimizer. This helps ensure that all this
+     * logic doesn't get eliminated.
+     */
+#if defined(__GNUC__) || defined(__clang__)
+    __asm__ __volatile__("" : "+r"(index));
+#endif
+#if defined(_MSVC_LANG)
+    /*
+     * MSVC doesn't have a good way for us to blind the optimizer, and doesn't
+     * even have inline asm on x64. Some experimentation indicates that this
+     * hack seems to confuse it sufficiently for our needs.
+     */
+    *((volatile uint8_t *)&index) += 0;
+#endif
+
+    /*
+     * If len > (SIZE_MAX / 2), then we can end up with len - buf->len being
+     * positive simply because the sign bit got inverted away. So we also check
+     * that the sign bit isn't set from the start.
+     *
+     * We also check that bound <= (SIZE_MAX / 2) to catch cases where the
+     * buffer is _already_ out of bounds.
+     */
+    size_t negative_mask = index | bound;
+    size_t toobig_mask = bound - index - (uintptr_t)1;
+    size_t combined_mask = negative_mask | toobig_mask;
+
+    /*
+     * combined_mask needs to have its sign bit OFF for us to be in range.
+     * We'd like to expand this to a mask we can AND into our index, so flip
+     * that bit (and everything else), shift it over so it's the only bit in the
+     * ones position, and multiply across the entire register.
+     *
+     * First, extract the (inverse) top bit and move it to the lowest bit.
+     * Because there's no standard SIZE_BIT in C99, we'll divide by a mask with
+     * just the top bit set instead.
+     */
+
+    combined_mask = (~combined_mask) / (SIZE_MAX - (SIZE_MAX >> 1));
+
+    /*
+     * Now multiply it to replicate it across all bits.
+     *
+     * Note that GCC is smart enough to optimize the divide-and-multiply into
+     * an arithmetic right shift operation on x86.
+     */
+    combined_mask = combined_mask * UINTPTR_MAX;
+
+    return combined_mask;
+}
+#ifdef CBMC
+#    pragma CPROVER check pop
+#endif
+
+/**
+ * Tests if the given aws_byte_cursor has at least len bytes remaining. If so,
+ * *buf is advanced by len bytes (incrementing ->ptr and decrementing ->len),
+ * and an aws_byte_cursor referring to the first len bytes of the original *buf
+ * is returned. Otherwise, an aws_byte_cursor with ->ptr = NULL, ->len = 0 is
+ * returned.
+ *
+ * Note that if len is above (SIZE_MAX / 2), this function will also treat it as
+ * a buffer overflow, and return NULL without changing *buf.
+ */
+struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cursor, const size_t len) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
+    struct aws_byte_cursor rv;
+    if (cursor->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || len > cursor->len) {
+        rv.ptr = NULL;
+        rv.len = 0;
+    } else {
+        rv.ptr = cursor->ptr;
+        rv.len = len;
+
+        cursor->ptr += len;
+        cursor->len -= len;
+    }
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
+    return rv;
+}
+
+/**
+ * Behaves identically to aws_byte_cursor_advance, but avoids speculative
+ * execution potentially reading out-of-bounds pointers (by returning an
+ * empty ptr in such speculated paths).
+ *
+ * This should generally be done when using an untrusted or
+ * data-dependent value for 'len', to avoid speculating into a path where
+ * cursor->ptr points outside the true ptr length.
+ */
+
+struct aws_byte_cursor aws_byte_cursor_advance_nospec(struct aws_byte_cursor *const cursor, size_t len) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
+
+    struct aws_byte_cursor rv;
+
+    if (len <= cursor->len && len <= (SIZE_MAX >> 1) && cursor->len <= (SIZE_MAX >> 1)) {
+        /*
+         * If we're speculating past a failed bounds check, null out the pointer. This ensures
+         * that we don't try to read past the end of the buffer and leak information about other
+         * memory through timing side-channels.
+         */
+        uintptr_t mask = aws_nospec_mask(len, cursor->len + 1);
+
+        /* Make sure we don't speculate-underflow len either */
+        len = len & mask;
+        cursor->ptr = (uint8_t *)((uintptr_t)cursor->ptr & mask);
+        /* Make sure subsequent nospec accesses don't advance ptr past NULL */
+        cursor->len = cursor->len & mask;
+
+        rv.ptr = cursor->ptr;
+        /* Make sure anything acting upon the returned cursor _also_ doesn't advance past NULL */
+        rv.len = len & mask;
+
+        cursor->ptr += len;
+        cursor->len -= len;
+    } else {
+        rv.ptr = NULL;
+        rv.len = 0;
+    }
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&rv));
+    return rv;
+}
+
+/**
+ * Reads specified length of data from byte cursor and copies it to the
+ * destination array.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read(struct aws_byte_cursor *AWS_RESTRICT cur, void *AWS_RESTRICT dest, const size_t len) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(dest, len));
+    struct aws_byte_cursor slice = aws_byte_cursor_advance_nospec(cur, len);
+
+    if (slice.ptr) {
+        memcpy(dest, slice.ptr, len);
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+        AWS_POSTCONDITION(AWS_MEM_IS_READABLE(dest, len));
+        return true;
+    }
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return false;
+}
+
+/**
+ * Reads as many bytes from cursor as size of buffer, and copies them to buffer.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_and_fill_buffer(
+    struct aws_byte_cursor *AWS_RESTRICT cur,
+    struct aws_byte_buf *AWS_RESTRICT dest) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(dest));
+    if (aws_byte_cursor_read(cur, dest->buffer, dest->capacity)) {
+        dest->len = dest->capacity;
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
+        return true;
+    }
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(dest));
+    return false;
+}
+
+/**
+ * Reads a single byte from cursor, placing it in *var.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_u8(struct aws_byte_cursor *AWS_RESTRICT cur, uint8_t *AWS_RESTRICT var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    bool rv = aws_byte_cursor_read(cur, var, 1);
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
+}
+
+/**
+ * Reads a 16-bit value in network byte order from cur, and places it in host
+ * byte order into var.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint16_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
+    bool rv = aws_byte_cursor_read(cur, var, 2);
+
+    if (AWS_LIKELY(rv)) {
+        *var = aws_ntoh16(*var);
+    }
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
+}
+
+/**
+ * Reads a 32-bit value in network byte order from cur, and places it in host
+ * byte order into var.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
+    bool rv = aws_byte_cursor_read(cur, var, 4);
+
+    if (AWS_LIKELY(rv)) {
+        *var = aws_ntoh32(*var);
+    }
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
+}
+
+/**
+ * Reads a 32-bit value in network byte order from cur, and places it in host
+ * byte order into var.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_float_be32(struct aws_byte_cursor *cur, float *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
+    bool rv = aws_byte_cursor_read(cur, var, sizeof(float));
+
+    if (AWS_LIKELY(rv)) {
+        *var = aws_ntohf32(*var);
+    }
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
+}
+
+/**
+ * Reads a 64-bit value in network byte order from cur, and places it in host
+ * byte order into var.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_float_be64(struct aws_byte_cursor *cur, double *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
+    bool rv = aws_byte_cursor_read(cur, var, sizeof(double));
+
+    if (AWS_LIKELY(rv)) {
+        *var = aws_ntohf64(*var);
+    }
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
+}
+
+/**
+ * Reads a 64-bit value in network byte order from cur, and places it in host
+ * byte order into var.
+ *
+ * On success, returns true and updates the cursor pointer/length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_cursor_read_be64(struct aws_byte_cursor *cur, uint64_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
+    bool rv = aws_byte_cursor_read(cur, var, sizeof(*var));
+
+    if (AWS_LIKELY(rv)) {
+        *var = aws_ntoh64(*var);
+    }
+
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cur));
+    return rv;
+}
+
+/**
+ * Appends a sub-buffer to the specified buffer.
+ *
+ * If the buffer has at least `len' bytes remaining (buffer->capacity - buffer->len >= len),
+ * then buffer->len is incremented by len, and an aws_byte_buf is assigned to *output corresponding
+ * to the last len bytes of the input buffer. The aws_byte_buf at *output will have a null
+ * allocator, a zero initial length, and a capacity of 'len'. The function then returns true.
+ *
+ * If there is insufficient space, then this function nulls all fields in *output and returns
+ * false.
+ */
+bool aws_byte_buf_advance(
+    struct aws_byte_buf *const AWS_RESTRICT buffer,
+    struct aws_byte_buf *const AWS_RESTRICT output,
+    const size_t len) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(output));
+    if (buffer->capacity - buffer->len >= len) {
+        *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
+        buffer->len += len;
+        output->len = 0;
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(output));
+        return true;
+    } else {
+        AWS_ZERO_STRUCT(*output);
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(output));
+        return false;
+    }
+}
+
+/**
+ * Write specified number of bytes from array to byte buffer.
+ *
+ * On success, returns true and updates the buffer length accordingly.
+ * If there is insufficient space in the buffer, returns false, leaving the
+ * buffer unchanged.
+ */
+bool aws_byte_buf_write(struct aws_byte_buf *AWS_RESTRICT buf, const uint8_t *AWS_RESTRICT src, size_t len) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(AWS_MEM_IS_WRITABLE(src, len), "Input array [src] must be readable up to [len] bytes.");
+
+    if (buf->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || buf->len + len > buf->capacity) {
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+        return false;
+    }
+
+    memcpy(buf->buffer + buf->len, src, len);
+    buf->len += len;
+
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    return true;
+}
+
+/**
+ * Copies all bytes from buffer to buffer.
+ *
+ * On success, returns true and updates the buffer /length accordingly.
+ * If there is insufficient space in the buffer, returns false, leaving the
+ * buffer unchanged.
+ */
+bool aws_byte_buf_write_from_whole_buffer(struct aws_byte_buf *AWS_RESTRICT buf, struct aws_byte_buf src) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(&src));
+    return aws_byte_buf_write(buf, src.buffer, src.len);
+}
+
+/**
+ * Copies all bytes from buffer to buffer.
+ *
+ * On success, returns true and updates the buffer /length accordingly.
+ * If there is insufficient space in the buffer, returns false, leaving the
+ * buffer unchanged.
+ */
+bool aws_byte_buf_write_from_whole_cursor(struct aws_byte_buf *AWS_RESTRICT buf, struct aws_byte_cursor src) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&src));
+    return aws_byte_buf_write(buf, src.ptr, src.len);
+}
+
+/**
+ * Copies one byte to buffer.
+ *
+ * On success, returns true and updates the cursor /length
+ accordingly.
+
+ * If there is insufficient space in the cursor, returns false, leaving the
+ cursor unchanged.
+ */
+bool aws_byte_buf_write_u8(struct aws_byte_buf *AWS_RESTRICT buf, uint8_t c) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    return aws_byte_buf_write(buf, &c, 1);
+}
+
+/**
+ * Writes a 16-bit integer in network byte order (big endian) to buffer.
+ *
+ * On success, returns true and updates the cursor /length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_buf_write_be16(struct aws_byte_buf *buf, uint16_t x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    x = aws_hton16(x);
+    return aws_byte_buf_write(buf, (uint8_t *)&x, 2);
+}
+
+/**
+ * Writes a 32-bit integer in network byte order (big endian) to buffer.
+ *
+ * On success, returns true and updates the cursor /length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_buf_write_be32(struct aws_byte_buf *buf, uint32_t x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    x = aws_hton32(x);
+    return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
+}
+
+/**
+ * Writes a 32-bit float in network byte order (big endian) to buffer.
+ *
+ * On success, returns true and updates the cursor /length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_buf_write_float_be32(struct aws_byte_buf *buf, float x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    x = aws_htonf32(x);
+    return aws_byte_buf_write(buf, (uint8_t *)&x, 4);
+}
+
+/**
+ * Writes a 64-bit integer in network byte order (big endian) to buffer.
+ *
+ * On success, returns true and updates the cursor /length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    x = aws_hton64(x);
+    return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
+}
+
+/**
+ * Writes a 64-bit float in network byte order (big endian) to buffer.
+ *
+ * On success, returns true and updates the cursor /length accordingly.
+ * If there is insufficient space in the cursor, returns false, leaving the
+ * cursor unchanged.
+ */
+bool aws_byte_buf_write_float_be64(struct aws_byte_buf *buf, double x) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    x = aws_htonf64(x);
+    return aws_byte_buf_write(buf, (uint8_t *)&x, 8);
+}

--- a/tests/cursor_test.c
+++ b/tests/cursor_test.c
@@ -14,6 +14,7 @@
  */
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/private/byte_buf.h>
 
 #include <aws/testing/aws_test_harness.h>
 

--- a/tests/device_random_test.c
+++ b/tests/device_random_test.c
@@ -124,7 +124,7 @@ static int s_device_rand_buffer_distribution_fn(struct aws_allocator *allocator,
     (void)allocator;
     (void)ctx;
 
-    uint8_t array[DISTRIBUTION_PUT_COUNT];
+    uint8_t array[DISTRIBUTION_PUT_COUNT] = {0};
     struct aws_byte_buf buf = aws_byte_buf_from_empty_array(array, sizeof(array));
     ASSERT_SUCCESS(aws_device_random_buffer(&buf));
 


### PR DESCRIPTION
*Description of changes:*
Right now, a lot of stuff is "static inline" in the header files.  This makes the header files hard to read, gives little performance benefit in most cases, and makes my CBMC proof life much harder.  This is the first of several refactorings to move the code the .c files where it belongs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
