### PR TITLE
idempotent clean_up() for mutex & condition_variable

### DIFF
--- a/include/aws/common/allocator.h
+++ b/include/aws/common/allocator.h
@@ -88,6 +88,7 @@ void *aws_mem_acquire_many(struct aws_allocator *allocator, size_t count, ...);
 
 /**
  * Releases ptr back to whatever allocated it.
+ * Nothing happens if ptr is NULL.
  */
 AWS_COMMON_API
 void aws_mem_release(struct aws_allocator *allocator, void *ptr);

--- a/include/aws/common/condition_variable.h
+++ b/include/aws/common/condition_variable.h
@@ -33,6 +33,7 @@ struct aws_condition_variable {
 #else
     pthread_cond_t condition_handle;
 #endif
+    bool initialized;
 };
 
 /**
@@ -45,10 +46,10 @@ struct aws_condition_variable {
  */
 #ifdef _WIN32
 #    define AWS_CONDITION_VARIABLE_INIT                                                                                \
-        { .condition_handle = NULL }
+        { .condition_handle = NULL, .initialized = true }
 #else
 #    define AWS_CONDITION_VARIABLE_INIT                                                                                \
-        { .condition_handle = PTHREAD_COND_INITIALIZER }
+        { .condition_handle = PTHREAD_COND_INITIALIZER, .initialized = true }
 #endif
 
 AWS_EXTERN_C_BEGIN

--- a/include/aws/common/mutex.h
+++ b/include/aws/common/mutex.h
@@ -19,7 +19,7 @@
 #include <aws/common/common.h>
 #ifdef _WIN32
 /* NOTE: Do not use this macro before including Windows.h */
-#    define AWSMUTEX_TO_WINDOWS(pCV) AWS_CONTAINER_OF((pCV), PSRWLOCK, mutex_handle)
+#    define AWSMUTEX_TO_WINDOWS(pMutex) (PSRWLOCK) & (pMutex)->mutex_handle
 #else
 #    include <pthread.h>
 #endif

--- a/include/aws/common/mutex.h
+++ b/include/aws/common/mutex.h
@@ -19,7 +19,7 @@
 #include <aws/common/common.h>
 #ifdef _WIN32
 /* NOTE: Do not use this macro before including Windows.h */
-#    define AWSMUTEX_TO_WINDOWS(pCV) (PSRWLOCK) pCV
+#    define AWSMUTEX_TO_WINDOWS(pCV) AWS_CONTAINER_OF((pCV), PSRWLOCK, mutex_handle)
 #else
 #    include <pthread.h>
 #endif

--- a/include/aws/common/mutex.h
+++ b/include/aws/common/mutex.h
@@ -30,14 +30,15 @@ struct aws_mutex {
 #else
     pthread_mutex_t mutex_handle;
 #endif
+    bool initialized;
 };
 
 #ifdef _WIN32
 #    define AWS_MUTEX_INIT                                                                                             \
-        { NULL }
+        { .mutex_handle = NULL, .initialized = true }
 #else
 #    define AWS_MUTEX_INIT                                                                                             \
-        { .mutex_handle = PTHREAD_MUTEX_INITIALIZER }
+        { .mutex_handle = PTHREAD_MUTEX_INITIALIZER, .initialized = true }
 #endif
 
 AWS_EXTERN_C_BEGIN

