### PR TITLE
set policy to allow BUILD_TESTING to be used as a variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if (POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW) # Enable LTO/IPO if available in the compiler, see AwsCFlags
 endif()
 
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 OLD) # Enable options to get their values from normal variables
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(AwsCFlags)
 include(AwsCheckHeaders)


### PR DESCRIPTION
Prevents warnings in all downstream projects whenever -DBUILD_TESTING is set in script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
