### PR TITLE
Stubs useful for ESDK proofs

### DIFF
--- a/.cbmc-batch/stubs/aws_byte_cursor_read_be16_override.c
+++ b/.cbmc-batch/stubs/aws_byte_cursor_read_be16_override.c
@@ -25,7 +25,7 @@ uint16_t AWS_BYTE_CURSOR_READ_BE16_GENERATOR(const struct aws_byte_cursor *curso
 
 /**
  * This function is used in deserializing values from a byte cursor.
- * Sometimes, for CBMB proof, it is expected that certain values in byte stream are constrained.
+ * Sometimes, for CBMC proof, it is expected that certain values in byte stream are constrained.
  * For example, in the aws_cryptosdk_enc_ctx_deserilize() proof, the first value we read is the number of elements,
  * which we need to be constrained in order to ensure that CBMC can fully unwind all loops. All other values can be left
  * nondet. In this case, define -DAWS_BYTE_CURSOR_READ_BE16_GENERATOR=generator_name, and the correct generator will be

--- a/.cbmc-batch/stubs/aws_byte_cursor_read_be16_override.c
+++ b/.cbmc-batch/stubs/aws_byte_cursor_read_be16_override.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/nondet.h>
+
+/**
+ * The signature for the value generator, if it is used.
+ */
+#ifdef AWS_BYTE_CURSOR_READ_BE16_GENERATOR
+uint16_t AWS_BYTE_CURSOR_READ_BE16_GENERATOR(const struct aws_byte_cursor *cursor);
+#endif
+
+/**
+ * This function is used in deserilizing values from a byte cursor.
+ * Sometimes, for the proof to go through, it is expected that certain values in byte stream are costrained.
+ * For example, in the aws_cryptosdk_enc_ctx_deserilize() proof, the first value we read is the number of elements,
+ * which we need to be constrained in order to ensure that the proof finishes. All other values can be left nondet.
+ * If there is no structure that must be followed, the function can be left undefined, and CBMC will automatically
+ * give nondet answers.
+ */
+bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cursor, uint16_t *var) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(var));
+
+#ifdef AWS_BYTE_CURSOR_READ_BE16_GENERATOR
+    *var = AWS_BYTE_CURSOR_READ_BE16_GENERATOR(cursor);
+#else
+    *var = nondet_uint16_t();
+#endif
+
+    const size_t len = sizeof(uint16_t);
+    /* If there are not 2 bytes left, or if we nondet fail */
+    if (cursor->len > (SIZE_MAX >> 1) || len > (SIZE_MAX >> 1) || len > cursor->len || nondet_bool()) {
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+        return false;
+    }
+
+    /* Otherwise, succeed */
+    cursor->ptr += len;
+    cursor->len -= len;
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
+    return true;
+}

--- a/.cbmc-batch/stubs/aws_byte_cursor_read_be16_override.c
+++ b/.cbmc-batch/stubs/aws_byte_cursor_read_be16_override.c
@@ -24,12 +24,13 @@ uint16_t AWS_BYTE_CURSOR_READ_BE16_GENERATOR(const struct aws_byte_cursor *curso
 #endif
 
 /**
- * This function is used in deserilizing values from a byte cursor.
- * Sometimes, for the proof to go through, it is expected that certain values in byte stream are costrained.
+ * This function is used in deserializing values from a byte cursor.
+ * Sometimes, for CBMB proof, it is expected that certain values in byte stream are constrained.
  * For example, in the aws_cryptosdk_enc_ctx_deserilize() proof, the first value we read is the number of elements,
- * which we need to be constrained in order to ensure that the proof finishes. All other values can be left nondet.
- * If there is no structure that must be followed, the function can be left undefined, and CBMC will automatically
- * give nondet answers.
+ * which we need to be constrained in order to ensure that CBMC can fully unwind all loops. All other values can be left
+ * nondet. In this case, define -DAWS_BYTE_CURSOR_READ_BE16_GENERATOR=generator_name, and the correct generator will be
+ * called. If there is no structure that must be followed, AWS_BYTE_CURSOR_READ_BE16_GENERATOR can be left undefined,
+ * and the var will be set to a nondet value.
  */
 bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cursor, uint16_t *var) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));

