### PR TITLE
min/max/sub functions for math.h

### DIFF
--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -95,6 +95,28 @@ AWS_COMMON_MATH_API uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
 AWS_COMMON_MATH_API int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
 
 /**
+ * Subtracts a - b. If the result overflows returns 0.
+ */
+AWS_STATIC_IMPL uint64_t aws_sub_u64_saturating(uint64_t a, uint64_t b);
+
+/**
+ * If a - b overflows, returns AWS_OP_ERR; otherwise subtracts
+ * a - b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ */
+AWS_STATIC_IMPL int aws_sub_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+
+/**
+ * Subtracts a - b. If the result overflows returns 0.
+ */
+AWS_STATIC_IMPL uint32_t aws_sub_u32_saturating(uint32_t a, uint32_t b);
+
+/**
+ * If a - b overflows, returns AWS_OP_ERR; otherwise subtracts
+ * a - b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ */
+AWS_STATIC_IMPL int aws_sub_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+
+/**
  * Multiplies a * b. If the result overflows, returns SIZE_MAX.
  */
 AWS_STATIC_IMPL size_t aws_mul_size_saturating(size_t a, size_t b);
@@ -123,6 +145,17 @@ AWS_STATIC_IMPL int aws_add_size_checked(size_t a, size_t b, size_t *r);
 AWS_COMMON_API int aws_add_size_checked_varargs(size_t num, size_t *r, ...);
 
 /**
+ * Subtracts a - b. If the result overflows returns 0.
+ */
+AWS_STATIC_IMPL size_t aws_sub_size_saturating(size_t a, size_t b);
+
+/**
+ * If a - b overflows, returns AWS_OP_ERR; otherwise subtracts
+ * a - b, returns the result in *r, and returns AWS_OP_SUCCESS.
+ */
+AWS_STATIC_IMPL int aws_sub_size_checked(size_t a, size_t b, size_t *r);
+
+/**
  * Function to check if x is power of 2
  */
 AWS_STATIC_IMPL bool aws_is_power_of_two(const size_t x);
@@ -131,6 +164,31 @@ AWS_STATIC_IMPL bool aws_is_power_of_two(const size_t x);
  * be done without overflow
  */
 AWS_STATIC_IMPL int aws_round_up_to_power_of_two(size_t n, size_t *result);
+
+AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
+AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
+AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
+AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
+AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
+AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
+AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
+AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
+AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
+AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
+AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
+AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
+AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
+AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
+AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
+AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
+AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
+AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
+AWS_STATIC_IMPL int aws_min_int(int a, int b);
+AWS_STATIC_IMPL int aws_max_int(int a, int b);
+AWS_STATIC_IMPL float aws_min_float(float a, float b);
+AWS_STATIC_IMPL float aws_max_float(float a, float b);
+AWS_STATIC_IMPL double aws_min_double(double a, double b);
+AWS_STATIC_IMPL double aws_max_double(double a, double b);
 
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/math.inl>

--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -57,6 +57,32 @@ AWS_EXTERN_C_BEGIN
 #    pragma warning(disable : 4127) /*Disable "conditional expression is constant" */
 #endif                              /* _MSC_VER */
 
+AWS_STATIC_IMPL uint64_t aws_sub_u64_saturating(uint64_t a, uint64_t b) {
+    return a <= b ? 0 : a - b;
+}
+
+AWS_STATIC_IMPL int aws_sub_u64_checked(uint64_t a, uint64_t b, uint64_t *r) {
+    if (a < b) {
+        return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+    }
+
+    *r = a - b;
+    return AWS_OP_SUCCESS;
+}
+
+AWS_STATIC_IMPL uint32_t aws_sub_u32_saturating(uint32_t a, uint32_t b) {
+    return a <= b ? 0 : a - b;
+}
+
+AWS_STATIC_IMPL int aws_sub_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
+    if (a < b) {
+        return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+    }
+
+    *r = a - b;
+    return AWS_OP_SUCCESS;
+}
+
 /**
  * Multiplies a * b. If the result overflows, returns SIZE_MAX.
  */
