### PR TITLE
Add libdl as needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ else ()
 
 endif()
 
+list(APPEND PLATFORM_LIBS ${CMAKE_DL_LIBS})
+
 file(GLOB COMMON_HEADERS
         ${AWS_COMMON_HEADERS}
         ${AWS_COMMON_OS_HEADERS}


### PR DESCRIPTION
We introduced this dependency a long time ago, but recent cmake changes have exposed the fact that we did not properly add it at the time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