--- a/.cbmc-batch/stubs/aws_hash_table_no_slots_override.c
+++ b/.cbmc-batch/stubs/aws_hash_table_no_slots_override.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/private/hash_table_impl.h>
+
+#include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
+
+/********************************************************************************
+ * This module represents a hash-table that is not backed by any actual memory
+ * It just takes non-det actions when given inputs. We know this is safe because
+ * we've already proven the c-common hash-table memory safe under these
+ * pre/post conditions.
+ *
+ * Since we're making almost everything nondet, the only externally visible property
+ * of the hash-table is the [entry_count].
+ */
+
+/**
+ * As noted above the only externally visible property of the hash-table is the [entry_count]. And it can vary between
+ * 0-SIZE_MAX.  So there is really nothing to assert here */
+bool aws_hash_table_is_valid(const struct aws_hash_table *map) {
+    return map && map->p_impl;
+}
+
+/**
+ * The allocator for the hash_table
+ */
+void make_hash_table_with_no_backing_store(struct aws_hash_table *map, size_t max_table_entries) {
+    /* Allocate a hash_table_state with no memory for the slots.
+     * This ensures that if I actually try to use the slots, CBMC will throw a fit.
+     */
+    map->p_impl = bounded_malloc(sizeof(struct hash_table_state));
+    __CPROVER_assume(map->p_impl->entry_count <= max_table_entries);
+}
+/**
+ * Nondet clear.  Since the only externally visible property of this
+ * table is the entry_count, just set it to 0
+ */
+void aws_hash_table_clear(struct aws_hash_table *map) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+    struct hash_table_state *state = map->p_impl;
+    state->entry_count = 0;
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+}
+
+/**
+ * Nondet put.  Since there is no backing store, we just non-determinstically either add it or don't.
+ */
+int aws_hash_table_put(struct aws_hash_table *map, const void *key, void *value, int *was_created) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+
+    int track_was_created;
+    if (was_created) {
+        *was_created = track_was_created;
+    }
+
+    int rval;
+
+    struct hash_table_state *state = map->p_impl;
+
+    /* Avoid overflow */
+    if (state->entry_count == SIZE_MAX) {
+        return track_was_created ? AWS_OP_ERR : rval;
+    }
+
+    if (rval == AWS_OP_SUCCESS) {
+        state->entry_count++;
+    }
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map));
+    return rval;
+}
+
+/**
+ * Not yet implemented
+ */
+int aws_hash_table_remove_element(struct aws_hash_table *map, struct aws_hash_element *p_value);
+
+/**
+ * Not yet implemented
+ */
+int aws_hash_table_remove(
+    struct aws_hash_table *map,
+    const void *key,
+    struct aws_hash_element *p_value,
+    int *was_present);
+
+/**
+ * Not yet implemented
+ */
+int aws_hash_table_create(
+    struct aws_hash_table *map,
+    const void *key,
+    struct aws_hash_element **p_elem,
+    int *was_created);
+
+/**
+ * Implements a version of aws_hash_table_find() that non-determinstially either:
+ *   1. Return NULL, indicating that the element didn't exist
+ *   2. Returns a newly created element.  By default, just create a totally non-determinstic element.
+ *      However, if the consumer of the stub uses the element, this may be insufficient.  Use the same
+ *      style of generator as the hash_iterator stubs, except with a different signature due to the different
+ *      calling context.
+ *
+ * To declare a genarator:
+ * -DHASH_TABLE_FIND_ELEMENT_GENERATOR=the_generator_fn, where the_generator_fn has signature:
+ *   the_generator_fnconst struct aws_hash_table *map, const void *key, struct aws_hash_element *p_elem).
+ *
+ * NOTE: If you want a version of aws_hash_table_find() that implements it be assuming the value on
+ * the slot matched the value returned, that can be found in [aws_hash_table_find_override.c]
+ */
+#ifdef HASH_TABLE_FIND_ELEMENT_GENERATOR
+void HASH_TABLE_FIND_ELEMENT_GENERATOR(
+    const struct aws_hash_table *map,
+    const void *key,
+    struct aws_hash_element *p_elem);
+#endif
+
+int aws_hash_table_find(const struct aws_hash_table *map, const void *key, struct aws_hash_element **p_elem) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(map), "Input hash_table [map] must be valid.");
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(p_elem), "Input pointer [p_elem] must be writable.");
+    const struct hash_table_state *const state = map->p_impl;
+    if (nondet_bool()) {
+        *p_elem = NULL;
+    } else {
+        *p_elem = malloc(sizeof(struct aws_hash_element));
+#ifdef HASH_TABLE_FIND_ELEMENT_GENERATOR
+        HASH_TABLE_FIND_ELEMENT_GENERATOR(map, key, *p_elem);
+#endif
+    }
+    AWS_POSTCONDITION(aws_hash_table_is_valid(map), "Output hash_table [map] must be valid.");
+    return AWS_OP_SUCCESS;
+}

