### PR TITLE
Remove AWS_ALIGN, as it doesn't work reliably, add AWS_ALIGNED_TYPEDEF

### DIFF
--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -59,7 +59,7 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 
 #if defined(_MSC_VER)
 #    include <malloc.h>
-#    define AWS_ALIGN(alignment) __declspec(align(alignment))
+#    define AWS_ALIGNED_TYPEDEF(from, to, alignment) typedef __declspec(align(alignment)) from to
 #    define AWS_LIKELY(x) x
 #    define AWS_UNLIKELY(x) x
 #    define AWS_FORCE_INLINE __forceinline
@@ -68,7 +68,7 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #    define AWS_ATTRIBUTE_NORETURN
 #else
 #    if defined(__GNUC__) || defined(__clang__)
-#        define AWS_ALIGN(alignment) __attribute__((aligned(alignment)))
+#        define AWS_ALIGNED_TYPEDEF(from, to, alignment) typedef from to __attribute__((aligned(alignment)))
 #        define AWS_TYPE_OF(a) __typeof__(a)
 #        define AWS_LIKELY(x) __builtin_expect(!!(x), 1)
 #        define AWS_UNLIKELY(x) __builtin_expect(!!(x), 0)
@@ -99,8 +99,6 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #        endif /* defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L */
 #    endif     /* defined(_MSC_VER) */
 #endif         /* defined(__cplusplus) */
-
-#define AWS_CACHE_ALIGN AWS_ALIGN(AWS_CACHE_LINE)
 
 #if defined(_MSC_VER)
 #    define AWS_THREAD_LOCAL __declspec(thread)

--- a/source/arch/encoding_avx2.c
+++ b/source/arch/encoding_avx2.c
@@ -88,9 +88,7 @@ static inline bool decode_vec(__m256i *in) {
     return _mm256_testz_si256(mask, mask);
 }
 
-struct aligned256 {
-    unsigned char bytes[32];
-} AWS_ALIGN(32);
+AWS_ALIGNED_TYPEDEF(uint8_t, aligned256[32], 32);
 
 /*
  * Input: a 256-bit vector, interpreted as 32 * 6-bit values
@@ -140,7 +138,7 @@ static inline __m256i pack_vec(__m256i in) {
      * those fragments in little endian but the order of fragments within the overall
      * vector is in memory order (big endian)
      */
-    const struct aligned256 shufvec_buf = {{
+    const aligned256 shufvec_buf = {
         /* clang-format off */
         /* MSB */
         0xFF, 0xFF, 0xFF, 0xFF, /* Zero out the top 4 bytes of the lane */
@@ -156,7 +154,7 @@ static inline __m256i pack_vec(__m256i in) {
         14, 13, 12
         /* LSB */
         /* clang-format on */
-    }};
+    };
     __m256i shufvec = _mm256_load_si256((__m256i const *)&shufvec_buf);
 
     dwords = _mm256_shuffle_epi8(dwords, shufvec);
@@ -298,7 +296,7 @@ static inline __m256i encode_stride(__m256i vec) {
      * -- -- -- -- 11 10 09 08 07 06 05 04 03 02 01 00
      */
 
-    const struct aligned256 shufvec_buf = {{
+    const aligned256 shufvec_buf = {
         /* clang-format off */
         /* MSB */
         2, 1, 0, 0xFF,
@@ -312,7 +310,7 @@ static inline __m256i encode_stride(__m256i vec) {
         11, 10, 9, 0xFF
         /* LSB */
         /* clang-format on */
-    }};
+    };
     vec = _mm256_shuffle_epi8(vec, _mm256_load_si256((__m256i const *)&shufvec_buf));
 
     /*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,6 +241,7 @@ add_test_case(test_byte_cursor_compare_lexical)
 add_test_case(test_byte_cursor_compare_lookup)
 
 add_test_case(byte_swap_test)
+add_test_case(alignment_test)
 
 add_test_case(test_cpu_count_at_least_works_superficially)
 add_test_case(test_stack_trace_decoding)

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -61,3 +61,24 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
     return 0;
 }
 AWS_TEST_CASE(byte_swap_test, s_byte_swap_test_fn);
+
+AWS_ALIGNED_TYPEDEF(uint8_t, aligned_storage[64], 32);
+
+struct padding_disaster {
+    aligned_storage a;
+    uint8_t dumb;
+    aligned_storage b;
+};
+
+static int s_alignment_test_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct padding_disaster padded;
+
+    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.a) % 32);
+    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.b) % 32);
+
+    return 0;
+}
+AWS_TEST_CASE(alignment_test, s_alignment_test_fn)

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -17,6 +17,10 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#ifdef _MSC_VER
+#    pragma warning(disable : 4324) /* structure was padded due to alignment specifier */
+#endif
+
 static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;


### PR DESCRIPTION
MSVC requires `__declspec(aligned(#))` before the struct decl, but GCC requires it be after. To avoid wrapping the whole thing in the macro, this is a much simpler way to get aligned structures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
