### PR TITLE
Builder2

### DIFF
--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -8,7 +8,7 @@ class ClangTidy(Builder.Action):
         clang_tidy = env.find_llvm_tool('clang-tidy')
         if not clang_tidy:
             print("No clang-tidy executable could be found, installing...")
-            sh.exec("sudo", "apt", "install", "-y", "clang-tidy")
+            sh.exec("sudo", "apt", "install", "-y", "clang-tidy-9")
         clang_tidy = env.find_llvm_tool('clang-tidy')
         if not clang_tidy:
             print("No clang-tidy executable could be found")

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -1,24 +1,23 @@
 
-# import codebuild.builder
-# import glob, os, sys
+import Builder
+import glob, os, sys
 
-# def find_clang_tidy(shell):
-#     for version in range(10, 6):
-#         for pattern in ('clang-tidy-{}', 'clang-tidy-{}.0'):
-#             exe = pattern.format(version)
-#             path = shell.where(exe)
-#             return path if path
-#     return None
+class ClangTidy(Builder.Action):
+    def run(self, env):
+        sh = env.shell
+        clang_tidy = env.find_llvm_tool('clang-tidy')
+        if not clang_tidy:
+            print("No clang-tidy executable could be found")
+            sys.exit(1)
 
-# class ClangTidy(Builder.Action):
-#     def run(self):
-#         shell = Builder.Shell()
-#         clang_tidy = find_clang_tidy()
-#         if not clang_tidy:
-#             print("No clang-tidy executable could be found")
-#             sys.exit(1)
-#         source_dir = shell.cwd()
-#         sources = [os.path.join(source_dir, file)
-#                    for file in glob.glob('**/*.c')]
-#         shell.exec(clang_tidy, '-p', build_dir)
+        source_dir = sh.cwd()
+        build_dir = os.path.join(source_dir, 'build')
+        sources = [os.path.join(source_dir, file) for file in glob.glob('**/*.c')]
+
+        return [
+            Builder.CMakeBuild(),
+            Builder.Script([
+                [clang_tidy, '-p', build_dir] + sources
+            ])
+        ]
         

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -16,7 +16,7 @@ class ClangTidy(Builder.Action):
 
         source_dir = sh.cwd()
         build_dir = os.path.join(source_dir, 'build')