@@ -111,6 +137,26 @@ AWS_STATIC_IMPL int aws_add_size_checked(size_t a, size_t b, size_t *r) {
 #endif
 }
 
+AWS_STATIC_IMPL size_t aws_sub_size_saturating(size_t a, size_t b) {
+#if SIZE_BITS == 32
+    return (size_t)aws_sub_u32_saturating(a, b);
+#elif SIZE_BITS == 64
+    return (size_t)aws_sub_u64_saturating(a, b);
+#else
+#    error "Target not supported"
+#endif
+}
+
+AWS_STATIC_IMPL int aws_sub_size_checked(size_t a, size_t b, size_t *r) {
+#if SIZE_BITS == 32
+    return aws_sub_u32_checked(a, b, (uint32_t *)r);
+#elif SIZE_BITS == 64
+    return aws_sub_u64_checked(a, b, (uint64_t *)r);
+#else
+#    error "Target not supported"
+#endif
+}
+
 /**
  * Function to check if x is power of 2
  */
@@ -149,6 +195,102 @@ AWS_STATIC_IMPL int aws_round_up_to_power_of_two(size_t n, size_t *result) {
 #if _MSC_VER
 #    pragma warning(pop)
 #endif /* _MSC_VER */
+
+AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL int aws_min_int(int a, int b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL int aws_max_int(int a, int b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL float aws_min_float(float a, float b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL float aws_max_float(float a, float b) {
+    return a > b ? a : b;
+}
+
+AWS_STATIC_IMPL double aws_min_double(double a, double b) {
+    return a < b ? a : b;
+}
+
+AWS_STATIC_IMPL double aws_max_double(double a, double b) {
+    return a > b ? a : b;
+}
 
 AWS_EXTERN_C_END
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,7 @@ add_test_case(test_add_u32_checked)
 add_test_case(test_add_u32_saturating)
 add_test_case(test_add_u64_checked)
 add_test_case(test_add_u64_saturating)
+add_test_case(test_min_max)
 
 add_test_case(nospec_index_test)
 add_test_case(test_byte_cursor_advance)

--- a/tests/math_test.c
+++ b/tests/math_test.c
@@ -17,6 +17,7 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include <float.h>
 #include <stdio.h>
 
 #define CHECK_SAT(fn, a, b, result)                                                                                    \
@@ -370,6 +371,38 @@ static int s_test_add_size_checked_fn(struct aws_allocator *allocator, void *ctx
     return 0;
 }
 
+AWS_TEST_CASE(test_sub_size_checked, s_test_sub_size_checked_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
+static int s_test_sub_size_checked_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const size_t HALF_MAX = SIZE_MAX / 2;
+    const size_t ACTUAL_MAX = SIZE_MAX;
+
+    /* No overflow expected */
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, 1, 0, 1);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, 9, 4, 5);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, 5555, 1234, 4321);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, ACTUAL_MAX, 0, ACTUAL_MAX);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, ACTUAL_MAX - 1, HALF_MAX, HALF_MAX);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, ACTUAL_MAX, HALF_MAX + 1, HALF_MAX);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, ACTUAL_MAX - 2, 100, ACTUAL_MAX - 102);
+    CHECK_NO_OVF(aws_sub_size_checked, size_t, ACTUAL_MAX, 100, ACTUAL_MAX - 100);
+
+    /* Overflow expected */
+    CHECK_OVF(aws_sub_size_checked, size_t, 0, 1);
+    CHECK_OVF(aws_sub_size_checked, size_t, 0, 100);
+    CHECK_OVF(aws_sub_size_checked, size_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_size_checked, size_t, 0, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_size_checked, size_t, HALF_MAX, HALF_MAX + 1);
+    CHECK_OVF(aws_sub_size_checked, size_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_size_checked, size_t, 99, 100);
+    CHECK_OVF(aws_sub_size_checked, size_t, 1, 100);
+    return 0;
+}
+
 #define CHECK_OVF_VARARGS(fn, type, num, ...)                                                                          \
     do {                                                                                                               \
         type result_val;                                                                                               \
@@ -564,6 +597,38 @@ static int s_test_add_size_saturating_fn(struct aws_allocator *allocator, void *
     return 0;
 }
 
+AWS_TEST_CASE(test_sub_size_saturating, s_test_sub_size_saturating_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
+static int s_test_sub_size_saturating_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const size_t HALF_MAX = SIZE_MAX / 2;
+    const size_t ACTUAL_MAX = SIZE_MAX;
+
+    /* No overflow expected */
+    CHECK_SAT(aws_sub_size_saturating, 0, 0, 0);
+    CHECK_SAT(aws_sub_size_saturating, 1, 0, 1);
+    CHECK_SAT(aws_sub_size_saturating, 9, 4, 5);
+    CHECK_SAT(aws_sub_size_saturating, 5555, 1234, 4321);
+    CHECK_SAT(aws_sub_size_saturating, ACTUAL_MAX, 0, ACTUAL_MAX);
+    CHECK_SAT(aws_sub_size_saturating, ACTUAL_MAX - 1, HALF_MAX, HALF_MAX);
+    CHECK_SAT(aws_sub_size_saturating, ACTUAL_MAX, HALF_MAX + 1, HALF_MAX);
+    CHECK_SAT(aws_sub_size_saturating, ACTUAL_MAX - 2, 100, ACTUAL_MAX - 102);
+    CHECK_SAT(aws_sub_size_saturating, ACTUAL_MAX, 100, ACTUAL_MAX - 100);
+
+    /* Overflow expected */
+    CHECK_SAT(aws_sub_size_saturating, 0, 1, 0);
+    CHECK_SAT(aws_sub_size_saturating, 0, 100, 0);
+    CHECK_SAT(aws_sub_size_saturating, HALF_MAX, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_size_saturating, 0, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_size_saturating, HALF_MAX, HALF_MAX + 1, 0);
+    CHECK_SAT(aws_sub_size_saturating, HALF_MAX, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_size_saturating, 99, 100, 0);
+    CHECK_SAT(aws_sub_size_saturating, 1, 100, 0);
+    return 0;
+}
+
 AWS_TEST_CASE(test_add_u32_checked, s_test_add_u32_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_u32_checked_fn(struct aws_allocator *allocator, void *ctx) {
@@ -627,6 +692,70 @@ static int s_test_add_u32_saturating_fn(struct aws_allocator *allocator, void *c
     return 0;
 }
 
+AWS_TEST_CASE(test_sub_u32_checked, s_test_sub_u32_checked_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
+static int s_test_sub_u32_checked_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const uint32_t HALF_MAX = UINT32_MAX / 2;
+    const uint32_t ACTUAL_MAX = UINT32_MAX;
+
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, 1, 0, 1);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, 9, 4, 5);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, 5555, 1234, 4321);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, ACTUAL_MAX, 0, ACTUAL_MAX);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, ACTUAL_MAX - 1, HALF_MAX, HALF_MAX);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, ACTUAL_MAX, HALF_MAX + 1, HALF_MAX);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, ACTUAL_MAX - 2, 100, ACTUAL_MAX - 102);
+    CHECK_NO_OVF(aws_sub_u32_checked, uint32_t, ACTUAL_MAX, 100, ACTUAL_MAX - 100);
+
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, 0, 1);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, 0, 100);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, 0, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, HALF_MAX, HALF_MAX + 1);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, 99, 100);
+    CHECK_OVF(aws_sub_u32_checked, uint32_t, 1, 100);
+
+    return 0;
+}
+
+AWS_TEST_CASE(test_sub_u32_saturating, s_test_sub_u32_saturating_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
+static int s_test_sub_u32_saturating_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const uint32_t HALF_MAX = UINT32_MAX / 2;
+    const uint32_t ACTUAL_MAX = UINT32_MAX;
+
+    /* No overflow expected */
+    CHECK_SAT(aws_sub_u32_saturating, 0, 0, 0);
+    CHECK_SAT(aws_sub_u32_saturating, 1, 0, 1);
+    CHECK_SAT(aws_sub_u32_saturating, 9, 4, 5);
+    CHECK_SAT(aws_sub_u32_saturating, 5555, 1234, 4321);
+    CHECK_SAT(aws_sub_u32_saturating, ACTUAL_MAX, 0, ACTUAL_MAX);
+    CHECK_SAT(aws_sub_u32_saturating, ACTUAL_MAX - 1, HALF_MAX, HALF_MAX);
+    CHECK_SAT(aws_sub_u32_saturating, ACTUAL_MAX, HALF_MAX + 1, HALF_MAX);
+    CHECK_SAT(aws_sub_u32_saturating, ACTUAL_MAX - 2, 100, ACTUAL_MAX - 102);
+    CHECK_SAT(aws_sub_u32_saturating, ACTUAL_MAX, 100, ACTUAL_MAX - 100);
+
+    /* Overflow expected */
+    CHECK_SAT(aws_sub_u32_saturating, 0, 1, 0);
+    CHECK_SAT(aws_sub_u32_saturating, 0, 100, 0);
+    CHECK_SAT(aws_sub_u32_saturating, HALF_MAX, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_u32_saturating, 0, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_u32_saturating, HALF_MAX, HALF_MAX + 1, 0);
+    CHECK_SAT(aws_sub_u32_saturating, HALF_MAX, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_u32_saturating, 99, 100, 0);
+    CHECK_SAT(aws_sub_u32_saturating, 1, 100, 0);
+
+    return 0;
+}
+
 AWS_TEST_CASE(test_add_u64_checked, s_test_add_u64_checked_fn)
 /* NOLINTNEXTLINE(readability-function-size) */
 static int s_test_add_u64_checked_fn(struct aws_allocator *allocator, void *ctx) {
@@ -687,5 +816,134 @@ static int s_test_add_u64_saturating_fn(struct aws_allocator *allocator, void *c
     CHECK_SAT(aws_add_u64_saturating, HALF_MAX, ACTUAL_MAX, ACTUAL_MAX);
     CHECK_SAT(aws_add_u64_saturating, 100, ACTUAL_MAX - 99, ACTUAL_MAX);
     CHECK_SAT(aws_add_u64_saturating, 100, ACTUAL_MAX - 1, ACTUAL_MAX);
+    return 0;
+}
+
+AWS_TEST_CASE(test_sub_u64_checked, s_test_sub_u64_checked_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
+static int s_test_sub_u64_checked_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const uint64_t HALF_MAX = UINT64_MAX / 2;
+    const uint64_t ACTUAL_MAX = UINT64_MAX;
+
+    /* No overflow expected */
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, 0, 0, 0);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, 1, 0, 1);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, 9, 4, 5);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, 5555, 1234, 4321);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, ACTUAL_MAX, 0, ACTUAL_MAX);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, ACTUAL_MAX - 1, HALF_MAX, HALF_MAX);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, ACTUAL_MAX, HALF_MAX + 1, HALF_MAX);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, ACTUAL_MAX - 2, 100, ACTUAL_MAX - 102);
+    CHECK_NO_OVF(aws_sub_u64_checked, uint64_t, ACTUAL_MAX, 100, ACTUAL_MAX - 100);
+
+    /* Overflow expected */
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, 0, 1);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, 0, 100);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, 0, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, HALF_MAX, HALF_MAX + 1);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, HALF_MAX, ACTUAL_MAX);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, 99, 100);
+    CHECK_OVF(aws_sub_u64_checked, uint64_t, 1, 100);
+
+    return 0;
+}
+
+AWS_TEST_CASE(test_sub_u64_saturating, s_test_sub_u64_saturating_fn)
+/* NOLINTNEXTLINE(readability-function-size) */
+static int s_test_sub_u64_saturating_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    const uint64_t HALF_MAX = UINT64_MAX / 2;
+    const uint64_t ACTUAL_MAX = UINT64_MAX;
+
+    /* No overflow expected */
+    CHECK_SAT(aws_sub_u64_saturating, 0, 0, 0);
+    CHECK_SAT(aws_sub_u64_saturating, 1, 0, 1);
+    CHECK_SAT(aws_sub_u64_saturating, 9, 4, 5);
+    CHECK_SAT(aws_sub_u64_saturating, 5555, 1234, 4321);
+    CHECK_SAT(aws_sub_u64_saturating, ACTUAL_MAX, 0, ACTUAL_MAX);
+    CHECK_SAT(aws_sub_u64_saturating, ACTUAL_MAX - 1, HALF_MAX, HALF_MAX);
+    CHECK_SAT(aws_sub_u64_saturating, ACTUAL_MAX, HALF_MAX + 1, HALF_MAX);
+    CHECK_SAT(aws_sub_u64_saturating, ACTUAL_MAX - 2, 100, ACTUAL_MAX - 102);
+    CHECK_SAT(aws_sub_u64_saturating, ACTUAL_MAX, 100, ACTUAL_MAX - 100);
+
+    /* Overflow expected */
+    CHECK_SAT(aws_sub_u64_saturating, 0, 1, 0);
+    CHECK_SAT(aws_sub_u64_saturating, 0, 100, 0);
+    CHECK_SAT(aws_sub_u64_saturating, HALF_MAX, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_u64_saturating, 0, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_u64_saturating, HALF_MAX, HALF_MAX + 1, 0);
+    CHECK_SAT(aws_sub_u64_saturating, HALF_MAX, ACTUAL_MAX, 0);
+    CHECK_SAT(aws_sub_u64_saturating, 99, 100, 0);
+    CHECK_SAT(aws_sub_u64_saturating, 1, 100, 0);
+    return 0;
+}
+
+AWS_TEST_CASE(test_min_max, s_test_min_max)
+static int s_test_min_max(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    ASSERT_UINT_EQUALS(0, aws_min_u8(0, UINT8_MAX));
+    ASSERT_UINT_EQUALS(0, aws_min_u8(UINT8_MAX, 0));
+    ASSERT_UINT_EQUALS(UINT8_MAX, aws_max_u8(0, UINT8_MAX));
+    ASSERT_UINT_EQUALS(UINT8_MAX, aws_max_u8(UINT8_MAX, 0));
+    ASSERT_INT_EQUALS(INT8_MIN, aws_min_i8(INT8_MIN, INT8_MAX));
+    ASSERT_INT_EQUALS(INT8_MIN, aws_min_i8(INT8_MAX, INT8_MIN));
+    ASSERT_INT_EQUALS(INT8_MAX, aws_max_i8(INT8_MIN, INT8_MAX));
+    ASSERT_INT_EQUALS(INT8_MAX, aws_max_i8(INT8_MAX, INT8_MIN));
+
+    ASSERT_UINT_EQUALS(0, aws_min_u16(0, UINT16_MAX));
+    ASSERT_UINT_EQUALS(0, aws_min_u16(UINT16_MAX, 0));
+    ASSERT_UINT_EQUALS(UINT16_MAX, aws_max_u16(0, UINT16_MAX));
+    ASSERT_UINT_EQUALS(UINT16_MAX, aws_max_u16(UINT16_MAX, 0));
+    ASSERT_INT_EQUALS(INT16_MIN, aws_min_i16(INT16_MIN, INT16_MAX));
+    ASSERT_INT_EQUALS(INT16_MIN, aws_min_i16(INT16_MAX, INT16_MIN));
+    ASSERT_INT_EQUALS(INT16_MAX, aws_max_i16(INT16_MIN, INT16_MAX));
+    ASSERT_INT_EQUALS(INT16_MAX, aws_max_i16(INT16_MAX, INT16_MIN));
+
+    ASSERT_UINT_EQUALS(0, aws_min_u32(0, UINT32_MAX));
+    ASSERT_UINT_EQUALS(0, aws_min_u32(UINT32_MAX, 0));
+    ASSERT_UINT_EQUALS(UINT32_MAX, aws_max_u32(0, UINT32_MAX));
+    ASSERT_UINT_EQUALS(UINT32_MAX, aws_max_u32(UINT32_MAX, 0));
+    ASSERT_INT_EQUALS(INT32_MIN, aws_min_i32(INT32_MIN, INT32_MAX));
+    ASSERT_INT_EQUALS(INT32_MIN, aws_min_i32(INT32_MAX, INT32_MIN));
+    ASSERT_INT_EQUALS(INT32_MAX, aws_max_i32(INT32_MIN, INT32_MAX));
+    ASSERT_INT_EQUALS(INT32_MAX, aws_max_i32(INT32_MAX, INT32_MIN));
+
+    ASSERT_UINT_EQUALS(0, aws_min_u64(0, UINT64_MAX));
+    ASSERT_UINT_EQUALS(0, aws_min_u64(UINT64_MAX, 0));
+    ASSERT_UINT_EQUALS(UINT64_MAX, aws_max_u64(0, UINT64_MAX));
+    ASSERT_UINT_EQUALS(UINT64_MAX, aws_max_u64(UINT64_MAX, 0));
+    ASSERT_INT_EQUALS(INT64_MIN, aws_min_i64(INT64_MIN, INT64_MAX));
+    ASSERT_INT_EQUALS(INT64_MIN, aws_min_i64(INT64_MAX, INT64_MIN));
+    ASSERT_INT_EQUALS(INT64_MAX, aws_max_i64(INT64_MIN, INT64_MAX));
+    ASSERT_INT_EQUALS(INT64_MAX, aws_max_i64(INT64_MAX, INT64_MIN));
+
+    ASSERT_UINT_EQUALS(0, aws_min_size(0, SIZE_MAX));
+    ASSERT_UINT_EQUALS(0, aws_min_size(SIZE_MAX, 0));
+    ASSERT_UINT_EQUALS(SIZE_MAX, aws_max_size(0, SIZE_MAX));
+    ASSERT_UINT_EQUALS(SIZE_MAX, aws_max_size(SIZE_MAX, 0));
+
+    ASSERT_INT_EQUALS(INT_MIN, aws_min_int(INT_MIN, INT_MAX));
+    ASSERT_INT_EQUALS(INT_MIN, aws_min_int(INT_MAX, INT_MIN));
+    ASSERT_INT_EQUALS(INT_MAX, aws_max_int(INT_MIN, INT_MAX));
+    ASSERT_INT_EQUALS(INT_MAX, aws_max_int(INT_MAX, INT_MIN));
+
+    ASSERT_TRUE(FLT_MIN == aws_min_float(FLT_MIN, FLT_MAX));
+    ASSERT_TRUE(FLT_MIN == aws_min_float(FLT_MAX, FLT_MIN));
+    ASSERT_TRUE(FLT_MAX == aws_max_float(FLT_MIN, FLT_MAX));
+    ASSERT_TRUE(FLT_MAX == aws_max_float(FLT_MAX, FLT_MIN));
+
+    ASSERT_TRUE(DBL_MIN == aws_min_double(DBL_MIN, DBL_MAX));
+    ASSERT_TRUE(DBL_MIN == aws_min_double(DBL_MAX, DBL_MIN));
+    ASSERT_TRUE(DBL_MAX == aws_max_double(DBL_MIN, DBL_MAX));
+    ASSERT_TRUE(DBL_MAX == aws_max_double(DBL_MAX, DBL_MIN));
+
     return 0;
 }


### PR DESCRIPTION
Some Trivial math functions I was sick of not having.

Should I bother with the min/max functions for esoteric types like float/double/signed? Currently math.h only has u32/u64/size_t stuff in it, but the min/max functions were easy to write, so I added everything reasonable I could think of.

I didn't do an assembly version of the sub functions (the add functions have this) because I wanted to invest 1hr into this, not 8. If you want to implement them, you get a free promotion to SDE2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
