### PR TITLE
Gating threads package so that it is used only for known platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,11 @@ else ()
         "source/posix/*.c"
         )
     set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads REQUIRED)
+
+    if (UNIX OR APPLE)
+        find_package(Threads REQUIRED)
+    endif ()
+
     if (APPLE)
         find_library(CORE_FOUNDATION_LIB CoreFoundation)
         if (NOT CORE_FOUNDATION_LIB)

--- a/cmake/aws-c-common-config.cmake
+++ b/cmake/aws-c-common-config.cmake
@@ -1,5 +1,8 @@
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+
+if(WIN32 OR UNIX OR APPLE)
+    find_package(Threads REQUIRED)
+endif()
 
 if (BUILD_SHARED_LIBS)
     include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)


### PR DESCRIPTION
*Description of changes:*
This is meant to mitigate breaking platforms that we don't build against.  This is in reference to: https://github.com/awslabs/aws-c-common/issues/567

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
