### PR TITLE
Check for travis branch env variable

### DIFF
--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -511,6 +511,12 @@ def produce_config(build_spec, config_file, **additional_variables):
 cwd = os.getcwd()
 
 def _get_git_branch():
+
+    travis_pr_branch = os.environ.get("TRAVIS_PULL_REQUEST_BRANCH")
+    if travis_pr_branch:
+        print("Found branch:", travis_pr_branch)
+        return travis_pr_branch
+
     branches = subprocess.check_output(["git", "branch", "-a", "--contains", "HEAD"]).decode("utf-8")
     branches = [branch.strip('*').strip() for branch in branches.split('\n') if branch]
 


### PR DESCRIPTION
This should fix the branch detection on Travis macOS builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
