### PR TITLE
__has_builtin check before calling __builtin_assume Macro

### DIFF
--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -37,7 +37,6 @@ AWS_EXTERN_C_END
 #    define AWS_ASSUME(cond)                                                                                           \
         do {                                                                                                           \
             bool _result = (cond);                                                                                     \
-            if __has_builtin
             __builtin_assume(_result);                                                                                 \
         } while (false)
 #    define AWS_UNREACHABLE() __builtin_unreachable()

--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -33,10 +33,11 @@ AWS_EXTERN_C_END
 #elif defined(_MSC_VER)
 #    define AWS_ASSUME(cond) __assume(cond)
 #    define AWS_UNREACHABLE() __assume(0)
-#elif defined(__clang__)
+#elif defined(__clang__) && __has_builtin(__builtin_assume)
 #    define AWS_ASSUME(cond)                                                                                           \
         do {                                                                                                           \
             bool _result = (cond);                                                                                     \
+            if __has_builtin
             __builtin_assume(_result);                                                                                 \
         } while (false)
 #    define AWS_UNREACHABLE() __builtin_unreachable()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

__builtin_assume is not supported by all Clang version. Its better to have a check condition of the macro before calling it.
