### PR TITLE
Fix misnamed parameter

### DIFF
--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -246,8 +246,8 @@ void s_resolve_cmd(char *cmd, size_t len, struct aws_stack_frame_info *frame) {
 }
 #    endif
 
-size_t aws_backtrace(void **frames, size_t size) {
-    return backtrace(frames, size);
+size_t aws_backtrace(void **frames, size_t num_frames) {
+    return backtrace(frames, num_frames);
 }
 
 char **aws_backtrace_symbols(void *const *frames, size_t stack_depth) {


### PR DESCRIPTION
clang-tidy-7 surfaced this issue on my machine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
