### PR TITLE
AWS_ASSUME

### DIFF
--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -40,7 +40,11 @@ AWS_EXTERN_C_END
 #elif defined(_MSC_VER)
 #    define AWS_ASSUME(cond) __assume(cond)
 #elif defined(__clang__)
-#    define AWS_ASSUME(cond) do { bool _result = (cond); __builtin_assume(_result); } while(false)
+#    define AWS_ASSUME(cond)                                                                                           \
+        do {                                                                                                           \
+            bool _result = (cond);                                                                                     \
+            __builtin_assume(_result);                                                                                 \
+        } while (false)
 #elif defined(__GNUC__)
 #    define AWS_ASSUME(cond) ((cond) ? (void)0 : __builtin_unreachable())
 #endif

--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -36,6 +36,16 @@ void aws_backtrace_print(FILE *fp, void *call_site_data);
 AWS_EXTERN_C_END
 
 #if defined(CBMC)
+#    define AWS_ASSUME(cond) __CPROVER_assume(cond)
+#elif defined(_MSC_VER)
+#    define AWS_ASSUME(cond) __assume(cond)
+#elif defined(__clang__)
+#    define AWS_ASSUME(cond) do { bool _result = (cond); __builtin_assume(_result); } while(false)
+#elif defined(__GNUC__)
+#    define AWS_ASSUME(cond) ((cond) ? (void)0 : __builtin_unreachable())
+#endif
+
+#if defined(CBMC)
 #    include <assert.h>
 #    define AWS_ASSERT(cond) assert(cond)
 #elif defined(DEBUG_BUILD) || __clang_analyzer__

--- a/source/lru_cache.c
+++ b/source/lru_cache.c
@@ -113,7 +113,7 @@ int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_valu
         /* we're over the cache size limit. Remove whatever is in the back of
          * the list. */
         struct aws_linked_list_node *node_to_remove = aws_linked_list_back(&cache->list);
-        AWS_ASSERT(node_to_remove);
+        AWS_ASSUME(node_to_remove);
         struct cache_node *entry_to_remove = AWS_CONTAINER_OF(node_to_remove, struct cache_node, node);
         /*the callback will unlink and deallocate the node */
         aws_hash_table_remove(&cache->table, entry_to_remove->key, NULL, NULL);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_test_case(unknown_error_code_in_slot_test)
 add_test_case(unknown_error_code_no_slot_test)
 add_test_case(unknown_error_code_range_too_large_test)
 add_test_case(aws_load_error_strings_test)
+add_test_case(aws_assume_compiles_test)
 
 add_test_case(thread_creation_join_test)
 

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -453,6 +453,15 @@ static int s_aws_load_error_strings_test(struct aws_allocator *allocator, void *
     return AWS_OP_SUCCESS;
 }
 
+static int s_aws_assume_compiles_test(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    AWS_ASSUME(true);
+
+    return AWS_OP_SUCCESS;
+}
+
 AWS_TEST_CASE_FIXTURE(
     raise_errors_test,
     s_setup_errors_test_fn,
@@ -496,3 +505,4 @@ AWS_TEST_CASE_FIXTURE(
     s_teardown_errors_test_fn,
     NULL)
 AWS_TEST_CASE(aws_load_error_strings_test, s_aws_load_error_strings_test)
+AWS_TEST_CASE(aws_assume_compiles_test, s_aws_assume_compiles_test)


### PR DESCRIPTION
Macro for formalizing compile-time assumptions without runtime overhead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