-        sources = [os.path.join(source_dir, file) for file in glob.glob('**/*.c')]
+        sources = [os.path.join(source_dir, file) for file in glob.glob('src/*.c')]
 
         return [
             Builder.CMakeBuild(),

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -9,7 +9,7 @@ class ClangTidy(Builder.Action):
         if not clang_tidy:
             print("No clang-tidy executable could be found, installing...")
             sh.exec("sudo", "apt", "install", "-y", "clang-tidy-9")
-        clang_tidy = env.find_llvm_tool('clang-tidy')
+        clang_tidy = env.find_llvm_tool('clang-tidy')[0]
         if not clang_tidy:
             print("No clang-tidy executable could be found")
             sys.exit(1)

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -7,6 +7,10 @@ class ClangTidy(Builder.Action):
         sh = env.shell
         clang_tidy = env.find_llvm_tool('clang-tidy')
         if not clang_tidy:
+            print("No clang-tidy executable could be found, installing...")
+            sh.exec("sudo", "apt", "install", "-y", "clang-tidy")
+        clang_tidy = env.find_llvm_tool('clang-tidy')
+        if not clang_tidy:
             print("No clang-tidy executable could be found")
             sys.exit(1)
 

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -20,6 +20,7 @@ class ClangTidy(Builder.Action):
             'source/**/*.c') if not 'windows' in file]
 
         return [
+            Builder.DownloadDependencies(),
             Builder.CMakeBuild(),
             Builder.Script([
                 [clang_tidy, '-p', build_dir] + sources

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -16,7 +16,7 @@ class ClangTidy(Builder.Action):
 
         source_dir = sh.cwd()
         build_dir = os.path.join(source_dir, 'build')
-        sources = [os.path.join(source_dir, file) for file in glob.glob('src/*.c')]
+        sources = [os.path.join(source_dir, file) for file in glob.glob('source/**/*.c')]
 
         return [
             Builder.CMakeBuild(),

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -1,0 +1,24 @@
+
+# import codebuild.builder
+# import glob, os, sys
+
+# def find_clang_tidy(shell):
+#     for version in range(10, 6):
+#         for pattern in ('clang-tidy-{}', 'clang-tidy-{}.0'):
+#             exe = pattern.format(version)
+#             path = shell.where(exe)
+#             return path if path
+#     return None
+
+# class ClangTidy(Builder.Action):
+#     def run(self):
+#         shell = Builder.Shell()
+#         clang_tidy = find_clang_tidy()
+#         if not clang_tidy:
+#             print("No clang-tidy executable could be found")
+#             sys.exit(1)
+#         source_dir = shell.cwd()
+#         sources = [os.path.join(source_dir, file)
+#                    for file in glob.glob('**/*.c')]
+#         shell.exec(clang_tidy, '-p', build_dir)
+        

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -16,7 +16,8 @@ class ClangTidy(Builder.Action):
 
         source_dir = sh.cwd()
         build_dir = os.path.join(source_dir, 'build')
-        sources = [os.path.join(source_dir, file) for file in glob.glob('source/**/*.c')]
+        sources = [os.path.join(source_dir, file) for file in glob.glob(
+            'source/**/*.c') if not 'windows' in file]
 
         return [
             Builder.CMakeBuild(),

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -9,10 +9,10 @@ class ClangTidy(Builder.Action):
         if not clang_tidy:
             print("No clang-tidy executable could be found, installing...")
             sh.exec("sudo", "apt", "install", "-y", "clang-tidy-9")
-        clang_tidy = env.find_llvm_tool('clang-tidy')[0]
-        if not clang_tidy:
-            print("No clang-tidy executable could be found")
-            sys.exit(1)
+            clang_tidy = env.find_llvm_tool('clang-tidy')[0]
+            if not clang_tidy:
+                print("No clang-tidy executable could be found")
+                sys.exit(1)
 
         source_dir = sh.cwd()
         build_dir = os.path.join(source_dir, 'build')

--- a/.builder/actions/clang-tidy.py
+++ b/.builder/actions/clang-tidy.py
@@ -5,7 +5,7 @@ import glob, os, sys
 class ClangTidy(Builder.Action):
     def run(self, env):
         sh = env.shell
-        clang_tidy = env.find_llvm_tool('clang-tidy')
+        clang_tidy = env.find_llvm_tool('clang-tidy')[0]
         if not clang_tidy:
             print("No clang-tidy executable could be found, installing...")
             sh.exec("sudo", "apt", "install", "-y", "clang-tidy-9")

--- a/.builder/actions/test.py
+++ b/.builder/actions/test.py
@@ -1,0 +1,6 @@
+
+import Builder
+
+class Test(Builder.Action):
+    def run(self):
+        print("TEST ACTION WORKS")

--- a/.builder/actions/test.py
+++ b/.builder/actions/test.py
@@ -2,5 +2,5 @@
 import Builder
 
 class Test(Builder.Action):
-    def run(self):
+    def run(self, env):
         print("TEST ACTION WORKS")

--- a/.builder/actions/test.py
+++ b/.builder/actions/test.py
@@ -1,6 +1,0 @@
-
-import Builder
-
-class Test(Builder.Action):
-    def run(self, env):
-        print("TEST ACTION WORKS")

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,4 +13,4 @@ jobs:
       
     - name: clang-tidy lint
       run: |
-        python3 ./codebuild/builder.py run clangtidy
+        python3 ./codebuild/builder.py run clang-tidy

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on: [push]
+
+jobs:
+  clang-tidy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v1
+      
+    - name: clang-tidy lint
+      run: |
+        python3 ./codebuild/builder.py run clangtidy

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -761,7 +761,7 @@ class Builder(VirtualModule):
             self._log_command(['popenv'])
             env = self.env_stack.pop()
             # clear out values that won't be overwritten
-            for name, value in dict(os.environ):
+            for name, value in dict(os.environ).items():
                 if name not in env:
                     del os.environ[name]
             # write the old env

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -761,7 +761,7 @@ class Builder(VirtualModule):
             self._log_command(['popenv'])
             env = self.env_stack.pop()
             # clear out values that won't be overwritten
-            for name, value in os.environ.items():
+            for name, value in dict(os.environ):
                 if name not in env:
                     del os.environ[name]
             # write the old env

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1454,12 +1454,16 @@ def default_spec(env):
 
     if sys.platform in ('linux', 'linux2'):
         target = host = 'linux'
-        clang_path, version = env.find_llvm_tool('clang')
-        gcc_path, version = env.find_gcc_tool('gcc')
+        clang_path, clang_version = env.find_llvm_tool('clang')
+        gcc_path, gcc_version = env.find_gcc_tool('gcc')
         if clang_path:
+            print('Found clang {} as default compiler'.format(clang_version))
             compiler = 'clang'
+            version = clang_version
         elif gcc_path:
+            print('Found gcc {} as default compiler'.format(gcc_version))
             compiler = 'gcc'
+            version = gcc_version
         else:
             print('Neither GCC or Clang could be found on this system, perhaps not installed yet?')
 

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -982,7 +982,7 @@ class Builder(VirtualModule):
             elif self.compiler == 'clang':
                 return env.find_llvm_tool('clang', self.compiler_version if self.compiler_version != 'default' else None)
             elif self.compiler == 'gcc':
-                return env.find_gcc_tool('gcc', self.compiler_version if self.compiler_version != default else None)
+                return env.find_gcc_tool('gcc', self.compiler_version if self.compiler_version != 'default' else None)
             elif self.compiler == 'msvc':
                 return env.shell.where('cl.exe')
             return None

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1108,7 +1108,8 @@ def run_build(build_spec, env):
             Builder.DownloadDependencies(),
             Builder.CMakeBuild(),
             Builder.CTestRun()
-        ])
+        ]),
+        env
     )
 
     return

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1296,6 +1296,9 @@ def run_build(build_spec, env):
     if not env.config['enabled']:
         raise Exception("The project is disabled in this configuration")
 
