### PR TITLE
Updating Clock.c WIDEN macro to properly prepend the wide char idenfiier

### DIFF
--- a/source/windows/clock.c
+++ b/source/windows/clock.c
@@ -26,7 +26,7 @@ static VOID WINAPI s_get_system_time_func_lazy_init(LPFILETIME filetime_p);
 static timefunc_t *volatile s_p_time_func = s_get_system_time_func_lazy_init;
 
 /* Convert a string from a macro to a wide string */
-#define WIDEN2(s) L#s
+#define WIDEN2(s) L ## #s
 #define WIDEN(s) WIDEN2(s)
 
 static BOOL CALLBACK s_get_system_time_init_once(PINIT_ONCE init_once, PVOID param, PVOID *context) {


### PR DESCRIPTION
The WIDEN2 macro was currently stringifying the input, but not concatenating the wchar_t identifier of L to the string.
This causes an issue if the input parameter was already stringified.
For example if the input parameter is `"Kernel32"`, the string `L"Kernel32"` would be formed.

The current logic works fine if the input parameter has not been stringified yet such as `"Kernel32"`

*Issue #, if available:*

*Description of changes:*
The changes here involve adding concatenation to the clock.c WIDEN2 macro which is used to make a wide string out of the WINDOWS_KERNEL_LIB macro value.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
