### PR TITLE
Add support for building with MinGW

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -68,6 +68,10 @@ function(aws_set_common_properties target)
         if (LEGACY_COMPILER_SUPPORT)
             list(APPEND AWS_C_FLAGS -Wno-strict-aliasing)
         endif()
+
+        if(CMAKE_C_IMPLICIT_LINK_LIBRARIES MATCHES "mingw32")
+            list(APPEND AWS_C_FLAGS -D__USE_MINGW_ANSI_STDIO=1 -Wno-unused-local-typedefs)
+        endif()
     endif()
 
     check_include_file(stdint.h HAS_STDINT)

--- a/include/aws/common/byte_order.inl
+++ b/include/aws/common/byte_order.inl
@@ -19,11 +19,11 @@
 #include <aws/common/byte_order.h>
 #include <aws/common/common.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #    include <stdlib.h>
 #else
 #    include <netinet/in.h>
-#endif /* _MSC_VER */
+#endif /* _WIN32 */
 
 AWS_EXTERN_C_BEGIN
 
@@ -49,7 +49,7 @@ AWS_STATIC_IMPL uint64_t aws_hton64(uint64_t x) {
     uint64_t v;
     __asm__("bswap %q0" : "=r"(v) : "0"(x));
     return v;
-#elif defined(_MSC_VER)
+#elif defined(_WIN32)
     return _byteswap_uint64(x);
 #else
     uint32_t low = (uint32_t)x;
@@ -69,7 +69,7 @@ AWS_STATIC_IMPL uint64_t aws_ntoh64(uint64_t x) {
  * Convert 32 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_hton32(uint32_t x) {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return aws_is_big_endian() ? x : _byteswap_ulong(x);
 #else
     return htonl(x);
@@ -126,7 +126,7 @@ AWS_STATIC_IMPL double aws_htonf64(double x) {
  * Convert 32 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_ntoh32(uint32_t x) {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return aws_is_big_endian() ? x : _byteswap_ulong(x);
 #else
     return ntohl(x);
@@ -151,7 +151,7 @@ AWS_STATIC_IMPL double aws_ntohf64(double x) {
  * Convert 16 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint16_t aws_hton16(uint16_t x) {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return aws_is_big_endian() ? x : _byteswap_ushort(x);
 #else
     return htons(x);
@@ -162,7 +162,7 @@ AWS_STATIC_IMPL uint16_t aws_hton16(uint16_t x) {
  * Convert 16 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint16_t aws_ntoh16(uint16_t x) {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return aws_is_big_endian() ? x : _byteswap_ushort(x);
 #else
     return ntohs(x);

--- a/include/aws/common/logging.h
+++ b/include/aws/common/logging.h
@@ -111,7 +111,9 @@ struct aws_logger_vtable {
         aws_log_subject_t subject,
         const char *format,
         ...)
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+#if defined(__MINGW32__)
+        __attribute__((format(gnu_printf, 4, 5)))
+#elif defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
         __attribute__((format(printf, 4, 5)))
 #endif /* non-ms compilers: TODO - find out what versions format support was added in */
         ;

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -365,6 +365,9 @@ struct aws_test_harness {
 };
 
 #if defined(_WIN32)
+#    ifdef __MINGW32__
+#        include <winsock2.h>
+#    endif
 #    include <windows.h>
 static LONG WINAPI s_test_print_stack_trace(struct _EXCEPTION_POINTERS *exception_pointers) {
 #    if !defined(AWS_HEADER_CHECKER)

--- a/source/windows/environment.c
+++ b/source/windows/environment.c
@@ -23,12 +23,16 @@ int aws_get_environment_value(
     const struct aws_string *variable_name,
     struct aws_string **value_out) {
 
-#pragma warning(push)
-#pragma warning(disable : 4996)
+#ifndef __MINGW32__
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
+#endif
 
     const char *value = getenv(aws_string_c_str(variable_name));
 
-#pragma warning(pop)
+#ifndef __MINGW32__
+#    pragma warning(pop)
+#endif
 
     if (value == NULL) {
         *value_out = NULL;

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -23,7 +23,9 @@
 
 #ifdef _WIN32
 #    include <malloc.h>
-#    define alloca _alloca
+#    ifndef __MINGW32__
+#        define alloca _alloca
+#    endif
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #    include <stdlib.h>
 #else


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR makes it possible to build aws-c-common with the MinGW toolchain on Windows.

The main changes are adding checks for the `__MINGW32__` define which is preset on both 32 and 64 bit MinGW installations. Additionally MinGW needs changes related to format strings such as defining `__USE_MINGW_ANSI_STDIO` and using the `gnu_printf` attribute.

Building with MSVC still works as before these changes. The test pass on both MinGW and MSVC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
