### PR TITLE
Relaxed constraints on gcc+x86/x64 to gcc 4.1.2

### DIFF
--- a/include/aws/common/atomics_gnu_old.inl
+++ b/include/aws/common/atomics_gnu_old.inl
@@ -21,9 +21,16 @@
 #include <stdlib.h>
 
 #if defined(__GNUC__)
-#    if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 4)
-/* See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36793 */
-#        error GCC versions before 4.4.0 are not supported
+#    if (__GNUC__ < 4)
+#        error GCC versions before 4.1.2 are not supported
+#    elif (defined(__arm__) || defined(__ia64__)) && (__GNUC__ == 4 && __GNUC_MINOR__ < 4)
+/* See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36793 Itanium codegen */
+/* https://bugs.launchpad.net/ubuntu/+source/gcc-4.4/+bug/491872 ARM codegen*/
+/* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42263 ARM codegen */
+#        error GCC versions before 4.4.0 are not supported on ARM or Itanium
+#    elif (defined(__x86_64__) || defined(__i386__)) && (__GNUC__ == 4 && __GNUC_MINOR__ < 1 && __GNUC_PATCHLEVEL__ < 2)
+/* 4.1.2 is the first gcc version with 100% working atomic intrinsics on Intel */
+#        error GCC versions before 4.1.2 are not supported on x86/x64
 #    endif
 #endif
 

--- a/include/aws/common/atomics_gnu_old.inl
+++ b/include/aws/common/atomics_gnu_old.inl
@@ -28,7 +28,7 @@
 /* https://bugs.launchpad.net/ubuntu/+source/gcc-4.4/+bug/491872 ARM codegen*/
 /* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42263 ARM codegen */
 #        error GCC versions before 4.4.0 are not supported on ARM or Itanium
-#    elif (defined(__x86_64__) || defined(__i386__)) && (__GNUC__ == 4 && __GNUC_MINOR__ < 1 && __GNUC_PATCHLEVEL__ < 2)
+#    elif (defined(__x86_64__) || defined(__i386__)) && (__GNUC__ == 4 && (__GNUC_MINOR__ < 1 || __GNUC_PATCHLEVEL__ < 2))
 /* 4.1.2 is the first gcc version with 100% working atomic intrinsics on Intel */
 #        error GCC versions before 4.1.2 are not supported on x86/x64
 #    endif

--- a/include/aws/common/atomics_gnu_old.inl
+++ b/include/aws/common/atomics_gnu_old.inl
@@ -28,7 +28,8 @@
 /* https://bugs.launchpad.net/ubuntu/+source/gcc-4.4/+bug/491872 ARM codegen*/
 /* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42263 ARM codegen */
 #        error GCC versions before 4.4.0 are not supported on ARM or Itanium
-#    elif (defined(__x86_64__) || defined(__i386__)) && (__GNUC__ == 4 && (__GNUC_MINOR__ < 1 || __GNUC_PATCHLEVEL__ < 2))
+#    elif (defined(__x86_64__) || defined(__i386__)) &&                                                                \
+        (__GNUC__ == 4 && (__GNUC_MINOR__ < 1 || __GNUC_PATCHLEVEL__ < 2))
 /* 4.1.2 is the first gcc version with 100% working atomic intrinsics on Intel */
 #        error GCC versions before 4.1.2 are not supported on x86/x64
 #    endif

--- a/include/aws/common/atomics_gnu_old.inl
+++ b/include/aws/common/atomics_gnu_old.inl
@@ -29,7 +29,7 @@
 /* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42263 ARM codegen */
 #        error GCC versions before 4.4.0 are not supported on ARM or Itanium
 #    elif (defined(__x86_64__) || defined(__i386__)) &&                                                                \
-        (__GNUC__ == 4 && (__GNUC_MINOR__ < 1 || __GNUC_PATCHLEVEL__ < 2))
+        (__GNUC__ == 4 && (__GNUC_MINOR__ < 1 || (__GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL__ < 2)))
 /* 4.1.2 is the first gcc version with 100% working atomic intrinsics on Intel */
 #        error GCC versions before 4.1.2 are not supported on x86/x64
 #    endif

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -360,6 +360,7 @@ static LONG WINAPI s_test_print_stack_trace(struct _EXCEPTION_POINTERS *exceptio
 #    include <signal.h>
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data) {
     (void)sig;
+    (void)sig_info;
     (void)user_data;
 #    if !defined(AWS_HEADER_CHECKER)
     aws_backtrace_print(stderr, sig_info);


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