+    from pprint import pprint
+    pprint(config)
+
     build_action = Builder.CMakeBuild()
     test_action = Builder.CTestRun()
 

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1104,7 +1104,7 @@ class Builder(VirtualModule):
 def run_build(build_spec, env):
 
     Builder.run_action(
-        Script([
+        Builder.Script([
             Builder.DownloadDependencies(),
             Builder.CMakeBuild(),
             Builder.CTestRun()

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1487,6 +1487,7 @@ if __name__ == '__main__':
                         help='The native code configuration to build with')
     parser.add_argument('--dump-config', action='store_true',
                         help="Print the config in use before running a build")
+    parser.add_argument('--spec', type=str, dest='build')
     commands = parser.add_subparsers(dest='command')
 
     build = commands.add_parser(
@@ -1522,8 +1523,11 @@ if __name__ == '__main__':
 
     # Build the config object
     config_file = os.path.join(env.shell.cwd(), "builder.json")
-    build_name = getattr(args, 'build', str(default_spec(env)))
-    build_spec = env.build_spec = BuildSpec(spec=build_name)
+    build_name = getattr(args, 'build', None)
+    if build_name:
+        build_spec = env.build_spec = BuildSpec(spec=build_name)
+    else:
+        build_spec = env.build_spec = default_spec(env)
     config = env.config = produce_config(build_spec, config_file)
     if not env.config['enabled']:
         raise Exception("The project is disabled in this configuration")

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1451,8 +1451,6 @@ def default_spec(env):
     target = host = 'default'
 
     arch = ('x64' if sys.maxsize > 2**32 else 'x86')
-    if os.uname()[4][:3].startswith('arm'):
-        arch = ('armv8' if sys.maxsize > 2**32 else 'armv7')
 
     if sys.platform in ('linux', 'linux2'):
         target = host = 'linux'
@@ -1464,6 +1462,9 @@ def default_spec(env):
             compiler = 'gcc'
         else:
             print('Neither GCC or Clang could be found on this system, perhaps not installed yet?')
+
+        if os.uname()[4][:3].startswith('arm'):
+            arch = ('armv8' if sys.maxsize > 2**32 else 'armv7')
 
     elif sys.platform in ('win32'):
         target = host = 'windows'

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1043,6 +1043,8 @@ class Builder(VirtualModule):
             install_dir = os.path.join(source_dir, 'install')
             sh.mkdir(install_dir)
 
+            config = env.config
+
             def build_project(project):
                 project_source_dir = sh.cwd()
                 project_build_dir = os.path.join(project_source_dir, 'build')
@@ -1055,6 +1057,10 @@ class Builder(VirtualModule):
                     for opt in ['c', 'cxx']:
                         compiler_flags.append(
                             '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), toolchain.compiler))
+
+                    for opt, variable in {'c': 'CC', 'cxx': 'CXX'}.items():
+                        if opt in config and config[opt]:
+                            os.environ[variable] = config[opt]
 
                 cmake_args = [
                     "-Werror=dev",

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1056,7 +1056,7 @@ class Builder(VirtualModule):
                         compiler_flags.append(
                             '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), toolchain.compiler))
 
-                    config = getattr(env, config, None)
+                    config = getattr(env, 'config', None)
                     if config:
                         for opt, variable in {'c': 'CC', 'cxx': 'CXX'}.items():
                             if opt in config and config[opt]:

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -649,7 +649,7 @@ class Builder(VirtualModule):
 
         def popd(self):
             if len(self.dir_stack) > 0:
-                self._log_command("popd", directory)
+                self._log_command("popd")
                 self.dir_stack.pop()
             if len(self.dir_stack) > 0:
                 self.cd(self.dir_stack[-1])

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1473,7 +1473,7 @@ def default_spec(env):
         target = host = 'macos'
         compiler = 'clang'
 
-    return BuildSpec(host=host, compiler=compiler, compiler_version=str(version), target=target, arch=arch)
+    return BuildSpec(host=host, compiler=compiler, compiler_version='{}'.format(version), target=target, arch=arch)
 
 if __name__ == '__main__':
     import argparse

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -986,7 +986,7 @@ class Builder(VirtualModule):
                     path = self.shell.where(exe)
                     if path:
                         return path, version
-            return None
+            return None, None
 
         def find_gcc_tool(self, name, version=None):
             """ Finds gcc, gcc-ld, gcc-ranlib, etc at a specific version, or the latest one available """

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -723,7 +723,7 @@ class Builder(VirtualModule):
                 return os.path.isfile(path) and os.access(path, os.X_OK)
             if sys.platform == 'win32':
                 pathext = os.environ['PATHEXT'].lower().split(os.pathsep)
-                (base, ext) = os.path.splitext(executable)
+                (base, ext) = os.path.splitext(exe)
                 if ext.lower() not in pathext:
                     extlist = pathext
             for ext in extlist:

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 from __future__ import print_function
-import os, sys, glob, subprocess, tempfile
+import os, sys, glob, shutil, subprocess, tempfile
 
 # Class to refer to a specific build permutation
 class BuildSpec(object):

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -856,8 +856,9 @@ class Builder(VirtualModule):
             return None
 
         def find_project(self, name):
-            if name in self._projects:
-                return self._projects[name]
+            project = self._projects.get(name, None)
+            if project
+                return project
             
             sh = self.shell
             search_dirs = [os.cwd(), name, os.path.join(sh.cwd(), 'deps'), os.path.join(sh.cwd(), 'build', 'deps', name)]

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -316,6 +316,17 @@ COMPILERS = {
 
                 'requires_privilege': True,
             },
+            '9': {
+                'apt_repos': [
+                    "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main",
+                ],
+                'apt_packages': ["clang-9", "clang-tidy-9"],
+
+                'c': "clang-9",
+                'cxx': "clang-9",
+
+                'requires_privilege': True,
+            },
         },
     },
     'gcc': {

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1081,9 +1081,11 @@ class Builder(VirtualModule):
                 # Set compiler flags
                 compiler_flags = []
                 if toolchain.compiler != 'default':
-                    for opt in ['c', 'cxx']:
-                        compiler_flags.append(
-                            '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), toolchain.compiler_path(env)))
+                    compiler_path = toolchain.compiler_path(env)
+                    if compiler_path:
+                        for opt in ['c', 'cxx']:
+                            compiler_flags.append(
+                                '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), compiler_path))
 
                     if config:
                         for opt, variable in {'c': 'CC', 'cxx': 'CXX'}.items():
@@ -1149,10 +1151,9 @@ class Builder(VirtualModule):
 
             project_source_dir = sh.cwd()
             project_build_dir = os.path.join(project_source_dir, 'build')
-            sh.mkdir(project_build_dir)
             sh.pushd(project_build_dir)
 
-            sh.exec("ctest", "--verbose", "--output-on-failure")
+            sh.exec("ctest", "--output-on-failure")
 
             sh.popd()
 

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -681,9 +681,9 @@ class Builder(VirtualModule):
             self._log_command(["rm -rf", path])
             if not self.dryrun:
                 try:
-                    shutil.rmtree(build_dir)
+                    shutil.rmtree(path)
                 except Exception as e:
-                    print("Failed to delete dir {}: {}".format(build_dir, e))
+                    print("Failed to delete dir {}: {}".format(path, e))
 
         def exec(self, *command):
             self._run_command(*command)

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -589,6 +589,7 @@ def produce_config(build_spec, config_file, **additional_variables):
         'version': build_spec.compiler_version,
         'target': build_spec.target,
         'arch': build_spec.arch,
+        'cwd': os.getcwd(),
         **additional_variables,
     }
 
@@ -1331,9 +1332,9 @@ def run_build(build_spec, env):
         test_action = Builder.Script(test_steps, name='test')
 
     # Set build environment
-    sh.pushenv()
+    env.shell.pushenv()
     for var, value in config.get('build_env', {}).items():
-        sh.setenv(var, value)
+        env.shell.setenv(var, value)
 
     Builder.run_action(
         Builder.Script([
@@ -1347,7 +1348,7 @@ def run_build(build_spec, env):
         env
     )
 
-    sh.popenv()
+    env.shell.popenv()
 
 ########################################################################################################################
 # CODEBUILD

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1521,7 +1521,8 @@ if __name__ == '__main__':
 
     # Build the config object
     config_file = os.path.join(env.shell.cwd(), "builder.json")
-    build_spec = getattr(args, 'build', default_spec(env))
+    build_name = getattr(args, 'build', str(default_spec(env)))
+    build_spec = env.build_spec = BuildSpec(spec=build_name)
     config = env.config = produce_config(build_spec, config_file)
     if not env.config['enabled']:
         raise Exception("The project is disabled in this configuration")
@@ -1532,11 +1533,7 @@ if __name__ == '__main__':
 
     # Run a build with a specific spec/toolchain
     if args.command == 'build':
-        # If build name not passed
-        build_name = args.build
-        build_spec = env.build_spec = BuildSpec(spec=build_name)
         print("Running build", build_spec.name, flush=True)
-
         run_build(build_spec, env)
 
     # run a single action, usually local to a project

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1270,11 +1270,6 @@ class Builder(VirtualModule):
 
             build_projects(env.project.upstream)
 
-            # Set build environment
-            sh.pushenv()
-            for var, value in config.get('build_env', {}).items():
-                sh.setenv(var, value)
-
             # BUILD
             build_project(env.project, getattr(env, 'build_tests', False))
 
@@ -1282,7 +1277,6 @@ class Builder(VirtualModule):
             if spec and spec.downstream:
                 build_projects(env.project.downstream)
 
-            sh.popenv()
             sh.popd()
 
     class CTestRun(Action):
@@ -1336,6 +1330,11 @@ def run_build(build_spec, env):
     if test_steps:
         test_action = Builder.Script(test_steps, name='test')
 
+    # Set build environment
+    sh.pushenv()
+    for var, value in config.get('build_env', {}).items():
+        sh.setenv(var, value)
+
     Builder.run_action(
         Builder.Script([
             Builder.InstallTools(),
@@ -1348,7 +1347,7 @@ def run_build(build_spec, env):
         env
     )
 
-    return
+    sh.popenv()
 
 ########################################################################################################################
 # CODEBUILD

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -575,6 +575,7 @@ class Builder(VirtualModule):
         
         scripts = glob.glob('.builder/**/*.py')
         for script in scripts:
+            print("Importing {}".format(os.path.abspath(script)))
             name = os.path.split(script)[1].split('.')[0]
             spec = importlib.util.spec_from_file_location(name, script)
             module = importlib.util.module_from_spec(spec)

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1408,6 +1408,7 @@ if __name__ == '__main__':
 
     run = commands.add_parser('run', help='Run action. Ex: do-thing')
     run.add_argument('run', type=str)
+    run.add_argument('args', nargs=argparse.REMAINDER)
 
     codebuild = commands.add_parser('codebuild', help="Create codebuild jobs")
     codebuild.add_argument(

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -21,10 +21,9 @@ import shutil
 import subprocess
 import tempfile
 
-# Class to refer to a specific build permutation
-
 
 class BuildSpec(object):
+    """ Refers to a specific build permutation, gets converted into a toolchain """
     def __init__(self, **kwargs):
         if 'spec' in kwargs:
             # Parse the spec from a single string
@@ -281,9 +280,6 @@ COMPILERS = {
         'hosts': ['linux', 'macos'],
         'targets': ['linux', 'macos'],
 
-        'post_build_steps': [
-            ["{clang_tidy}", "-p", "{build_dir}", "{sources}"],
-        ],
         'cmake_args': ['-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', '-DENABLE_FUZZ_TESTS=ON'],
 
         'apt_keys': ["http://apt.llvm.org/llvm-snapshot.gpg.key"],
@@ -307,10 +303,6 @@ COMPILERS = {
                 'c': "clang-6.0",
                 'cxx': "clang-6.0",
 
-                'variables': {
-                    'clang_tidy': 'clang-tidy-6.0',
-                },
-
                 'requires_privilege': True,
             },
             '8': {
@@ -321,10 +313,6 @@ COMPILERS = {
 
                 'c': "clang-8",
                 'cxx': "clang-8",
-
-                'variables': {
-                    'clang_tidy': 'clang-tidy-8',
-                },
 
                 'requires_privilege': True,
             },

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -562,7 +562,11 @@ def produce_config(build_spec, config_file, **additional_variables):
 # ACTIONS
 ########################################################################################################################
 class Builder(VirtualModule):
+    """ The interface available to scripts that define projects, builds, actions, or configuration """
+    # Must cache available actions or the GC will delete them
+    all_actions = set()
     def __init__(self):
+        Builder.all_actions = set(Builder.Action.__subclasses__())
         self._load_scripts()
 
     @staticmethod
@@ -575,11 +579,16 @@ class Builder(VirtualModule):
         
         scripts = glob.glob('.builder/**/*.py')
         for script in scripts:
-            print("Importing {}".format(os.path.abspath(script)))
+            print("Importing {}".format(os.path.abspath(script)), flush=True)
+            
             name = os.path.split(script)[1].split('.')[0]
             spec = importlib.util.spec_from_file_location(name, script)
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
+            actions = frozenset(Builder._find_actions())
+            new_actions = actions.difference(Builder.all_actions)
+            print("Imported {}".format(', '.join([a.__name__ for a in new_actions])))
+            Builder.all_actions.update(new_actions)
 
 
     @staticmethod
@@ -588,16 +597,24 @@ class Builder(VirtualModule):
 
     @staticmethod
     def find_action(name):
-        for action in Builder._find_actions():
-            if action.__name__.lower() == name.lower():
+        name = name.replace('-', '').lower()
+        all_actions = Builder._find_actions()
+        for action in all_actions:
+            if action.__name__.lower() == name:
                 return action
 
     @staticmethod
     def run_action(action, env):
         action_type = type(action)
         if action_type is str:
-            action_cls = Builder.find_action(action)
-            action = action_cls()
+            try:
+                action_cls = Builder.find_action(action)
+                action = action_cls()
+            except:
+                print("Unable to find action {} to run".format(action))
+                all_actions = [a.__name__ for a in Builder._find_actions()]
+                print("Available actions: \n\t{}".format('\n\t'.join(all_actions)))
+                sys.exit(2)
 
         print("Running: {}".format(action), flush=True)
         children = action.run(env)

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -635,6 +635,11 @@ class Builder(VirtualModule):
 
         scripts = glob.glob('.builder/**/*.py')
         for script in scripts:
+            # Ensure that the import path includes the directory the script is in
+            # so that relative imports work
+            script_dir = os.path.dirname(script)
+            if script_dir not in sys.path:
+                sys.path.append(script_dir)
             print("Importing {}".format(os.path.abspath(script)), flush=True)
 
             name = os.path.split(script)[1].split('.')[0]

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1043,8 +1043,6 @@ class Builder(VirtualModule):
             install_dir = os.path.join(source_dir, 'install')
             sh.mkdir(install_dir)
 
-            config = env.config
-
             def build_project(project):
                 project_source_dir = sh.cwd()
                 project_build_dir = os.path.join(project_source_dir, 'build')
@@ -1058,9 +1056,11 @@ class Builder(VirtualModule):
                         compiler_flags.append(
                             '-DCMAKE_{}_COMPILER={}'.format(opt.upper(), toolchain.compiler))
 
-                    for opt, variable in {'c': 'CC', 'cxx': 'CXX'}.items():
-                        if opt in config and config[opt]:
-                            os.environ[variable] = config[opt]
+                    config = getattr(env, config, None)
+                    if config:
+                        for opt, variable in {'c': 'CC', 'cxx': 'CXX'}.items():
+                            if opt in config and config[opt]:
+                                os.environ[variable] = config[opt]
 
                 cmake_args = [
                     "-Werror=dev",

--- a/codebuild/builder.py
+++ b/codebuild/builder.py
@@ -1463,7 +1463,7 @@ def default_spec(env):
         elif gcc_path:
             compiler = 'gcc'
         else:
-            raise Exception('Neither GCC or Clang could be found on this system')
+            print('Neither GCC or Clang could be found on this system, perhaps not installed yet?')
 
     elif sys.platform in ('win32'):
         target = host = 'windows'


### PR DESCRIPTION
Updates the builder to allow for code injection, and abstracts build steps into composable actions. Will allow us to have builds that don't do cmake compiles, and allow us to create jobs with just code or shell commands.

See clang-tidy.py for an example of a utility script.

This is a huge rewrite, so it may be easier to review it by looking at some of the commits where features went in to see differences.

See https://github.com/awslabs/aws-crt-python/pull/119 for example usage, compare the build vs action versions of the CI job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
