### PR TITLE
added aws_string_clone_or_reuse() function, and test for it

### DIFF
--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -198,6 +198,13 @@ bool aws_byte_buf_write_from_whole_string(
 AWS_COMMON_API
 struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src);
 
+/**
+ * If the string was dynamically allocated, clones it. If the string was statically allocated (i.e. has no allocator),
+ * returns the original string.
+ */
+AWS_COMMON_API
+struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, const struct aws_string *str);
+
 AWS_EXTERN_C_END
 
 /**

--- a/source/string.c
+++ b/source/string.c
@@ -243,3 +243,18 @@ struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src)
     AWS_PRECONDITION(aws_string_is_valid(src));
     return aws_byte_cursor_from_array(aws_string_bytes(src), src->len);
 }
+
+struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, const struct aws_string *str) {
+    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(aws_string_is_valid(str));
+
+    if (str->allocator == NULL) {
+        /* Since the string cannot be deallocated, we assume that it will remain valid for the lifetime of the
+         * application */
+        AWS_POSTCONDITION(aws_string_is_valid(str));
+        return (struct aws_string *)str;
+    }
+
+    AWS_POSTCONDITION(aws_string_is_valid(str));
+    return aws_string_new_from_string(allocator, str);
+}

--- a/tests/string_test.c
+++ b/tests/string_test.c
@@ -85,10 +85,23 @@ static int s_string_tests_fn(struct aws_allocator *allocator, void *ctx) {
     ASSERT_NOT_NULL(dup_string_2, "Memory allocation of string should have succeeded.");
     ASSERT_TRUE(aws_string_eq(test_string_2, dup_string_2), "Strings should be equal.");
 
+    /* Test: can clone_or_reuse both a static string and an allocated one. */
+    struct aws_string *clone_string_1 = aws_string_clone_or_reuse(allocator, test_string_1);
+    ASSERT_NOT_NULL(clone_string_1, "Memory allocation of string should have succeeded.");
+    ASSERT_TRUE(aws_string_eq(test_string_1, clone_string_1), "Strings should be equal.");
+    ASSERT_TRUE(test_string_1 == clone_string_1, "Static strings should be reused");
+
+    struct aws_string *clone_string_2 = aws_string_clone_or_reuse(allocator, test_string_2);
+    ASSERT_NOT_NULL(clone_string_2, "Memory allocation of string should have succeeded.");
+    ASSERT_TRUE(aws_string_eq(test_string_2, clone_string_2), "Strings should be equal.");
+    ASSERT_TRUE(test_string_2 != clone_string_2, "Dynamic strings should not be reused");
+
     /* Test: all allocated memory is deallocated properly. */
     aws_string_destroy(test_string_2);
     aws_string_destroy(dup_string_1);
     aws_string_destroy(dup_string_2);
+    aws_string_destroy(clone_string_1);
+    aws_string_destroy(clone_string_2);
 
     return 0;
 }


### PR DESCRIPTION
*Description of changes:*
Add `aws_string_clone_or_reuse()` functionality, and a test for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