--- a/source/posix/condition_variable.c
+++ b/source/posix/condition_variable.c
@@ -32,18 +32,30 @@ static int process_error_code(int err) {
 }
 
 int aws_condition_variable_init(struct aws_condition_variable *condition_variable) {
+    AWS_PRECONDITION(condition_variable);
+
     if (pthread_cond_init(&condition_variable->condition_handle, NULL)) {
+        AWS_ZERO_STRUCT(*condition_variable);
         return aws_raise_error(AWS_ERROR_COND_VARIABLE_INIT_FAILED);
     }
 
+    condition_variable->initialized = true;
     return AWS_OP_SUCCESS;
 }
 
 void aws_condition_variable_clean_up(struct aws_condition_variable *condition_variable) {
-    pthread_cond_destroy(&condition_variable->condition_handle);
+    AWS_PRECONDITION(condition_variable);
+
+    if (condition_variable->initialized) {
+        pthread_cond_destroy(&condition_variable->condition_handle);
+    }
+
+    AWS_ZERO_STRUCT(*condition_variable);
 }
 
 int aws_condition_variable_notify_one(struct aws_condition_variable *condition_variable) {
+    AWS_PRECONDITION(condition_variable && condition_variable->initialized);
+
     int err_code = pthread_cond_signal(&condition_variable->condition_handle);
 
     if (err_code) {
@@ -54,6 +66,8 @@ int aws_condition_variable_notify_one(struct aws_condition_variable *condition_v
 }
 
 int aws_condition_variable_notify_all(struct aws_condition_variable *condition_variable) {
+    AWS_PRECONDITION(condition_variable && condition_variable->initialized);
+
     int err_code = pthread_cond_broadcast(&condition_variable->condition_handle);
 
     if (err_code) {
@@ -64,6 +78,9 @@ int aws_condition_variable_notify_all(struct aws_condition_variable *condition_v
 }
 
 int aws_condition_variable_wait(struct aws_condition_variable *condition_variable, struct aws_mutex *mutex) {
+    AWS_PRECONDITION(condition_variable && condition_variable->initialized);
+    AWS_PRECONDITION(mutex && mutex->initialized);
+
     int err_code = pthread_cond_wait(&condition_variable->condition_handle, &mutex->mutex_handle);
 
     if (err_code) {
@@ -77,6 +94,9 @@ int aws_condition_variable_wait_for(
     struct aws_condition_variable *condition_variable,
     struct aws_mutex *mutex,
     int64_t time_to_wait) {
+
+    AWS_PRECONDITION(condition_variable && condition_variable->initialized);
+    AWS_PRECONDITION(mutex && mutex->initialized);
 
     uint64_t current_sys_time = 0;
     if (aws_sys_clock_get_ticks(&current_sys_time)) {

--- a/source/posix/mutex.c
+++ b/source/posix/mutex.c
@@ -19,10 +19,15 @@
 #include <errno.h>
 
 void aws_mutex_clean_up(struct aws_mutex *mutex) {
-    pthread_mutex_destroy(&mutex->mutex_handle);
+    AWS_PRECONDITION(mutex);
+    if (mutex->initialized) {
+        pthread_mutex_destroy(&mutex->mutex_handle);
+    }
+    AWS_ZERO_STRUCT(*mutex);
 }
 
 int aws_mutex_init(struct aws_mutex *mutex) {
+    AWS_PRECONDITION(mutex);
     pthread_mutexattr_t attr;
     int err_code = pthread_mutexattr_init(&attr);
     int return_code = AWS_OP_SUCCESS;
@@ -38,20 +43,21 @@ int aws_mutex_init(struct aws_mutex *mutex) {
         return_code = aws_private_convert_and_raise_error_code(err_code);
     }
 
+    mutex->initialized = (return_code == AWS_OP_SUCCESS);
     return return_code;
 }
 
 int aws_mutex_lock(struct aws_mutex *mutex) {
-
+    AWS_PRECONDITION(mutex && mutex->initialized);
     return aws_private_convert_and_raise_error_code(pthread_mutex_lock(&mutex->mutex_handle));
 }
 
 int aws_mutex_try_lock(struct aws_mutex *mutex) {
-
+    AWS_PRECONDITION(mutex && mutex->initialized);
     return aws_private_convert_and_raise_error_code(pthread_mutex_trylock(&mutex->mutex_handle));
 }
 
 int aws_mutex_unlock(struct aws_mutex *mutex) {
-
+    AWS_PRECONDITION(mutex && mutex->initialized);
     return aws_private_convert_and_raise_error_code(pthread_mutex_unlock(&mutex->mutex_handle));
 }

--- a/source/windows/condition_variable.c
+++ b/source/windows/condition_variable.c
@@ -20,7 +20,7 @@
 
 #include <Windows.h>
 
-#define AWSCV_TO_WINDOWS(pCV) AWS_CONTAINER_OF((pCV), PCONDITION_VARIABLE, condition_handle)
+#define AWSCV_TO_WINDOWS(pCV) (PCONDITION_VARIABLE) & (pCV)->condition_handle
 
 int aws_condition_variable_init(struct aws_condition_variable *condition_variable) {
     /* Ensure our condition variable and Windows' condition variables are the same size */

--- a/source/windows/condition_variable.c
+++ b/source/windows/condition_variable.c
@@ -20,12 +20,12 @@
 
 #include <Windows.h>
 
-/* Ensure our condition variable and Windows' condition variables are the same size */
-AWS_STATIC_ASSERT(sizeof(CONDITION_VARIABLE) == sizeof(struct aws_condition_variable));
-
-#define AWSCV_TO_WINDOWS(pCV) (PCONDITION_VARIABLE) pCV
+#define AWSCV_TO_WINDOWS(pCV) AWS_CONTAINER_OF((pCV), PCONDITION_VARIABLE, condition_handle)
 
 int aws_condition_variable_init(struct aws_condition_variable *condition_variable) {
+    /* Ensure our condition variable and Windows' condition variables are the same size */
+    AWS_STATIC_ASSERT(sizeof(CONDITION_VARIABLE) == sizeof(condition_variable->condition_handle));
+
     AWS_PRECONDITION(condition_variable);
     InitializeConditionVariable(AWSCV_TO_WINDOWS(condition_variable));
     condition_variable->initialized = true;

--- a/source/windows/mutex.c
+++ b/source/windows/mutex.c
@@ -17,10 +17,10 @@
 
 #include <Windows.h>
 
-/* Ensure our condition variable and Windows' condition variables are the same size */
-AWS_STATIC_ASSERT(sizeof(SRWLOCK) == sizeof(struct aws_mutex));
-
 int aws_mutex_init(struct aws_mutex *mutex) {
+    /* Ensure our mutex and Windows' mutex are the same size */
+    AWS_STATIC_ASSERT(sizeof(SRWLOCK) == sizeof(mutex->mutex_handle));
+
     InitializeSRWLock(AWSMUTEX_TO_WINDOWS(mutex));
     mutex->initialized = true;
     return AWS_OP_SUCCESS;


### PR DESCRIPTION
Makes error-handling simpler for datastructures that have mutexes/cond-vars within them.
the `error:` label can clean_up() the mutex whether or not it was ever initialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