--- a/.cbmc-batch/stubs/aws_string_destroy_override.c
+++ b/.cbmc-batch/stubs/aws_string_destroy_override.c
@@ -16,13 +16,16 @@
 #include <aws/common/string.h>
 
 /**
- * Saves the function pointer dereferences when doing the delloc. Otherwise the same as the
- * real function.
+ * Allocation/Deallocation using the standard aws-c-common allocators requires
+ * calls through function pointers.  Until we get better function pointer support in
+ * CBMC, this is expensive.  Instead, since we know we're using "malloc" to do allocation
+ * in CBMC proofs, we can just directly use "free" here, saving the function pointer derefences.
+ * Otherwise the same as the real function.
  */
 void aws_string_destroy(struct aws_string *str) {
-    AWS_PRECONDITION(aws_string_is_valid(str));
+    AWS_PRECONDITION(!str || aws_string_is_valid(str));
     /* If the string has no allocator, its a static string and can't be freed */
-    if (str->allocator) {
+    if (str && str->allocator) {
         free(str);
     }
 }

--- a/.cbmc-batch/stubs/aws_string_destroy_override.c
+++ b/.cbmc-batch/stubs/aws_string_destroy_override.c
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-#pragma once
-
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <aws/common/string.h>
 
 /**
- * Non-determinstic functions used in CBMC proofs
+ * Saves the function pointer dereferences when doing the delloc. Otherwise the same as the
+ * real function.
  */
-bool nondet_bool();
-int nondet_int();
-size_t nondet_size_t();
-uint16_t nondet_uint16_t();
-uint32_t nondet_uint32_t();
-uint64_t nondet_uint64_t();
-uint8_t nondet_uint8_t();
-void *nondet_voidp();
+void aws_string_destroy(struct aws_string *str) {
+    AWS_PRECONDITION(aws_string_is_valid(str));
+    /* If the string has no allocator, its a static string and can't be freed */
+    if (str->allocator) {
+        free(str);
+    }
+}

--- a/.cbmc-batch/stubs/aws_string_new_from_array_override.c
+++ b/.cbmc-batch/stubs/aws_string_new_from_array_override.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/string.h>
+#include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
+
+/**
+ * Override the aws_string_new_from_array to just give non-det bytes, rather than doing the memcpy.
+ * Since we already check AWS_MEM_IS_READABLE(bytes, len) in the precondition, this is totally sound
+ */
+struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len) {
+    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(AWS_MEM_IS_READABLE(bytes, len));
+
+    size_t malloc_size = sizeof(struct aws_string) + 1 + len;
+
+    struct aws_string *str = bounded_malloc(malloc_size);
+
+    __CPROVER_assume(str->allocator == allocator);
+    __CPROVER_assume(str->len == len);
+    __CPROVER_assume(str->bytes[len] == '\0');
+    /* Fields are declared const, so we need to copy them in like this */
+    // *(struct aws_allocator **)(&str->allocator) = allocator;
+    //*(size_t *)(&str->len) = len;
+    //*(uint8_t *)&str->bytes[len] = '\0';
+    AWS_RETURN_WITH_POSTCONDITION(str, aws_string_is_valid(str));
+}

