### PR TITLE
Test null-ness using AWS_NOT_NULL

### DIFF
--- a/.cbmc-batch/jobs/aws_array_eq_c_str/aws_array_eq_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_array_eq_c_str/aws_array_eq_c_str_harness.c
@@ -33,8 +33,8 @@ void aws_array_eq_c_str_harness() {
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 
     /* pre-conditions */
-    __CPROVER_assume(array || (array_len == 0));
-    __CPROVER_assume(c_str);
+    __CPROVER_assume(AWS_NOT_NULL(array) || (array_len == 0));
+    __CPROVER_assume(AWS_NOT_NULL(c_str));
 
     /* operation under verification */
     if (aws_array_eq_c_str(array, array_len, c_str)) {

--- a/.cbmc-batch/jobs/aws_array_eq_c_str_ignore_case/aws_array_eq_c_str_ignore_case_harness.c
+++ b/.cbmc-batch/jobs/aws_array_eq_c_str_ignore_case/aws_array_eq_c_str_ignore_case_harness.c
@@ -32,8 +32,8 @@ void aws_array_eq_c_str_ignore_case_harness() {
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 
     /* pre-conditions */
-    __CPROVER_assume(array || (array_len == 0));
-    __CPROVER_assume(c_str);
+    __CPROVER_assume(AWS_NOT_NULL(array) || (array_len == 0));
+    __CPROVER_assume(AWS_NOT_NULL(c_str));
 
     /* operation under verification */
     if (aws_array_eq_c_str_ignore_case(array, array_len, c_str)) {

--- a/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_front/aws_array_list_front_harness.c
@@ -44,7 +44,7 @@ void aws_array_list_front_harness() {
     if (!aws_array_list_front(&list, val)) {
         /* In the case aws_array_list_front is successful, we can ensure the list isn't empty */
         assert(AWS_BYTES_EQ(val, list.data, list.item_size));
-        assert(list.data);
+        assert(AWS_NOT_NULL(list.data));
         assert(list.length);
     }
 

--- a/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at/aws_array_list_get_at_harness.c
@@ -46,7 +46,7 @@ void aws_array_list_get_at_harness() {
         /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
          * and index is within bounds.
          */
-        assert(list.data);
+        assert(AWS_NOT_NULL(list.data));
         assert(list.length > index);
     }
 

--- a/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_get_at_ptr/aws_array_list_get_at_ptr_harness.c
@@ -37,14 +37,14 @@ void aws_array_list_get_at_ptr_harness() {
 
     /* assume preconditions */
     __CPROVER_assume(aws_array_list_is_valid(&list));
-    __CPROVER_assume(val);
+    __CPROVER_assume(AWS_NOT_NULL(val));
 
     /* perform operation under verification */
     if (!aws_array_list_get_at_ptr(&list, val, index)) {
         /* In the case aws_array_list_get_at is successful, we can ensure the list isn't empty
          * and index is within bounds.
          */
-        assert(list.data);
+        assert(AWS_NOT_NULL(list.data));
         assert(list.length > index);
     }
 

--- a/.cbmc-batch/jobs/aws_array_list_pop_back/aws_array_list_pop_back_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_pop_back/aws_array_list_pop_back_harness.c
@@ -36,7 +36,7 @@ void aws_array_list_pop_back_harness() {
     /* perform operation under verification and assertions */
     if (!aws_array_list_pop_back(&list)) {
         assert(list.length == old.length - 1);
-        assert(list.data);
+        assert(AWS_NOT_NULL(list.data));
         assert(list.alloc == old.alloc);
         assert(list.current_size == old.current_size);
         assert(list.item_size == old.item_size);

--- a/.cbmc-batch/jobs/aws_array_list_pop_front/aws_array_list_pop_front_harness.c
+++ b/.cbmc-batch/jobs/aws_array_list_pop_front/aws_array_list_pop_front_harness.c
@@ -36,7 +36,7 @@ void aws_array_list_pop_front_harness() {
     /* perform operation under verification and assertions */
     if (!aws_array_list_pop_front(&list)) {
         assert(list.length == old.length - 1);
-        assert(list.data);
+        assert(AWS_NOT_NULL(list.data));
         assert(list.alloc == old.alloc);
         assert(list.current_size == old.current_size);
         assert(list.item_size == old.item_size);

--- a/.cbmc-batch/jobs/aws_hash_table_init-bounded/aws_hash_table_init_bounded_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_init-bounded/aws_hash_table_init_bounded_harness.c
@@ -27,9 +27,9 @@ void aws_hash_table_init_bounded_harness() {
     size_t size;
     __CPROVER_assume(size <= MAX_TABLE_SIZE);
     aws_hash_fn *hash_fn;
-    __CPROVER_assume(hash_fn);
+    __CPROVER_assume(AWS_NOT_NULL(hash_fn));
     aws_hash_callback_eq_fn *equals_fn;
-    __CPROVER_assume(equals_fn);
+    __CPROVER_assume(AWS_NOT_NULL(equals_fn));
     aws_hash_callback_destroy_fn *destroy_key_fn;
     aws_hash_callback_destroy_fn *destroy_value_fn;
     struct aws_hash_table map;

--- a/.cbmc-batch/jobs/aws_hash_table_init-unbounded/aws_hash_table_init_unbounded_harness.c
+++ b/.cbmc-batch/jobs/aws_hash_table_init-unbounded/aws_hash_table_init_unbounded_harness.c
@@ -27,9 +27,9 @@ void aws_hash_table_init_unbounded_harness() {
     struct aws_allocator *allocator = can_fail_allocator();
     size_t size;
     aws_hash_fn *hash_fn;
-    __CPROVER_assume(hash_fn);
+    __CPROVER_assume(AWS_NOT_NULL(hash_fn));
     aws_hash_callback_eq_fn *equals_fn;
-    __CPROVER_assume(equals_fn);
+    __CPROVER_assume(AWS_NOT_NULL(equals_fn));
     aws_hash_callback_destroy_fn *destroy_key_fn;
     aws_hash_callback_destroy_fn *destroy_value_fn;
     struct aws_hash_table map;

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -207,8 +207,8 @@ cleanup:
 #undef AWS_ALIGN_ROUND_UP
 
 void aws_mem_release(struct aws_allocator *allocator, void *ptr) {
-    AWS_FATAL_PRECONDITION(allocator != NULL);
-    AWS_FATAL_PRECONDITION(allocator->mem_release != NULL);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_release));
 
     if (ptr != NULL) {
         free(ptr);
@@ -216,9 +216,9 @@ void aws_mem_release(struct aws_allocator *allocator, void *ptr) {
 }
 
 int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize, size_t newsize) {
-    AWS_FATAL_PRECONDITION(allocator != NULL);
-    AWS_FATAL_PRECONDITION(allocator->mem_realloc || allocator->mem_acquire);
-    AWS_FATAL_PRECONDITION(allocator->mem_release);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_realloc) || AWS_NOT_NULL(allocator->mem_acquire));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_release));
 
     /* Protect against https://wiki.sei.cmu.edu/confluence/display/c/MEM04-C.+Beware+of+zero-length+allocations */
     if (newsize == 0) {

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -31,8 +31,8 @@ int aws_array_list_init_dynamic(
     size_t initial_item_allocation,
     size_t item_size) {
 
-    AWS_FATAL_PRECONDITION(list != NULL);
-    AWS_FATAL_PRECONDITION(alloc != NULL);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(list));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(alloc));
     AWS_FATAL_PRECONDITION(item_size > 0);
 
     AWS_ZERO_STRUCT(*list);
@@ -56,7 +56,7 @@ int aws_array_list_init_dynamic(
     list->item_size = item_size;
     list->alloc = alloc;
 
-    AWS_FATAL_POSTCONDITION(list->current_size == 0 || list->data);
+    AWS_FATAL_POSTCONDITION(list->current_size == 0 || AWS_NOT_NULL(list->data));
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
     return AWS_OP_SUCCESS;
 
@@ -72,8 +72,8 @@ void aws_array_list_init_static(
     size_t item_count,
     size_t item_size) {
 
-    AWS_FATAL_PRECONDITION(list != NULL);
-    AWS_FATAL_PRECONDITION(raw_array != NULL);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(list));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(raw_array));
     AWS_FATAL_PRECONDITION(item_count > 0);
     AWS_FATAL_PRECONDITION(item_size > 0);
 
@@ -129,7 +129,7 @@ AWS_STATIC_IMPL
 int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(
-        val && AWS_MEM_IS_READABLE(val, list->item_size),
+        AWS_NOT_NULL(val) && AWS_MEM_IS_READABLE(val, list->item_size),
         "Input pointer [val] must point writable memory of [list->item_size] bytes.");
 
     int err_code = aws_array_list_set_at(list, val, aws_array_list_length(list));
@@ -147,7 +147,7 @@ AWS_STATIC_IMPL
 int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(
-        val && AWS_MEM_IS_WRITABLE(val, list->item_size),
+        AWS_NOT_NULL(val) && AWS_MEM_IS_WRITABLE(val, list->item_size),
         "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         memcpy(val, list->data, list->item_size);
@@ -230,7 +230,7 @@ AWS_STATIC_IMPL
 int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(
-        val && AWS_MEM_IS_WRITABLE(val, list->item_size),
+        AWS_NOT_NULL(val) && AWS_MEM_IS_WRITABLE(val, list->item_size),
         "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > 0) {
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
@@ -249,7 +249,7 @@ int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     if (aws_array_list_length(list) > 0) {
 
-        AWS_FATAL_PRECONDITION(list->data);
+        AWS_FATAL_PRECONDITION(AWS_NOT_NULL(list->data));
 
         size_t last_item_offset = list->item_size * (aws_array_list_length(list) - 1);
 
@@ -279,7 +279,7 @@ AWS_STATIC_IMPL
 void aws_array_list_swap_contents(
     struct aws_array_list *AWS_RESTRICT list_a,
     struct aws_array_list *AWS_RESTRICT list_b) {
-    AWS_FATAL_PRECONDITION(list_a->alloc);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(list_a->alloc));
     AWS_FATAL_PRECONDITION(list_a->alloc == list_b->alloc);
     AWS_FATAL_PRECONDITION(list_a->item_size == list_b->item_size);
     AWS_FATAL_PRECONDITION(list_a != list_b);
@@ -308,7 +308,7 @@ size_t aws_array_list_length(const struct aws_array_list *AWS_RESTRICT list) {
      * This assert teaches clang-tidy and friends that list->data cannot be null in a non-empty
      * list.
      */
-    AWS_FATAL_PRECONDITION(!list->length || list->data);
+    AWS_FATAL_PRECONDITION(!list->length || AWS_NOT_NULL(list->data));
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     size_t len = list->length;
     AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -319,7 +319,7 @@ AWS_STATIC_IMPL
 int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(
-        val && AWS_MEM_IS_WRITABLE(val, list->item_size),
+        AWS_NOT_NULL(val) && AWS_MEM_IS_WRITABLE(val, list->item_size),
         "Input pointer [val] must point writable memory of [list->item_size] bytes.");
     if (aws_array_list_length(list) > index) {
         memcpy(val, (void *)((uint8_t *)list->data + (list->item_size * index)), list->item_size);
@@ -333,7 +333,7 @@ int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *
 AWS_STATIC_IMPL
 int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
-    AWS_PRECONDITION(val != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(val));
     if (aws_array_list_length(list) > index) {
         *val = (void *)((uint8_t *)list->data + (list->item_size * index));
         AWS_POSTCONDITION(aws_array_list_is_valid(list));
@@ -347,7 +347,7 @@ AWS_STATIC_IMPL
 int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index) {
     AWS_PRECONDITION(aws_array_list_is_valid(list));
     AWS_PRECONDITION(
-        val && AWS_MEM_IS_READABLE(val, list->item_size),
+        AWS_NOT_NULL(val) && AWS_MEM_IS_READABLE(val, list->item_size),
         "Input pointer [val] must point readable memory of [list->item_size] bytes.");
 
     if (aws_array_list_ensure_capacity(list, index)) {
@@ -355,7 +355,7 @@ int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *
         return AWS_OP_ERR;
     }
 
-    AWS_FATAL_PRECONDITION(list->data);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(list->data));
 
     memcpy((void *)((uint8_t *)list->data + (list->item_size * index)), val, list->item_size);
 

--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -153,4 +153,6 @@ AWS_EXTERN_C_END
 #define AWS_OBJECT_PTR_IS_READABLE(ptr) AWS_MEM_IS_READABLE((ptr), sizeof(*(ptr)))
 #define AWS_OBJECT_PTR_IS_WRITABLE(ptr) AWS_MEM_IS_WRITABLE((ptr), sizeof(*(ptr)))
 
+#define AWS_NOT_NULL(ptr) (ptr != NULL)
+
 #endif /* AWS_COMMON_ASSERT_H */

--- a/include/aws/common/linked_list.inl
+++ b/include/aws/common/linked_list.inl
@@ -26,7 +26,7 @@ AWS_EXTERN_C_BEGIN
  * Set node's next and prev pointers to NULL.
  */
 AWS_STATIC_IMPL void aws_linked_list_node_reset(struct aws_linked_list_node *node) {
-    AWS_PRECONDITION(node != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(node));
     AWS_ZERO_STRUCT(*node);
     AWS_POSTCONDITION(AWS_IS_ZEROED(*node));
 }
@@ -40,7 +40,7 @@ AWS_STATIC_IMPL void aws_linked_list_node_reset(struct aws_linked_list_node *nod
  * Tests if the list is empty.
  */
 AWS_STATIC_IMPL bool aws_linked_list_empty(const struct aws_linked_list *list) {
-    AWS_PRECONDITION(list);
+    AWS_PRECONDITION(AWS_NOT_NULL(list));
     return list->head.next == &list->tail;
 }
 
@@ -116,7 +116,7 @@ AWS_STATIC_IMPL bool aws_linked_list_is_valid_deep(const struct aws_linked_list 
  * Initializes the list. List will be empty after this call.
  */
 AWS_STATIC_IMPL void aws_linked_list_init(struct aws_linked_list *list) {
-    AWS_PRECONDITION(list);
+    AWS_PRECONDITION(AWS_NOT_NULL(list));
     list->head.next = &list->tail;
     list->head.prev = NULL;
     list->tail.prev = &list->head;
@@ -203,7 +203,7 @@ AWS_STATIC_IMPL void aws_linked_list_insert_after(
     struct aws_linked_list_node *after,
     struct aws_linked_list_node *to_add) {
     AWS_PRECONDITION(aws_linked_list_node_next_is_valid(after));
-    AWS_PRECONDITION(to_add != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(to_add));
     to_add->prev = after;
     to_add->next = after->next;
     after->next->prev = to_add;
@@ -252,7 +252,7 @@ AWS_STATIC_IMPL void aws_linked_list_insert_before(
     struct aws_linked_list_node *before,
     struct aws_linked_list_node *to_add) {
     AWS_PRECONDITION(aws_linked_list_node_prev_is_valid(before));
-    AWS_PRECONDITION(to_add != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(to_add));
     to_add->next = before;
     to_add->prev = before->prev;
     before->prev->next = to_add;
@@ -281,7 +281,7 @@ AWS_STATIC_IMPL void aws_linked_list_remove(struct aws_linked_list_node *node) {
  */
 AWS_STATIC_IMPL void aws_linked_list_push_back(struct aws_linked_list *list, struct aws_linked_list_node *node) {
     AWS_PRECONDITION(aws_linked_list_is_valid(list));
-    AWS_PRECONDITION(node != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(node));
     aws_linked_list_insert_before(&list->tail, node);
     AWS_POSTCONDITION(aws_linked_list_is_valid(list));
     AWS_POSTCONDITION(list->tail.prev == node, "[node] is the new last element of [list]");
@@ -318,7 +318,7 @@ AWS_STATIC_IMPL struct aws_linked_list_node *aws_linked_list_pop_back(struct aws
  */
 AWS_STATIC_IMPL void aws_linked_list_push_front(struct aws_linked_list *list, struct aws_linked_list_node *node) {
     AWS_PRECONDITION(aws_linked_list_is_valid(list));
-    AWS_PRECONDITION(node != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(node));
     aws_linked_list_insert_before(list->head.next, node);
     AWS_POSTCONDITION(aws_linked_list_is_valid(list));
     AWS_POSTCONDITION(list->head.next == node, "[node] is the new first element of [list]");

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -73,8 +73,8 @@ struct aws_allocator *aws_default_allocator(void) {
 }
 
 void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
-    AWS_FATAL_PRECONDITION(allocator != NULL);
-    AWS_FATAL_PRECONDITION(allocator->mem_acquire != NULL);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_acquire));
     /* Protect against https://wiki.sei.cmu.edu/confluence/display/c/MEM04-C.+Beware+of+zero-length+allocations */
     AWS_FATAL_PRECONDITION(size != 0);
 
@@ -86,8 +86,8 @@ void *aws_mem_acquire(struct aws_allocator *allocator, size_t size) {
 }
 
 void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
-    AWS_FATAL_PRECONDITION(allocator != NULL);
-    AWS_FATAL_PRECONDITION(allocator->mem_calloc || allocator->mem_acquire);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_calloc) || AWS_NOT_NULL(allocator->mem_acquire));
     /* Protect against https://wiki.sei.cmu.edu/confluence/display/c/MEM04-C.+Beware+of+zero-length+allocations */
     AWS_FATAL_PRECONDITION(num != 0 && size != 0);
 
@@ -115,7 +115,7 @@ void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
         return NULL;
     }
     memset(mem, 0, required_bytes);
-    AWS_POSTCONDITION(mem != NULL);
+    AWS_POSTCONDITION(AWS_NOT_NULL(mem));
     return mem;
 }
 
@@ -173,8 +173,8 @@ cleanup:
 #undef AWS_ALIGN_ROUND_UP
 
 void aws_mem_release(struct aws_allocator *allocator, void *ptr) {
-    AWS_FATAL_PRECONDITION(allocator != NULL);
-    AWS_FATAL_PRECONDITION(allocator->mem_release != NULL);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_release));
 
     if (ptr != NULL) {
         allocator->mem_release(allocator, ptr);
@@ -182,9 +182,9 @@ void aws_mem_release(struct aws_allocator *allocator, void *ptr) {
 }
 
 int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize, size_t newsize) {
-    AWS_FATAL_PRECONDITION(allocator != NULL);
-    AWS_FATAL_PRECONDITION(allocator->mem_realloc || allocator->mem_acquire);
-    AWS_FATAL_PRECONDITION(allocator->mem_release);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_realloc) || AWS_NOT_NULL(allocator->mem_acquire));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(allocator->mem_release));
 
     /* Protect against https://wiki.sei.cmu.edu/confluence/display/c/MEM04-C.+Beware+of+zero-length+allocations */
     if (newsize == 0) {
@@ -256,7 +256,7 @@ static void *s_cf_allocator_reallocate(void *ptr, CFIndex new_size, CFOptionFlag
     (void)hint;
 
     struct aws_allocator *allocator = info;
-    AWS_ASSERT(allocator->mem_realloc);
+    AWS_ASSERT(AWS_NOT_NULL(allocator->mem_realloc));
 
     void *original_allocation = (uint8_t *)ptr - sizeof(size_t);
     size_t original_size = 0;

--- a/source/array_list.c
+++ b/source/array_list.c
@@ -69,7 +69,7 @@ int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list) {
 
 int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to) {
     AWS_FATAL_PRECONDITION(from->item_size == to->item_size);
-    AWS_FATAL_PRECONDITION(from->data);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(from->data));
     AWS_PRECONDITION(aws_array_list_is_valid(from));
     AWS_PRECONDITION(aws_array_list_is_valid(to));
 
@@ -179,8 +179,8 @@ int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, siz
 static void aws_array_list_mem_swap(void *AWS_RESTRICT item1, void *AWS_RESTRICT item2, size_t item_size) {
     enum { SLICE = 128 };
 
-    AWS_FATAL_PRECONDITION(item1);
-    AWS_FATAL_PRECONDITION(item2);
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(item1));
+    AWS_FATAL_PRECONDITION(AWS_NOT_NULL(item2));
 
     /* copy SLICE sized bytes at a time */
     size_t slice_count = item_size / SLICE;

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -25,8 +25,8 @@
 #endif
 
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity) {
-    AWS_PRECONDITION(buf);
-    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(AWS_NOT_NULL(buf));
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator));
 
     buf->buffer = (capacity == 0) ? NULL : aws_mem_acquire(allocator, capacity);
     if (capacity != 0 && buf->buffer == NULL) {
@@ -41,8 +41,8 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
 }
 
 int aws_byte_buf_init_copy(struct aws_byte_buf *dest, struct aws_allocator *allocator, const struct aws_byte_buf *src) {
-    AWS_PRECONDITION(allocator);
-    AWS_PRECONDITION(dest);
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_PRECONDITION(AWS_NOT_NULL(dest));
     AWS_ERROR_PRECONDITION(aws_byte_buf_is_valid(src));
 
     if (!src->buffer) {
@@ -128,7 +128,7 @@ bool aws_byte_buf_eq_ignore_case(const struct aws_byte_buf *const a, const struc
 
 bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(c_str != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(c_str));
     bool rval = aws_array_eq_c_str(buf->buffer, buf->len, c_str);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return rval;
@@ -136,7 +136,7 @@ bool aws_byte_buf_eq_c_str(const struct aws_byte_buf *const buf, const char *con
 
 bool aws_byte_buf_eq_c_str_ignore_case(const struct aws_byte_buf *const buf, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(c_str != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(c_str));
     bool rval = aws_array_eq_c_str_ignore_case(buf->buffer, buf->len, c_str);
     AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
     return rval;
@@ -146,8 +146,8 @@ int aws_byte_buf_init_copy_from_cursor(
     struct aws_byte_buf *dest,
     struct aws_allocator *allocator,
     struct aws_byte_cursor src) {
-    AWS_PRECONDITION(allocator);
-    AWS_PRECONDITION(dest);
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator));
+    AWS_PRECONDITION(AWS_NOT_NULL(dest));
     AWS_ERROR_PRECONDITION(aws_byte_cursor_is_valid(&src));
 
     AWS_ZERO_STRUCT(*dest);
@@ -222,8 +222,8 @@ int aws_byte_cursor_split_on_char_n(
     char split_on,
     size_t n,
     struct aws_array_list *AWS_RESTRICT output) {
-    AWS_ASSERT(input_str && input_str->ptr);
-    AWS_ASSERT(output);
+    AWS_ASSERT(AWS_NOT_NULL(input_str) && AWS_NOT_NULL(input_str->ptr));
+    AWS_ASSERT(AWS_NOT_NULL(output));
     AWS_ASSERT(output->item_size >= sizeof(struct aws_byte_cursor));
 
     size_t max_splits = n > 0 ? n : SIZE_MAX;
@@ -398,9 +398,9 @@ bool aws_array_eq(const void *const array_a, const size_t len_a, const void *con
 
 bool aws_array_eq_c_str_ignore_case(const void *const array, const size_t array_len, const char *const c_str) {
     AWS_PRECONDITION(
-        array || (array_len == 0),
+        AWS_NOT_NULL(array) || (array_len == 0),
         "Either input pointer [array_a] mustn't be NULL or input [array_len] mustn't be zero.");
-    AWS_PRECONDITION(c_str != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(c_str));
 
     /* Simpler implementation could have been:
      *   return aws_array_eq_ignore_case(array, array_len, c_str, strlen(c_str));
@@ -426,9 +426,9 @@ bool aws_array_eq_c_str_ignore_case(const void *const array, const size_t array_
 
 bool aws_array_eq_c_str(const void *const array, const size_t array_len, const char *const c_str) {
     AWS_PRECONDITION(
-        array || (array_len == 0),
+        AWS_NOT_NULL(array) || (array_len == 0),
         "Either input pointer [array_a] mustn't be NULL or input [array_len] mustn't be zero.");
-    AWS_PRECONDITION(c_str != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(c_str));
 
     /* Simpler implementation could have been:
      *   return aws_array_eq(array, array_len, c_str, strlen(c_str));
@@ -507,7 +507,7 @@ bool aws_byte_cursor_eq_byte_buf_ignore_case(
 
 bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_PRECONDITION(c_str != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(c_str));
     bool rv = aws_array_eq_c_str(cursor->ptr, cursor->len, c_str);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
     return rv;
@@ -515,7 +515,7 @@ bool aws_byte_cursor_eq_c_str(const struct aws_byte_cursor *const cursor, const 
 
 bool aws_byte_cursor_eq_c_str_ignore_case(const struct aws_byte_cursor *const cursor, const char *const c_str) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(cursor));
-    AWS_PRECONDITION(c_str != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(c_str));
     bool rv = aws_array_eq_c_str_ignore_case(cursor->ptr, cursor->len, c_str);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
     return rv;
@@ -533,8 +533,8 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
 
     if (from->len > 0) {
         /* This assert teaches clang-tidy that from->ptr and to->buffer cannot be null in a non-empty buffers */
-        AWS_ASSERT(from->ptr);
-        AWS_ASSERT(to->buffer);
+        AWS_ASSERT(AWS_NOT_NULL(from->ptr));
+        AWS_ASSERT(AWS_NOT_NULL(to->buffer));
         memcpy(to->buffer + to->len, from->ptr, from->len);
         to->len += from->len;
     }
@@ -575,7 +575,7 @@ int aws_byte_buf_append_with_lookup(
 int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_cursor *from) {
     AWS_PRECONDITION(aws_byte_buf_is_valid(to));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(from));
-    AWS_ERROR_PRECONDITION(to->allocator);
+    AWS_ERROR_PRECONDITION(AWS_NOT_NULL(to->allocator));
 
     if (to->capacity - to->len < from->len) {
         /*
@@ -652,8 +652,8 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
     } else {
         if (from->len > 0) {
             /* This assert teaches clang-tidy that from->ptr and to->buffer cannot be null in a non-empty buffers */
-            AWS_ASSERT(from->ptr);
-            AWS_ASSERT(to->buffer);
+            AWS_ASSERT(AWS_NOT_NULL(from->ptr));
+            AWS_ASSERT(AWS_NOT_NULL(to->buffer));
             memcpy(to->buffer + to->len, from->ptr, from->len);
         }
     }
@@ -666,7 +666,7 @@ int aws_byte_buf_append_dynamic(struct aws_byte_buf *to, const struct aws_byte_c
 }
 
 int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity) {
-    AWS_ERROR_PRECONDITION(buffer->allocator);
+    AWS_ERROR_PRECONDITION(AWS_NOT_NULL(buffer->allocator));
     AWS_ERROR_PRECONDITION(aws_byte_buf_is_valid(buffer));
 
     if (requested_capacity <= buffer->capacity) {
@@ -686,7 +686,7 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
 }
 
 int aws_byte_buf_reserve_relative(struct aws_byte_buf *buffer, size_t additional_length) {
-    AWS_ERROR_PRECONDITION(buffer->allocator);
+    AWS_ERROR_PRECONDITION(AWS_NOT_NULL(buffer->allocator));
     AWS_ERROR_PRECONDITION(aws_byte_buf_is_valid(buffer));
 
     size_t requested_capacity = 0;
@@ -702,7 +702,7 @@ struct aws_byte_cursor aws_byte_cursor_right_trim_pred(
     const struct aws_byte_cursor *source,
     aws_byte_predicate_fn *predicate) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
-    AWS_PRECONDITION(predicate != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(predicate));
     struct aws_byte_cursor trimmed = *source;
 
     while (trimmed.len > 0 && predicate(*(trimmed.ptr + trimmed.len - 1))) {
@@ -717,7 +717,7 @@ struct aws_byte_cursor aws_byte_cursor_left_trim_pred(
     const struct aws_byte_cursor *source,
     aws_byte_predicate_fn *predicate) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
-    AWS_PRECONDITION(predicate != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(predicate));
     struct aws_byte_cursor trimmed = *source;
 
     while (trimmed.len > 0 && predicate(*(trimmed.ptr))) {
@@ -733,7 +733,7 @@ struct aws_byte_cursor aws_byte_cursor_trim_pred(
     const struct aws_byte_cursor *source,
     aws_byte_predicate_fn *predicate) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(source));
-    AWS_PRECONDITION(predicate != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(predicate));
     struct aws_byte_cursor left_trimmed = aws_byte_cursor_left_trim_pred(source, predicate);
     struct aws_byte_cursor dest = aws_byte_cursor_right_trim_pred(&left_trimmed, predicate);
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(source));
@@ -752,8 +752,8 @@ int aws_byte_cursor_compare_lexical(const struct aws_byte_cursor *lhs, const str
     AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
     /* make sure we don't pass NULL pointers to memcmp */
-    AWS_PRECONDITION(lhs->ptr != NULL);
-    AWS_PRECONDITION(rhs->ptr != NULL);
+    AWS_PRECONDITION(AWS_NOT_NULL(lhs->ptr));
+    AWS_PRECONDITION(AWS_NOT_NULL(rhs->ptr));
     size_t comparison_length = lhs->len;
     if (comparison_length > rhs->len) {
         comparison_length = rhs->len;

--- a/source/error.c
+++ b/source/error.c
@@ -146,8 +146,8 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
      * - we'll either segfault immediately (for the first two) or for the count
      * assert, the registration will be ineffective.
      */
-    AWS_FATAL_ASSERT(error_info);
-    AWS_FATAL_ASSERT(error_info->error_list);
+    AWS_FATAL_ASSERT(AWS_NOT_NULL(error_info));
+    AWS_FATAL_ASSERT(AWS_NOT_NULL(error_info->error_list));
     AWS_FATAL_ASSERT(error_info->count);
 
     const int min_range = error_info->error_list[0].error_code;
@@ -180,8 +180,8 @@ void aws_register_error_info(const struct aws_error_info_list *error_info) {
 }
 
 void aws_unregister_error_info(const struct aws_error_info_list *error_info) {
-    AWS_FATAL_ASSERT(error_info);
-    AWS_FATAL_ASSERT(error_info->error_list);
+    AWS_FATAL_ASSERT(AWS_NOT_NULL(error_info));
+    AWS_FATAL_ASSERT(AWS_NOT_NULL(error_info->error_list));
     AWS_FATAL_ASSERT(error_info->count);
 
     const int min_range = error_info->error_list[0].error_code;

--- a/source/string.c
+++ b/source/string.c
@@ -15,12 +15,12 @@
 #include <aws/common/string.h>
 
 struct aws_string *aws_string_new_from_c_str(struct aws_allocator *allocator, const char *c_str) {
-    AWS_PRECONDITION(allocator && c_str);
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator) && AWS_NOT_NULL(c_str));
     return aws_string_new_from_array(allocator, (const uint8_t *)c_str, strlen(c_str));
 }
 
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, const uint8_t *bytes, size_t len) {
-    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator));
     AWS_PRECONDITION(AWS_MEM_IS_READABLE(bytes, len));
     size_t malloc_size;
     if (aws_add_size_checked(sizeof(struct aws_string) + 1, len, &malloc_size)) {
@@ -40,19 +40,19 @@ struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator, co
 }
 
 struct aws_string *aws_string_new_from_string(struct aws_allocator *allocator, const struct aws_string *str) {
-    AWS_PRECONDITION(allocator && aws_string_is_valid(str));
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator) && aws_string_is_valid(str));
     return aws_string_new_from_array(allocator, str->bytes, str->len);
 }
 
 void aws_string_destroy(struct aws_string *str) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
     if (str && str->allocator) {
         aws_mem_release(str->allocator, str);
     }
 }
 
 void aws_string_destroy_secure(struct aws_string *str) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
     if (str) {
         aws_secure_zero((void *)aws_string_bytes(str), str->len);
         if (str->allocator) {
@@ -112,8 +112,8 @@ int aws_array_list_comparator_string(const void *a, const void *b) {
  * Returns true if bytes of string are the same, false otherwise.
  */
 bool aws_string_eq(const struct aws_string *a, const struct aws_string *b) {
-    AWS_PRECONDITION(!a || aws_string_is_valid(a));
-    AWS_PRECONDITION(!b || aws_string_is_valid(b));
+    AWS_PRECONDITION(!AWS_NOT_NULL(a) || aws_string_is_valid(a));
+    AWS_PRECONDITION(!AWS_NOT_NULL(b) || aws_string_is_valid(b));
     if (a == b) {
         return true;
     }
@@ -127,8 +127,8 @@ bool aws_string_eq(const struct aws_string *a, const struct aws_string *b) {
  * Returns true if bytes of string are equivalent, using a case-insensitive comparison.
  */
 bool aws_string_eq_ignore_case(const struct aws_string *a, const struct aws_string *b) {
-    AWS_PRECONDITION(!a || aws_string_is_valid(a));
-    AWS_PRECONDITION(!b || aws_string_is_valid(b));
+    AWS_PRECONDITION(!AWS_NOT_NULL(a) || aws_string_is_valid(a));
+    AWS_PRECONDITION(!AWS_NOT_NULL(b) || aws_string_is_valid(b));
     if (a == b) {
         return true;
     }
@@ -142,8 +142,8 @@ bool aws_string_eq_ignore_case(const struct aws_string *a, const struct aws_stri
  * Returns true if bytes of string and cursor are the same, false otherwise.
  */
 bool aws_string_eq_byte_cursor(const struct aws_string *str, const struct aws_byte_cursor *cur) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
-    AWS_PRECONDITION(!cur || aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(cur) || aws_byte_cursor_is_valid(cur));
     if (str == NULL && cur == NULL) {
         return true;
     }
@@ -158,8 +158,8 @@ bool aws_string_eq_byte_cursor(const struct aws_string *str, const struct aws_by
  */
 
 bool aws_string_eq_byte_cursor_ignore_case(const struct aws_string *str, const struct aws_byte_cursor *cur) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
-    AWS_PRECONDITION(!cur || aws_byte_cursor_is_valid(cur));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(cur) || aws_byte_cursor_is_valid(cur));
     if (str == NULL && cur == NULL) {
         return true;
     }
@@ -173,8 +173,8 @@ bool aws_string_eq_byte_cursor_ignore_case(const struct aws_string *str, const s
  * Returns true if bytes of string and buffer are the same, false otherwise.
  */
 bool aws_string_eq_byte_buf(const struct aws_string *str, const struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
-    AWS_PRECONDITION(!buf || aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(buf) || aws_byte_buf_is_valid(buf));
     if (str == NULL && buf == NULL) {
         return true;
     }
@@ -189,8 +189,8 @@ bool aws_string_eq_byte_buf(const struct aws_string *str, const struct aws_byte_
  */
 
 bool aws_string_eq_byte_buf_ignore_case(const struct aws_string *str, const struct aws_byte_buf *buf) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
-    AWS_PRECONDITION(!buf || aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(buf) || aws_byte_buf_is_valid(buf));
     if (str == NULL && buf == NULL) {
         return true;
     }
@@ -201,7 +201,7 @@ bool aws_string_eq_byte_buf_ignore_case(const struct aws_string *str, const stru
 }
 
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
     if (str == NULL && c_str == NULL) {
         return true;
     }
@@ -215,7 +215,7 @@ bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str) {
  * Returns true if bytes of strings are equivalent, using a case-insensitive comparison.
  */
 bool aws_string_eq_c_str_ignore_case(const struct aws_string *str, const char *c_str) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
+    AWS_PRECONDITION(!AWS_NOT_NULL(str) || aws_string_is_valid(str));
     if (str == NULL && c_str == NULL) {
         return true;
     }
@@ -228,8 +228,8 @@ bool aws_string_eq_c_str_ignore_case(const struct aws_string *str, const char *c
 bool aws_byte_buf_write_from_whole_string(
     struct aws_byte_buf *AWS_RESTRICT buf,
     const struct aws_string *AWS_RESTRICT src) {
-    AWS_PRECONDITION(!buf || aws_byte_buf_is_valid(buf));
-    AWS_PRECONDITION(!src || aws_string_is_valid(src));
+    AWS_PRECONDITION(!AWS_NOT_NULL(buf) || aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(!AWS_NOT_NULL(src) || aws_string_is_valid(src));
     if (buf == NULL || src == NULL) {
         return false;
     }
@@ -245,7 +245,7 @@ struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src)
 }
 
 struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, const struct aws_string *str) {
-    AWS_PRECONDITION(allocator);
+    AWS_PRECONDITION(AWS_NOT_NULL(allocator));
     AWS_PRECONDITION(aws_string_is_valid(str));
 
     if (str->allocator == NULL) {
@@ -260,7 +260,7 @@ struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, co
 }
 
 int aws_secure_strlen(const char *str, size_t max_read_len, size_t *str_len) {
-    AWS_ERROR_PRECONDITION(str && str_len, AWS_ERROR_INVALID_ARGUMENT);
+    AWS_ERROR_PRECONDITION(AWS_NOT_NULL(str) && str_len, AWS_ERROR_INVALID_ARGUMENT);
 
     /* why not strnlen? It doesn't work everywhere as it wasn't standardized til C11, and is considered
      * a GNU extension. This should be faster anyways. This should work for ascii and utf8.


### PR DESCRIPTION
Pre- and post-conditions previously mostly (though not always) relied on
the implicit cast from a pointer to an integral type. This might be ok
for a cast to _Bool, but cases where an assert expands to a function
expecting an int the results could be ambiguous.

Avoid any ambiguity by introducing a new macro AWS_NOT_NULL that
explicitly compares the pointer to NULL.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
