### PR TITLE
Implement AWS_UNREACHABLE()

### DIFF
--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -39,16 +39,20 @@ AWS_EXTERN_C_END
 #    define AWS_ASSUME(cond) __CPROVER_assume(cond)
 #elif defined(_MSC_VER)
 #    define AWS_ASSUME(cond) __assume(cond)
+#    define AWS_UNREACHABLE() __assume(0)
 #elif defined(__clang__)
 #    define AWS_ASSUME(cond)                                                                                           \
         do {                                                                                                           \
             bool _result = (cond);                                                                                     \
             __builtin_assume(_result);                                                                                 \
         } while (false)
+#    define AWS_UNREACHABLE() __builtin_unreachable()
 #elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
 #    define AWS_ASSUME(cond) ((cond) ? (void)0 : __builtin_unreachable())
+#    define AWS_UNREACHABLE() __builtin_unreachable()
 #else
 #    define AWS_ASSUME(cond)
+#    define AWS_UNREACHABLE()
 #endif
 
 #if defined(CBMC)

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -459,6 +459,10 @@ static int s_aws_assume_compiles_test(struct aws_allocator *allocator, void *ctx
 
     AWS_ASSUME(true);
 
+    if (false) {
+        AWS_UNREACHABLE();
+    }
+
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
This is only necessary because clang treats __builtin_assume(false) and __builtin_unreachable() differently, which I think is stupid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
