### PR TITLE
Builder work

### DIFF
--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -665,6 +665,8 @@ def run_build(build_spec, build_config, is_dryrun):
             project_source_dir = os.path.join(build_dir, project)
             project_build_dir = os.path.join(project_source_dir, 'build')
 
+        print("Project {}, source_dir {}, build_dir {}".format(project,project_source_dir, project_build_dir))
+
         def _build_project_cmake():
             # If the build directory doesn't already exist, make it
             _mkdir(project_build_dir)
@@ -729,6 +731,8 @@ def run_build(build_spec, build_config, is_dryrun):
                 **config,
                 **config['variables'],
             }
+
+            print("command_variables : {}".format(command_variables))
 
             config_build = project_config.get("build", None)
             if config_build:

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -723,6 +723,9 @@ def run_build(build_spec, build_config, is_dryrun):
             upstream = project_config.get("upstream", [])
             downstream = project_config.get("downstream", [])
 
+            print("WTF is **config : {}".format(**config))
+            print("WTF is **config['variables'] : {}".format(**config['variables']))
+
             command_variables = {
                 'source_dir': project_source_dir,
                 'build_dir': project_build_dir,

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -723,8 +723,7 @@ def run_build(build_spec, build_config, is_dryrun):
             upstream = project_config.get("upstream", [])
             downstream = project_config.get("downstream", [])
 
-            print("WTF is **config : {}".format(**config))
-            print("WTF is **config['variables'] : {}".format(**config['variables']))
+            print("WTF is config : {}".format(config))
 
             command_variables = {
                 'source_dir': project_source_dir,

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -726,12 +726,12 @@ def run_build(build_spec, build_config, is_dryrun):
             print("WTF is config : {}".format(config))
 
             command_variables = {
+                **config,
+                **config['variables'],
                 'source_dir': project_source_dir,
                 'build_dir': project_build_dir,
                 'install_dir': install_dir,
                 'build_config': build_config,
-                **config,
-                **config['variables'],
             }
 
             print("command_variables : {}".format(command_variables))

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -656,16 +656,12 @@ def run_build(build_spec, build_config, is_dryrun):
     # Helper to build
     def _build_project(project=None, build_tests=False, run_tests=False, build_downstream=False):
 
-        print("Project {} called with build_tests={}, run_tests={}, build_downstream={}".format(project, build_tests, run_tests, build_downstream))
-        
         if not project:
             project_source_dir = source_dir
             project_build_dir = build_dir
         else:
             project_source_dir = os.path.join(build_dir, project)
             project_build_dir = os.path.join(project_source_dir, 'build')
-
-        print("Project {}, source_dir {}, build_dir {}".format(project,project_source_dir, project_build_dir))
 
         def _build_project_cmake():
             # If the build directory doesn't already exist, make it
@@ -723,8 +719,6 @@ def run_build(build_spec, build_config, is_dryrun):
             upstream = project_config.get("upstream", [])
             downstream = project_config.get("downstream", [])
 
-            print("WTF is config : {}".format(config))
-
             command_variables = {
                 **config,
                 **config['variables'],
@@ -733,8 +727,6 @@ def run_build(build_spec, build_config, is_dryrun):
                 'install_dir': install_dir,
                 'build_config': build_config,
             }
-
-            print("command_variables : {}".format(command_variables))
 
             config_build = project_config.get("build", None)
             if config_build:
@@ -753,11 +745,8 @@ def run_build(build_spec, build_config, is_dryrun):
             if config_test:
                 assert isinstance(config_test, list)
                 def _test_project_config():
-                    print("Substitution variable context: {}".format(command_variables))
                     for command in config_test:
-                        print("Subbing variables into test command \"{}\"".format(command))
                         final_command = _replace_variables(command, command_variables)
-                        print("Substitution result: \"{}\"".format(final_command))
                         _run_command(final_command)
                 test_fn = _test_project_config
 

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -656,6 +656,8 @@ def run_build(build_spec, build_config, is_dryrun):
     # Helper to build
     def _build_project(project=None, build_tests=False, run_tests=False, build_downstream=False):
 
+        print("Project {} called with build_tests={}, run_tests={}, build_downstream={}".format(project, build_tests, run_tests, build_downstream))
+        
         if not project:
             project_source_dir = source_dir
             project_build_dir = build_dir
@@ -745,8 +747,11 @@ def run_build(build_spec, build_config, is_dryrun):
             if config_test:
                 assert isinstance(config_test, list)
                 def _test_project_config():
+                    print("Substitution variable context: {}".format(command_variables))
                     for command in config_test:
+                        print("Subbing variables into test command \"{}\"".format(command))
                         final_command = _replace_variables(command, command_variables)
+                        print("Substitution result: \"{}\"".format(final_command))
                         _run_command(final_command)
                 test_fn = _test_project_config
 


### PR DESCRIPTION
Nested build path overrides were getting stomped by the top-level values due to the order of inputs to the hash map construction expression.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
