### PR TITLE
thread-sanitizer fix spiritual journey

### DIFF
--- a/include/aws/common/math.gcc_x64_asm.inl
+++ b/include/aws/common/math.gcc_x64_asm.inl
@@ -23,6 +23,8 @@
 #include <aws/common/common.h>
 #include <aws/common/math.h>
 
+/* clang-format off */
+
 AWS_EXTERN_C_BEGIN
 
 /**
@@ -186,5 +188,7 @@ AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
 }
 
 AWS_EXTERN_C_END
+
+/* clang-format on */
 
 #endif /* AWS_COMMON_MATH_GCC_X64_ASM_INL */

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -384,7 +384,9 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
     }
 
     /* clean up */
-    aws_mem_tracer_destroy(allocator);
+    if (!harness->suppress_memcheck) {
+        aws_mem_tracer_destroy(allocator);
+    }
     aws_logger_set(NULL);
     aws_logger_clean_up(&err_logger);
 

--- a/source/memtrace.c
+++ b/source/memtrace.c
@@ -25,6 +25,7 @@
 
 /* describes a single live allocation */
 struct alloc_info {
+    struct aws_allocator *allocator; /* Allocator of this object */
     size_t size;
     time_t time;
     uint64_t stack; /* hash of stack frame pointers */
@@ -42,8 +43,9 @@ struct alloc_info {
 
 /* one of these is stored per unique stack */
 struct stack_trace {
-    size_t depth;         /* length of frames[] */
-    void *const frames[]; /* rest of frames are allocated after */
+    struct aws_allocator *allocator; /* Allocator of this object */
+    size_t depth;                    /* length of frames[] */
+    void *const frames[];            /* rest of frames are allocated after */
 };
 
 #ifdef _MSC_VER
@@ -52,7 +54,7 @@ struct stack_trace {
 
 /* Tracking structure, used as the allocator impl */
 struct alloc_tracer {
-    struct aws_allocator *allocator;        /* underlying allocator */
+    struct aws_allocator *traced_allocator; /* underlying allocator */
     struct aws_allocator *system_allocator; /* bookkeeping allocator */
     enum aws_mem_trace_level level;         /* level to trace at */
     size_t frames_per_stack;                /* how many frames to keep per stack */
@@ -60,7 +62,6 @@ struct alloc_tracer {
     struct aws_mutex mutex;                 /* protects everything below */
     struct aws_hash_table allocs;           /* live allocations, maps address -> alloc_info */
     struct aws_hash_table stacks;           /* unique stack traces, maps hash -> stack_trace */
-    struct aws_hash_table stack_info;       /* only used during dumps, maps stack hash/id -> stack_metadata */
 };
 
 /* number of frames to skip in call stacks (s_alloc_tracer_track, and the vtable function) */
@@ -68,7 +69,7 @@ struct alloc_tracer {
 
 static void *s_trace_mem_acquire(struct aws_allocator *allocator, size_t size);
 static void s_trace_mem_release(struct aws_allocator *allocator, void *ptr);
-static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *ptr, size_t old_size, size_t new_size);
+static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *old_ptr, size_t old_size, size_t new_size);
 static void *s_trace_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size);
 
 static struct aws_allocator s_trace_allocator = {
@@ -80,20 +81,18 @@ static struct aws_allocator s_trace_allocator = {
 
 /* for the hash table, to destroy elements */
 static void s_destroy_alloc(void *data) {
-    struct aws_allocator *allocator = aws_default_allocator();
     struct alloc_info *alloc = data;
-    aws_mem_release(allocator, alloc);
+    aws_mem_release(alloc->allocator, alloc);
 }
 
 static void s_destroy_stacktrace(void *data) {
-    struct aws_allocator *allocator = aws_default_allocator();
     struct stack_trace *stack = data;
-    aws_mem_release(allocator, stack);
+    aws_mem_release(stack->allocator, stack);
 }
 
 static void s_alloc_tracer_init(
     struct alloc_tracer *tracer,
-    struct aws_allocator *allocator,
+    struct aws_allocator *traced_allocator,
     struct aws_allocator *system_allocator,
     enum aws_mem_trace_level level,
     size_t frames_per_stack) {
@@ -104,7 +103,7 @@ static void s_alloc_tracer_init(
         level = level > AWS_MEMTRACE_BYTES ? AWS_MEMTRACE_BYTES : level;
     }
 
-    tracer->allocator = allocator;
+    tracer->traced_allocator = traced_allocator;
     tracer->system_allocator = system_allocator;
     tracer->level = level;
 
@@ -137,6 +136,8 @@ static void s_alloc_tracer_track(struct alloc_tracer *tracer, void *ptr, size_t 
     aws_atomic_fetch_add(&tracer->allocated, size);
 
     struct alloc_info *alloc = aws_mem_calloc(tracer->system_allocator, 1, sizeof(struct alloc_info));
+    AWS_FATAL_ASSERT(alloc);
+    alloc->allocator = tracer->system_allocator;
     alloc->size = size;
     alloc->time = time(NULL);
 
@@ -163,6 +164,8 @@ static void s_alloc_tracer_track(struct alloc_tracer *tracer, void *ptr, size_t 
                     tracer->system_allocator,
                     1,
                     sizeof(struct stack_trace) + (sizeof(void *) * tracer->frames_per_stack));
+                AWS_FATAL_ASSERT(stack);
+                stack->allocator = tracer->system_allocator;
                 memcpy(
                     (void **)&stack->frames[0],
                     &stack_frames[FRAMES_TO_SKIP],
@@ -237,6 +240,7 @@ static int s_collect_stack_trace(void *context, struct aws_hash_element *item) {
     free(symbols);
     /* record the resultant buffer as a string */
     stack_info->trace = aws_string_new_from_array(allocator, stacktrace.buffer, stacktrace.len);
+    AWS_FATAL_ASSERT(stack_info->trace);
     aws_byte_buf_clean_up(&stacktrace);
     return AWS_COMMON_HASH_TABLE_ITER_CONTINUE;
 }
@@ -262,15 +266,16 @@ static void s_stack_info_destroy(void *data) {
 
 /* tally up count/size per stack from all allocs */
 static int s_collect_stack_stats(void *context, struct aws_hash_element *item) {
-    struct alloc_tracer *tracer = context;
+    struct aws_hash_table *stack_info = context;
     struct alloc_info *alloc = item->value;
     struct aws_hash_element *stack_item = NULL;
     int was_created = 0;
     AWS_FATAL_ASSERT(
         AWS_OP_SUCCESS ==
-        aws_hash_table_create(&tracer->stack_info, (void *)(uintptr_t)alloc->stack, &stack_item, &was_created));
+        aws_hash_table_create(stack_info, (void *)(uintptr_t)alloc->stack, &stack_item, &was_created));
     if (was_created) {
-        stack_item->value = aws_mem_calloc(tracer->system_allocator, 1, sizeof(struct stack_metadata));
+        stack_item->value = aws_mem_calloc(alloc->allocator, 1, sizeof(struct stack_metadata));
+        AWS_FATAL_ASSERT(stack_item->value);
     }
     struct stack_metadata *stack = stack_item->value;
     stack->count++;
@@ -298,7 +303,8 @@ static int s_alloc_compare(const void *a, const void *b) {
     return alloc_a->time > alloc_b->time;
 }
 
-static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
+void aws_mem_tracer_dump(struct aws_allocator *trace_allocator) {
+    struct alloc_tracer *tracer = trace_allocator->impl;
     if (tracer->level == AWS_MEMTRACE_NONE || aws_atomic_load_int(&tracer->allocated) == 0) {
         return;
     }
@@ -319,21 +325,25 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
         num_allocs);
 
     /* convert stacks from pointers -> symbols */
+    struct aws_hash_table stack_info;
+    AWS_ZERO_STRUCT(stack_info);
     if (tracer->level == AWS_MEMTRACE_STACKS) {
         AWS_FATAL_ASSERT(
             AWS_OP_SUCCESS ==
             aws_hash_table_init(
-                &tracer->stack_info, tracer->allocator, 64, aws_hash_ptr, aws_ptr_eq, NULL, s_stack_info_destroy));
+                &stack_info, tracer->system_allocator, 64, aws_hash_ptr, aws_ptr_eq, NULL, s_stack_info_destroy));
         /* collect active stacks, tally up sizes and counts */
-        aws_hash_table_foreach(&tracer->allocs, s_collect_stack_stats, tracer);
+        aws_hash_table_foreach(&tracer->allocs, s_collect_stack_stats, &stack_info);
         /* collect stack traces for active stacks */
-        aws_hash_table_foreach(&tracer->stack_info, s_collect_stack_trace, tracer);
+        aws_hash_table_foreach(&stack_info, s_collect_stack_trace, tracer);
     }
 
     /* sort allocs by time */
     struct aws_priority_queue allocs;
-    aws_priority_queue_init_dynamic(
-        &allocs, tracer->allocator, num_allocs, sizeof(struct alloc_info *), s_alloc_compare);
+    AWS_FATAL_ASSERT(
+        AWS_OP_SUCCESS ==
+        aws_priority_queue_init_dynamic(
+            &allocs, tracer->system_allocator, num_allocs, sizeof(struct alloc_info *), s_alloc_compare));
     aws_hash_table_foreach(&tracer->allocs, s_insert_allocs, &allocs);
     /* dump allocs by time */
     AWS_LOGF_TRACE(
@@ -348,7 +358,7 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
         if (alloc->stack) {
             struct aws_hash_element *item = NULL;
             AWS_FATAL_ASSERT(
-                AWS_OP_SUCCESS == aws_hash_table_find(&tracer->stack_info, (void *)(uintptr_t)alloc->stack, &item));
+                AWS_OP_SUCCESS == aws_hash_table_find(&stack_info, (void *)(uintptr_t)alloc->stack, &item));
             struct stack_metadata *stack = item->value;
             AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "  stacktrace:\n%s\n", (const char *)aws_string_bytes(stack->trace));
         }
@@ -357,17 +367,17 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
     aws_priority_queue_clean_up(&allocs);
 
     if (tracer->level == AWS_MEMTRACE_STACKS) {
-        size_t num_stacks = aws_hash_table_get_entry_count(&tracer->stack_info);
+        size_t num_stacks = aws_hash_table_get_entry_count(&stack_info);
         /* sort stacks by total size leaked */
         struct aws_priority_queue stacks_by_size;
         AWS_FATAL_ASSERT(
             AWS_OP_SUCCESS == aws_priority_queue_init_dynamic(
                                   &stacks_by_size,
-                                  tracer->allocator,
+                                  tracer->system_allocator,
                                   num_stacks,
                                   sizeof(struct stack_metadata *),
                                   s_stack_info_compare_size));
-        aws_hash_table_foreach(&tracer->stack_info, s_insert_stacks, &stacks_by_size);
+        aws_hash_table_foreach(&stack_info, s_insert_stacks, &stacks_by_size);
         AWS_LOGF_TRACE(
             AWS_LS_COMMON_MEMTRACE,
             "################################################################################\n");
@@ -388,7 +398,7 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
         AWS_FATAL_ASSERT(
             AWS_OP_SUCCESS == aws_priority_queue_init_dynamic(
                                   &stacks_by_count,
-                                  tracer->allocator,
+                                  tracer->system_allocator,
                                   num_stacks,
                                   sizeof(struct stack_metadata *),
                                   s_stack_info_compare_count));
@@ -399,7 +409,7 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
         AWS_LOGF_TRACE(
             AWS_LS_COMMON_MEMTRACE,
             "################################################################################\n");
-        aws_hash_table_foreach(&tracer->stack_info, s_insert_stacks, &stacks_by_count);
+        aws_hash_table_foreach(&stack_info, s_insert_stacks, &stacks_by_count);
         while (aws_priority_queue_size(&stacks_by_count) > 0) {
             struct stack_metadata *stack = NULL;
             aws_priority_queue_pop(&stacks_by_count, &stack);
@@ -407,7 +417,7 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
             AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "%s\n", (const char *)aws_string_bytes(stack->trace));
         }
         aws_priority_queue_clean_up(&stacks_by_count);
-        aws_hash_table_clean_up(&tracer->stack_info);
+        aws_hash_table_clean_up(&stack_info);
     }
 
     AWS_LOGF_TRACE(
@@ -422,24 +432,27 @@ static void s_alloc_tracer_dump(struct alloc_tracer *tracer) {
 
 static void *s_trace_mem_acquire(struct aws_allocator *allocator, size_t size) {
     struct alloc_tracer *tracer = allocator->impl;
-    void *ptr = aws_mem_acquire(tracer->allocator, size);
-    s_alloc_tracer_track(tracer, ptr, size);
+    void *ptr = aws_mem_acquire(tracer->traced_allocator, size);
+    if (ptr) {
+        s_alloc_tracer_track(tracer, ptr, size);
+    }
     return ptr;
 }
 
 static void s_trace_mem_release(struct aws_allocator *allocator, void *ptr) {
     struct alloc_tracer *tracer = allocator->impl;
     s_alloc_tracer_untrack(tracer, ptr);
-    aws_mem_release(tracer->allocator, ptr);
+    aws_mem_release(tracer->traced_allocator, ptr);
 }
 
-static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *ptr, size_t old_size, size_t new_size) {
+static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *old_ptr, size_t old_size, size_t new_size) {
     struct alloc_tracer *tracer = allocator->impl;
-    void *new_ptr = ptr;
+    void *new_ptr = old_ptr;
+    if (aws_mem_realloc(tracer->traced_allocator, &new_ptr, old_size, new_size)) {
+        return NULL;
+    }
 
-    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_mem_realloc(tracer->allocator, &new_ptr, old_size, new_size));
-
-    s_alloc_tracer_untrack(tracer, ptr);
+    s_alloc_tracer_untrack(tracer, old_ptr);
     s_alloc_tracer_track(tracer, new_ptr, new_size);
 
     return new_ptr;
@@ -447,8 +460,10 @@ static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *ptr, siz
 
 static void *s_trace_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size) {
     struct alloc_tracer *tracer = allocator->impl;
-    void *ptr = aws_mem_calloc(tracer->allocator, num, size);
-    s_alloc_tracer_track(tracer, ptr, num * size);
+    void *ptr = aws_mem_calloc(tracer->traced_allocator, num, size);
+    if (ptr) {
+        s_alloc_tracer_track(tracer, ptr, num * size);
+    }
     return ptr;
 }
 
@@ -483,35 +498,37 @@ struct aws_allocator *aws_mem_tracer_new(
 
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator) {
     struct alloc_tracer *tracer = trace_allocator->impl;
-    struct aws_allocator *allocator = tracer->allocator;
+    struct aws_allocator *allocator = tracer->traced_allocator;
 
-    /* This is not necessary, as if you are destroying the allocator, what are your
-     * expectations? Either way, we can, so we might as well...
-     */
-    aws_mutex_lock(&tracer->mutex);
-    aws_hash_table_clean_up(&tracer->allocs);
-    aws_hash_table_clean_up(&tracer->stacks);
-    aws_mutex_unlock(&tracer->mutex);
-    aws_mutex_clean_up(&tracer->mutex);
+    if (tracer->level != AWS_MEMTRACE_NONE) {
+        aws_mutex_lock(&tracer->mutex);
+        aws_hash_table_clean_up(&tracer->allocs);
+        aws_hash_table_clean_up(&tracer->stacks);
+        aws_mutex_unlock(&tracer->mutex);
+        aws_mutex_clean_up(&tracer->mutex);
+    }
 
-    struct aws_allocator *system_allocator = tracer->system_allocator;
-    aws_mem_release(system_allocator, tracer);
+    aws_mem_release(tracer->system_allocator, tracer);
     /* trace_allocator is freed as part of the block tracer was allocated in */
-    return allocator;
-}
 
-void aws_mem_tracer_dump(struct aws_allocator *trace_allocator) {
-    struct alloc_tracer *tracer = trace_allocator->impl;
-    s_alloc_tracer_dump(tracer);
+    return allocator;
 }
 
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator) {
     struct alloc_tracer *tracer = trace_allocator->impl;
+    if (tracer->level == AWS_MEMTRACE_NONE) {
+        return 0;
+    }
+
     return aws_atomic_load_int(&tracer->allocated);
 }
 
 size_t aws_mem_tracer_count(struct aws_allocator *trace_allocator) {
     struct alloc_tracer *tracer = trace_allocator->impl;
+    if (tracer->level == AWS_MEMTRACE_NONE) {
+        return 0;
+    }
+
     aws_mutex_lock(&tracer->mutex);
     size_t count = aws_hash_table_get_entry_count(&tracer->allocs);
     aws_mutex_unlock(&tracer->mutex);

--- a/tests/ring_buffer_test.c
+++ b/tests/ring_buffer_test.c
@@ -375,6 +375,8 @@ static int s_test_acquire_any_muti_threaded(
         &test_data.termination_signal, &test_data.mutex, s_termination_predicate, &test_data);
     aws_mutex_unlock(&test_data.mutex);
 
+    aws_thread_join(&consumer_thread);
+
     aws_ring_buffer_clean_up(&test_data.ring_buf);
     aws_thread_clean_up(&consumer_thread);
 


### PR DESCRIPTION
- Fixed missing thread_join() in a unit test
- memtrace.c fixes
    - don't clean up stuff we never initialized
    - fix places where tracer wasn't using system allocator for bookkeeping.
- turned off clang-format on a file full of ASM. it was failing clang-format on my machine, not sure why build machines didn't care

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