--- a/.cbmc-batch/stubs/aws_string_new_from_array_override.c
+++ b/.cbmc-batch/stubs/aws_string_new_from_array_override.c
@@ -20,7 +20,7 @@
 /**
  * Override the aws_string_new_from_array to just give non-det bytes, rather than doing the memcpy.
  * Since we already check AWS_MEM_IS_READABLE(bytes, len) in the precondition, this is sound - it overapproximates
- * the behaviour of the real function, butand has all the same memory safety checks.
+ * the behaviour of the real function, and has all the same memory safety checks.
  */
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len) {
     AWS_PRECONDITION(allocator);

--- a/.cbmc-batch/stubs/hash_table_generators.c
+++ b/.cbmc-batch/stubs/hash_table_generators.c
@@ -14,50 +14,51 @@
  */
 
 #include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/nondet.h>
 #include <proof_helpers/proof_allocators.h>
-#include <proof_helpers/make_common_data_structures.h>
 
-/* This file contains generators useful in hash-table stubs. See 
+/* This file contains generators useful in hash-table stubs. See
  * aws_hash_table_non_slots_override.c and aws_hash_iter_overrides.c for how these are used
  */
 
 /**
- * The common case for the hash-table is that it maps strings to strings. This generates 
+ * The common case for the hash-table is that it maps strings to strings. This generates
  * fully non-deterministic strings for both key and value
- */ 
+ */
 void hash_iterator_string_string_generator(struct aws_hash_iter *new_iter, const struct aws_hash_iter *old_iter) {
     (void)old_iter;
     if (new_iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE) {
-        new_iter->element.key   = ensure_string_is_allocated_nondet_length();
+        new_iter->element.key = ensure_string_is_allocated_nondet_length();
         new_iter->element.value = ensure_string_is_allocated_nondet_length();
     }
 }
 
 /**
- * The common case for the hash-table is that it maps strings to strings. This generates 
+ * The common case for the hash-table is that it maps strings to strings. This generates
  * fully non-deterministic strings for both key and value
- */ 
+ */
 void hash_find_string_string_generator(
-				       const struct aws_hash_table *map,
-				       const void *key,
-				       struct aws_hash_element *p_elem){
-  p_elem->key   = ensure_string_is_allocated_nondet_length();
-  p_elem->value = ensure_string_is_allocated_nondet_length();  
+    const struct aws_hash_table *map,
+    const void *key,
+    struct aws_hash_element *p_elem) {
+    p_elem->key = ensure_string_is_allocated_nondet_length();
+    p_elem->value = ensure_string_is_allocated_nondet_length();
 }
-
 
 /**
  * The common case for the hash-table is that it maps strings to strings.
  * Some code (for e.g. the aws_cryptosdk_enc_ctx_size() function in the ESDK uses the string header
  * but not the actual string itself.  So this allocates the header, but not the string.
  * This ensures that no successful proof CAN use the bytes of the string.
- */ 
-void hash_iterator_unbacked_string_string_generator(struct aws_hash_iter *new_iter, const struct aws_hash_iter *old_iter) {
+ */
+void hash_iterator_unbacked_string_string_generator(
+    struct aws_hash_iter *new_iter,
+    const struct aws_hash_iter *old_iter) {
     (void)old_iter;
     if (new_iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE) {
-        new_iter->element.key   = malloc(sizeof(struct aws_string));
-        new_iter->element.value = malloc(sizeof(struct aws_string));
+        new_iter->element.key = bounded_malloc(sizeof(struct aws_string));
+        new_iter->element.value = bounded_malloc(sizeof(struct aws_string));
     }
 }
 
@@ -66,10 +67,11 @@ void hash_iterator_unbacked_string_string_generator(struct aws_hash_iter *new_it
  * Some code (for e.g. the aws_cryptosdk_enc_ctx_size() function in the ESDK uses the string header
  * but not the actual string itself.  So this allocates the header, but not the string.
  * This ensures that no successful proof CAN use the bytes of the string.
- */ 
-void hash_find_unbacked_string_string_generator(const struct aws_hash_table *map,
-				       const void *key,
-				       struct aws_hash_element *p_elem){
-  p_elem->key   = malloc(sizeof(struct aws_string));
-  p_elem->value =  malloc(sizeof(struct aws_string));
+ */
+void hash_find_unbacked_string_string_generator(
+    const struct aws_hash_table *map,
+    const void *key,
+    struct aws_hash_element *p_elem) {
+    p_elem->key = bounded_malloc(sizeof(struct aws_string));
+    p_elem->value = bounded_malloc(sizeof(struct aws_string));
 }

--- a/.cbmc-batch/stubs/hash_table_generators.c
+++ b/.cbmc-batch/stubs/hash_table_generators.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/private/hash_table_impl.h>
+#include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/* This file contains generators useful in hash-table stubs. See 
+ * aws_hash_table_non_slots_override.c and aws_hash_iter_overrides.c for how these are used
+ */
+
+/**
+ * The common case for the hash-table is that it maps strings to strings. This generates 
+ * fully non-deterministic strings for both key and value
+ */ 
+void hash_iterator_string_string_generator(struct aws_hash_iter *new_iter, const struct aws_hash_iter *old_iter) {
+    (void)old_iter;
+    if (new_iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE) {
+        new_iter->element.key   = ensure_string_is_allocated_nondet_length();
+        new_iter->element.value = ensure_string_is_allocated_nondet_length();
+    }
+}
+
+/**
+ * The common case for the hash-table is that it maps strings to strings. This generates 
+ * fully non-deterministic strings for both key and value
+ */ 
+void hash_find_string_string_generator(
+				       const struct aws_hash_table *map,
+				       const void *key,
+				       struct aws_hash_element *p_elem){
+  p_elem->key   = ensure_string_is_allocated_nondet_length();
+  p_elem->value = ensure_string_is_allocated_nondet_length();  
+}
+
+
+/**
+ * The common case for the hash-table is that it maps strings to strings.
+ * Some code (for e.g. the aws_cryptosdk_enc_ctx_size() function in the ESDK uses the string header
+ * but not the actual string itself.  So this allocates the header, but not the string.
+ * This ensures that no successful proof CAN use the bytes of the string.
+ */ 
+void hash_iterator_unbacked_string_string_generator(struct aws_hash_iter *new_iter, const struct aws_hash_iter *old_iter) {
+    (void)old_iter;
+    if (new_iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE) {
+        new_iter->element.key   = malloc(sizeof(struct aws_string));
+        new_iter->element.value = malloc(sizeof(struct aws_string));
+    }
+}
+
+/**
+ * The common case for the hash-table is that it maps strings to strings.
+ * Some code (for e.g. the aws_cryptosdk_enc_ctx_size() function in the ESDK uses the string header
+ * but not the actual string itself.  So this allocates the header, but not the string.
+ * This ensures that no successful proof CAN use the bytes of the string.
+ */ 
+void hash_find_unbacked_string_string_generator(const struct aws_hash_table *map,
+				       const void *key,
+				       struct aws_hash_element *p_elem){
+  p_elem->key   = malloc(sizeof(struct aws_string));
+  p_elem->value =  malloc(sizeof(struct aws_string));
+}

--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -424,6 +424,12 @@ bool aws_ptr_eq(const void *a, const void *b);
 AWS_COMMON_API
 bool aws_hash_table_is_valid(const struct aws_hash_table *map);
 
+/**
+ * Given a pointer to a hash_iter, checks that it is well-formed, with all data-structure invariants.
+ */
+AWS_COMMON_API
+bool aws_hash_iter_is_valid(const struct aws_hash_iter *iter);
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_HASH_TABLE_H */

--- a/include/aws/common/private/hash_table_impl.h
+++ b/include/aws/common/private/hash_table_impl.h
@@ -59,60 +59,7 @@ struct hash_table_state {
  * Some invariants, such as that the number of entries is actually the
  * same as the entry_count field, would require a loop to check
  */
-AWS_STATIC_IMPL
-bool hash_table_state_is_valid(const struct hash_table_state *map) {
-    if (!map) {
-        return false;
-    }
-    bool hash_fn_nonnull = (map->hash_fn != NULL);
-    bool equals_fn_nonnull = (map->equals_fn != NULL);
-    /*destroy_key_fn and destroy_value_fn are both allowed to be NULL*/
-    bool alloc_nonnull = (map->alloc != NULL);
-    bool size_at_least_two = (map->size >= 2);
-    bool size_is_power_of_two = aws_is_power_of_two(map->size);
-    bool entry_count = (map->entry_count <= map->max_load);
-    bool max_load = (map->max_load < map->size);
-    bool mask_is_correct = (map->mask == (map->size - 1));
-    bool max_load_factor_bounded = map->max_load_factor == 0.95; //(map->max_load_factor < 1.0);
-    bool slots_allocated = AWS_MEM_IS_WRITABLE(&map->slots[0], sizeof(map->slots[0]) * map->size);
-
-    return hash_fn_nonnull && equals_fn_nonnull && alloc_nonnull && size_at_least_two && size_is_power_of_two &&
-           entry_count && max_load && mask_is_correct && max_load_factor_bounded && slots_allocated;
-}
-
-/**
- * Given a pointer to a hash_iter, checks that it is well-formed, with all data-structure invariants.
- */
-AWS_STATIC_IMPL
-bool aws_hash_iter_is_valid(const struct aws_hash_iter *iter) {
-    if (!iter) {
-        return false;
-    }
-    if (!iter->map) {
-        return false;
-    }
-    if (!aws_hash_table_is_valid(iter->map)) {
-        return false;
-    }
-    if (iter->limit > iter->map->p_impl->size) {
-        return false;
-    }
-
-    switch (iter->status) {
-        case AWS_HASH_ITER_STATUS_DONE:
-            /* Done iff slot == limit */
-            return iter->slot == iter->limit;
-        case AWS_HASH_ITER_STATUS_DELETE_CALLED:
-            /* iter->slot can underflow to SIZE_MAX after a delete
-             * see the comments for aws_hash_iter_delete() */
-            return iter->slot <= iter->limit || iter->slot == SIZE_MAX;
-        case AWS_HASH_ITER_STATUS_READY_FOR_USE:
-            /* A slot must point to a valid location (i.e. hash_code != 0) */
-            return iter->slot < iter->limit && iter->map->p_impl->slots[iter->slot].hash_code != 0;
-    }
-    /* Invalid status code */
-    return false;
-}
+bool hash_table_state_is_valid(const struct hash_table_state *map);
 
 /**
  * Determine the total number of bytes needed for a hash-table with
@@ -120,19 +67,6 @@ bool aws_hash_iter_is_valid(const struct aws_hash_iter *iter) {
  * AWS_OP_ERR; otherwise, return AWS_OP_SUCCESS with the result in
  * "required_bytes".
  */
-AWS_STATIC_IMPL
-int hash_table_state_required_bytes(size_t size, size_t *required_bytes) {
-
-    size_t elemsize;
-    if (aws_mul_size_checked(size, sizeof(struct hash_table_entry), &elemsize)) {
-        return AWS_OP_ERR;
-    }
-
-    if (aws_add_size_checked(elemsize, sizeof(struct hash_table_state), required_bytes)) {
-        return AWS_OP_ERR;
-    }
-
-    return AWS_OP_SUCCESS;
-}
+int hash_table_state_required_bytes(size_t size, size_t *required_bytes);
 
 #endif /* AWS_COMMON_PRIVATE_HASH_TABLE_IMPL_H */


### PR DESCRIPTION
*Description of changes:*
The ESDK proofs require several new stubs.  This adds them to the C-Common stubs library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
