### PR TITLE
Move include ctest up, this should reenable tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include(AwsSharedLibSetup)
 include(AwsFeatureTests)
 include(AwsSanitizers)
 include(AwsSIMD)
+include(CTest)
 
 set(GENERATED_ROOT_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(GENERATED_INCLUDE_DIR "${GENERATED_ROOT_DIR}/include")
@@ -233,7 +234,6 @@ configure_file(${CONFIG_HEADER_TEMPLATE}
 
 if (NOT CMAKE_CROSSCOMPILING)
     if (BUILD_TESTING)
-        include(CTest)
         add_subdirectory(tests)
     endif()
 endif()


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
