### PR TITLE
Split alignment tests 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,7 +241,13 @@ add_test_case(test_byte_cursor_compare_lexical)
 add_test_case(test_byte_cursor_compare_lookup)
 
 add_test_case(byte_swap_test)
-add_test_case(alignment_test)
+
+if (HAVE_AVX2_INTRINSICS AND HAVE_SIMD_CPUID)
+    add_test_case(alignment32_test)
+else()
+    add_test_case(alignment16_test)
+endif()
+
 
 add_test_case(test_cpu_count_at_least_works_superficially)
 add_test_case(test_stack_trace_decoding)

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -66,23 +66,44 @@ static int s_byte_swap_test_fn(struct aws_allocator *allocator, void *ctx) {
 }
 AWS_TEST_CASE(byte_swap_test, s_byte_swap_test_fn);
 
-AWS_ALIGNED_TYPEDEF(uint8_t, aligned_storage[64], 32);
+AWS_ALIGNED_TYPEDEF(uint8_t, aligned32_storage[64], 32);
 
-struct padding_disaster {
-    aligned_storage a;
+struct padding32_disaster {
+    aligned32_storage a;
     uint8_t dumb;
-    aligned_storage b;
+    aligned32_storage b;
 };
 
-static int s_alignment_test_fn(struct aws_allocator *allocator, void *ctx) {
+static int s_alignment32_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
 
-    struct padding_disaster padded;
+    struct padding32_disaster padded;
 
     ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.a) % 32);
     ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.b) % 32);
 
     return 0;
 }
-AWS_TEST_CASE(alignment_test, s_alignment_test_fn)
+AWS_TEST_CASE(alignment32_test, s_alignment32_test_fn)
+
+AWS_ALIGNED_TYPEDEF(uint8_t, aligned16_storage[64], 16);
+
+struct padding16_disaster {
+    aligned16_storage a;
+    uint8_t dumb;
+    aligned16_storage b;
+};
+
+static int s_alignment16_test_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct padding16_disaster padded;
+
+    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.a) % 16);
+    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.b) % 16);
+
+    return 0;
+}
+AWS_TEST_CASE(alignment16_test, s_alignment16_test_fn)

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -77,9 +77,7 @@ static int s_alignment32_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
 
-    struct padding32_disaster padded;
-
-    ptrdiff_t spacing = (intptr_t)&padded.b - (intptr_t)&padded.dumb;
+    size_t spacing = offsetof(struct padding32_disaster, b) - offsetof(struct padding32_disaster, dumb);
     ASSERT_UINT_EQUALS(0, spacing % 32);
 
     return 0;
@@ -97,9 +95,7 @@ static int s_alignment16_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
 
-    struct padding16_disaster padded;
-
-    ptrdiff_t spacing = (intptr_t)&padded.b - (intptr_t)&padded.dumb;
+    size_t spacing = offsetof(struct padding32_disaster, b) - offsetof(struct padding32_disaster, dumb);
     ASSERT_UINT_EQUALS(0, spacing % 16);
 
     return 0;

--- a/tests/byte_order_test.c
+++ b/tests/byte_order_test.c
@@ -69,7 +69,6 @@ AWS_TEST_CASE(byte_swap_test, s_byte_swap_test_fn);
 AWS_ALIGNED_TYPEDEF(uint8_t, aligned32_storage[64], 32);
 
 struct padding32_disaster {
-    aligned32_storage a;
     uint8_t dumb;
     aligned32_storage b;
 };
@@ -80,8 +79,8 @@ static int s_alignment32_test_fn(struct aws_allocator *allocator, void *ctx) {
 
     struct padding32_disaster padded;
 
-    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.a) % 32);
-    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.b) % 32);
+    ptrdiff_t spacing = (intptr_t)&padded.b - (intptr_t)&padded.dumb;
+    ASSERT_UINT_EQUALS(0, spacing % 32);
 
     return 0;
 }
@@ -90,7 +89,6 @@ AWS_TEST_CASE(alignment32_test, s_alignment32_test_fn)
 AWS_ALIGNED_TYPEDEF(uint8_t, aligned16_storage[64], 16);
 
 struct padding16_disaster {
-    aligned16_storage a;
     uint8_t dumb;
     aligned16_storage b;
 };
@@ -101,8 +99,8 @@ static int s_alignment16_test_fn(struct aws_allocator *allocator, void *ctx) {
 
     struct padding16_disaster padded;
 
-    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.a) % 16);
-    ASSERT_UINT_EQUALS(0, ((intptr_t)&padded.b) % 16);
+    ptrdiff_t spacing = (intptr_t)&padded.b - (intptr_t)&padded.dumb;
+    ASSERT_UINT_EQUALS(0, spacing % 16);
 
     return 0;
 }


### PR DESCRIPTION
Split alignment tests into 16 and 32 bytes; 32 enabled only if avx2 support is active


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
