### PR TITLE
ARN parsing and serialization added

### DIFF
--- a/include/aws/common/resource_name.h
+++ b/include/aws/common/resource_name.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
+
+struct aws_resource_name {
+    struct aws_byte_cursor partition;
+    struct aws_byte_cursor service;
+    struct aws_byte_cursor region;
+    struct aws_byte_cursor account_id;
+    struct aws_byte_cursor resource_id;
+};
+
+AWS_EXTERN_C_BEGIN
+
+/**
+    Given an ARN "Amazon Resource Name" represented as an in memory a
+    structure representing the parts
+*/
+AWS_COMMON_API
+int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *string);
+
+/**
+    Calculates the space needed to write an ARN to a byte buf
+*/
+AWS_COMMON_API
+int aws_resource_name_length(const struct aws_resource_name *arn, size_t *size);
+
+/**
+    Serializes an ARN structure into the lexical string format
+*/
+AWS_COMMON_API
+int aws_byte_buf_append_resource_name(struct aws_byte_buf *buf, const struct aws_resource_name *arn);
+
+AWS_EXTERN_C_END

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -21,7 +21,7 @@
 static const char ARN_DELIMETER[] = ":";
 static const char ARN_DELIMETER_CHAR = ':';
 
-static const size_t DELIMETER_LEN = strlen("arn:::::");
+static const size_t DELIMETER_LEN = 8; /* strlen("arn:::::") */
 
 AWS_COMMON_API
 int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -15,16 +15,18 @@
 
 #include <aws/common/resource_name.h>
 
+#define ARN_SPLIT_COUNT ((size_t)5)
+#define ARN_PARTS_COUNT ((size_t)6)
+
 static const char ARN_DELIMETER[] = ":";
 static const char ARN_DELIMETER_CHAR = ':';
 
 AWS_COMMON_API
 int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {
-    const size_t split_count = 5;
-    struct aws_byte_cursor arn_parts[split_count + 1];
+    struct aws_byte_cursor arn_parts[ARN_PARTS_COUNT];
     struct aws_array_list arn_part_list;
-    aws_array_list_init_static(&arn_part_list, arn_parts, split_count + 1, sizeof(struct aws_byte_cursor));
-    if (aws_byte_cursor_split_on_char_n(input, ARN_DELIMETER_CHAR, split_count, &arn_part_list)) {
+    aws_array_list_init_static(&arn_part_list, arn_parts, ARN_PARTS_COUNT, sizeof(struct aws_byte_cursor));
+    if (aws_byte_cursor_split_on_char_n(input, ARN_DELIMETER_CHAR, ARN_SPLIT_COUNT, &arn_part_list)) {
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }
 

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -21,6 +21,8 @@
 static const char ARN_DELIMETER[] = ":";
 static const char ARN_DELIMETER_CHAR = ':';
 
+static const size_t DELIMETER_LEN = strlen("arn:::::");
+
 AWS_COMMON_API
 int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {
     struct aws_byte_cursor arn_parts[ARN_PARTS_COUNT];
@@ -44,7 +46,7 @@ int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct 
     if (aws_array_list_get_at(&arn_part_list, &arn->region, 3)) {
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }
-    if (aws_array_list_get_at(&arn_part_list, &arn->account_id, 4)) {
+    if (aws_array_list_get_at(&arn_part_list, &arn->account_id, 4) || aws_byte_cursor_eq_c_str(&arn->account_id, "")) {
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }
     if (aws_array_list_get_at(&arn_part_list, &arn->resource_id, 5)) {
@@ -61,7 +63,8 @@ int aws_resource_name_length(const struct aws_resource_name *arn, size_t *size) 
     AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->account_id));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->resource_id));
 
-    *size = arn->partition.len + arn->region.len + arn->service.len + arn->account_id.len + arn->resource_id.len + 8;
+    *size = arn->partition.len + arn->region.len + arn->service.len + arn->account_id.len + arn->resource_id.len +
+            DELIMETER_LEN;
 
     return AWS_OP_SUCCESS;
 }

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -27,6 +27,12 @@ int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct 
     if (aws_byte_cursor_split_on_char_n(input, ARN_DELIMETER_CHAR, split_count, &arn_part_list)) {
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }
+
+    struct aws_byte_cursor *arn_prefix;
+    if (aws_array_list_get_at_ptr(&arn_part_list, (void **)&arn_prefix, 0) ||
+        !aws_byte_cursor_eq_c_str(arn_prefix, "arn")) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
     if (aws_array_list_get_at(&arn_part_list, &arn->partition, 1)) {
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -21,9 +21,9 @@ const char ARN_DELIMETER_CHAR = ':';
 AWS_COMMON_API
 int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {
     const size_t split_count = 5;
-    struct aws_byte_cursor arn_parts[split_count+1];
+    struct aws_byte_cursor arn_parts[split_count + 1];
     struct aws_array_list arn_part_list;
-    aws_array_list_init_static(&arn_part_list, arn_parts, split_count+1, sizeof(struct aws_byte_cursor));
+    aws_array_list_init_static(&arn_part_list, arn_parts, split_count + 1, sizeof(struct aws_byte_cursor));
     if (aws_byte_cursor_split_on_char_n(input, ARN_DELIMETER_CHAR, split_count, &arn_part_list)) {
         return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
     }

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/resource_name.h>
+
+#define ARN_DELIMETER ":"
+
+static int s_parse_resource_name_part(
+    struct aws_byte_cursor *token_cursor,
+    const struct aws_byte_cursor *cursor_split_on,
+    struct aws_byte_cursor *prev_token_cursor) {
+    *prev_token_cursor = *token_cursor;
+    aws_byte_cursor_advance(prev_token_cursor, 1);
+
+    if (aws_byte_cursor_find_exact(prev_token_cursor, cursor_split_on, token_cursor)) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    prev_token_cursor->len = token_cursor->ptr - prev_token_cursor->ptr;
+    return AWS_OP_SUCCESS;
+}
+
+AWS_COMMON_API
+int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(input));
+    AWS_PRECONDITION(input->ptr);
+    AWS_PRECONDITION(arn);
+
+    const struct aws_byte_cursor cursor_split_on = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(ARN_DELIMETER);
+    struct aws_byte_cursor cursor;
+
+    if (input->len < 4) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    cursor.ptr = input->ptr;
+    cursor.len = 4;
+    if (!aws_byte_cursor_eq_c_str(&cursor, "arn:")) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    cursor.len = input->len;
+    aws_byte_cursor_advance(&cursor, 3);
+
+    if (s_parse_resource_name_part(&cursor, &cursor_split_on, &arn->partition)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (s_parse_resource_name_part(&cursor, &cursor_split_on, &arn->service)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (s_parse_resource_name_part(&cursor, &cursor_split_on, &arn->region)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (s_parse_resource_name_part(&cursor, &cursor_split_on, &arn->account_id)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    arn->resource_id.ptr = cursor.ptr + 1;
+    arn->resource_id.len =
+        input->len - 8 - (arn->partition.len + arn->service.len + arn->region.len + arn->account_id.len);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_COMMON_API
+int aws_resource_name_length(const struct aws_resource_name *arn, size_t *size) {
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->partition));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->service));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->region));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->account_id));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->resource_id));
+
+    *size = arn->partition.len + arn->region.len + arn->service.len + arn->account_id.len + arn->resource_id.len + 8;
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_COMMON_API
+int aws_byte_buf_append_resource_name(struct aws_byte_buf *buf, const struct aws_resource_name *arn) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(buf));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->partition));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->service));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->region));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->account_id));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&arn->resource_id));
+
+    const struct aws_byte_cursor prefix = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:");
+    const struct aws_byte_cursor colon_cur = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(ARN_DELIMETER);
+
+    if (aws_byte_buf_append(buf, &prefix)) {
+        return aws_raise_error(aws_last_error());
+    }
+    if (aws_byte_buf_append(buf, &arn->partition)) {
+        return aws_raise_error(aws_last_error());
+    }
+    if (aws_byte_buf_append(buf, &colon_cur)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (aws_byte_buf_append(buf, &arn->service)) {
+        return aws_raise_error(aws_last_error());
+    }
+    if (aws_byte_buf_append(buf, &colon_cur)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (aws_byte_buf_append(buf, &arn->region)) {
+        return aws_raise_error(aws_last_error());
+    }
+    if (aws_byte_buf_append(buf, &colon_cur)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (aws_byte_buf_append(buf, &arn->account_id)) {
+        return aws_raise_error(aws_last_error());
+    }
+    if (aws_byte_buf_append(buf, &colon_cur)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    if (aws_byte_buf_append(buf, &arn->resource_id)) {
+        return aws_raise_error(aws_last_error());
+    }
+
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(buf));
+    return AWS_OP_SUCCESS;
+}

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -33,6 +33,34 @@ static int s_parse_resource_name_part(
 
 AWS_COMMON_API
 int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {
+    const size_t part_count = 6;
+    struct aws_byte_cursor arn_parts[6];
+    struct aws_array_list arn_part_list;
+    aws_array_list_init_static(&arn_part_list, arn_parts, part_count, sizeof(struct aws_byte_cursor));
+    if (aws_byte_cursor_split_on_char_n(input, ':', part_count, &arn_part_list)) {
+        return aws_raise_error(aws_last_error());
+    }
+    printf("List size: %ld\n", aws_array_list_length(&arn_part_list));
+    if (aws_array_list_get_at(&arn_part_list, &arn->partition, 1)) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    if (aws_array_list_get_at(&arn_part_list, &arn->service, 2)) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    if (aws_array_list_get_at(&arn_part_list, &arn->region, 3)) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    if (aws_array_list_get_at(&arn_part_list, &arn->account_id, 4)) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    if (aws_array_list_get_at(&arn_part_list, &arn->resource_id, 5)) {
+        return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+    }
+    return AWS_OP_SUCCESS;
+}
+
+AWS_COMMON_API
+int aws_resource_name_init_from_cur_1(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {
     AWS_PRECONDITION(aws_byte_cursor_is_valid(input));
     AWS_PRECONDITION(input->ptr);
     AWS_PRECONDITION(arn);

--- a/source/resource_name.c
+++ b/source/resource_name.c
@@ -15,8 +15,8 @@
 
 #include <aws/common/resource_name.h>
 
-const char ARN_DELIMETER[] = ":";
-const char ARN_DELIMETER_CHAR = ':';
+static const char ARN_DELIMETER[] = ":";
+static const char ARN_DELIMETER_CHAR = ':';
 
 AWS_COMMON_API
 int aws_resource_name_init_from_cur(struct aws_resource_name *arn, const struct aws_byte_cursor *input) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -411,6 +411,12 @@ add_test_case(test_bigint_divide_single_digit_divisor)
 add_test_case(test_bigint_divide_general)
 add_test_case(test_bigint_append_binary)
 
+add_test_case(parse_resource_name_test)
+add_test_case(parse_resource_name_failures_test)
+add_test_case(resource_name_tostring_test)
+add_test_case(resource_name_tostring_failure_test)
+add_test_case(resource_name_length_test)
+
 generate_test_driver(${PROJECT_NAME}-tests)
 
 if (NOT MSVC AND NOT LEGACY_COMPILER_SUPPORT)

--- a/tests/resource_name_test.c
+++ b/tests/resource_name_test.c
@@ -89,6 +89,13 @@ static int s_test_parse_resource_name_failures(struct aws_allocator *allocator, 
     /* arn prefix isn't present/correct */
     ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_06, &arn_string_06));
 
+    struct aws_byte_cursor arn_string_07 =
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws:cloudformation:us-east-1::stack/FooBar");
+    struct aws_resource_name arn_07;
+    AWS_ZERO_STRUCT(arn_07);
+    /* account ID is an empty string */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_07, &arn_string_07));
+
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/resource_name_test.c
+++ b/tests/resource_name_test.c
@@ -23,7 +23,7 @@ static int s_test_parse_resource_name(struct aws_allocator *allocator, void *ctx
     (void)ctx;
 
     struct aws_byte_cursor arn_string_01 =
-        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov:iam::123456789012:user/*");
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov:iam::123456789012:user:ooo");
     struct aws_resource_name arn_01;
     AWS_ZERO_STRUCT(arn_01);
     ASSERT_SUCCESS(aws_resource_name_init_from_cur(&arn_01, &arn_string_01));
@@ -31,7 +31,8 @@ static int s_test_parse_resource_name(struct aws_allocator *allocator, void *ctx
     ASSERT_BIN_ARRAYS_EQUALS("iam", strlen("iam"), arn_01.service.ptr, arn_01.service.len);
     ASSERT_BIN_ARRAYS_EQUALS("", strlen(""), arn_01.region.ptr, arn_01.region.len);
     ASSERT_BIN_ARRAYS_EQUALS("123456789012", strlen("123456789012"), arn_01.account_id.ptr, arn_01.account_id.len);
-    ASSERT_BIN_ARRAYS_EQUALS("user/*", strlen("user/*"), arn_01.resource_id.ptr, arn_01.resource_id.len);
+    printf("ResourceID: [" PRInSTR "]\n", AWS_BYTE_CURSOR_PRI(arn_01.resource_id));
+    ASSERT_BIN_ARRAYS_EQUALS("user:ooo", strlen("user:ooo"), arn_01.resource_id.ptr, arn_01.resource_id.len);
 
     struct aws_byte_cursor arn_string_02 =
         AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws:cloudformation:us-east-1:1234567890:stack/FooBar");

--- a/tests/resource_name_test.c
+++ b/tests/resource_name_test.c
@@ -159,6 +159,15 @@ static int s_test_resource_name_tostring_failure(struct aws_allocator *allocator
     ASSERT_ERROR(AWS_ERROR_DEST_COPY_TOO_SMALL, aws_byte_buf_append_resource_name(&too_small_buffer, &arn_01));
     aws_byte_buf_clean_up(&too_small_buffer);
 
+    uint8_t static_space[16];
+    struct aws_byte_buf static_buffer = {.len = 0, .buffer = static_space, .capacity = 16, .allocator = NULL};
+    struct aws_resource_name arn_02 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("s3"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(""),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("123456789"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bucket/key")};
+    ASSERT_ERROR(AWS_ERROR_DEST_COPY_TOO_SMALL, aws_byte_buf_append_resource_name(&static_buffer, &arn_02));
+
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/resource_name_test.c
+++ b/tests/resource_name_test.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/resource_name.h>
+#include <aws/testing/aws_test_harness.h>
+
+AWS_TEST_CASE(parse_resource_name_test, s_test_parse_resource_name)
+static int s_test_parse_resource_name(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct aws_byte_cursor arn_string_01 =
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov:iam::123456789012:user/*");
+    struct aws_resource_name arn_01;
+    AWS_ZERO_STRUCT(arn_01);
+    ASSERT_SUCCESS(aws_resource_name_init_from_cur(&arn_01, &arn_string_01));
+    ASSERT_BIN_ARRAYS_EQUALS("aws-us-gov", strlen("aws-us-gov"), arn_01.partition.ptr, arn_01.partition.len);
+    ASSERT_BIN_ARRAYS_EQUALS("iam", strlen("iam"), arn_01.service.ptr, arn_01.service.len);
+    ASSERT_BIN_ARRAYS_EQUALS("", strlen(""), arn_01.region.ptr, arn_01.region.len);
+    ASSERT_BIN_ARRAYS_EQUALS("123456789012", strlen("123456789012"), arn_01.account_id.ptr, arn_01.account_id.len);
+    ASSERT_BIN_ARRAYS_EQUALS("user/*", strlen("user/*"), arn_01.resource_id.ptr, arn_01.resource_id.len);
+
+    struct aws_byte_cursor arn_string_02 =
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws:cloudformation:us-east-1:1234567890:stack/FooBar");
+    struct aws_resource_name arn_02;
+    AWS_ZERO_STRUCT(arn_02);
+    ASSERT_SUCCESS(aws_resource_name_init_from_cur(&arn_02, &arn_string_02));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&arn_02.partition, "aws"));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&arn_02.service, "cloudformation"));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&arn_02.region, "us-east-1"));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&arn_02.account_id, "1234567890"));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&arn_02.resource_id, "stack/FooBar"));
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(parse_resource_name_failures_test, s_test_parse_resource_name_failures)
+static int s_test_parse_resource_name_failures(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct aws_byte_cursor arn_string_01 = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov:iam::123456789012");
+    struct aws_resource_name arn_01;
+    AWS_ZERO_STRUCT(arn_01);
+    /* arn has no resource id */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_01, &arn_string_01));
+
+    struct aws_byte_cursor arn_string_02 = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov:iam:");
+    struct aws_resource_name arn_02;
+    AWS_ZERO_STRUCT(arn_02);
+    /* arn has no account id */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_02, &arn_string_02));
+
+    struct aws_byte_cursor arn_string_03 = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov:iam");
+    struct aws_resource_name arn_03;
+    AWS_ZERO_STRUCT(arn_03);
+    /* arn has no region */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_03, &arn_string_03));
+
+    struct aws_byte_cursor arn_string_04 = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn:aws-us-gov");
+    struct aws_resource_name arn_04;
+    AWS_ZERO_STRUCT(arn_04);
+    /* arn has no partition */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_04, &arn_string_04));
+
+    struct aws_byte_cursor arn_string_05 = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("arn");
+    struct aws_resource_name arn_05;
+    AWS_ZERO_STRUCT(arn_05);
+    /* arn cannot parse arn prefix (must end with :) */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_05, &arn_string_05));
+
+    struct aws_byte_cursor arn_string_06 =
+        AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("ar:aws:cloudformation:us-east-1:1234567890:stack/FooBar");
+    struct aws_resource_name arn_06;
+    AWS_ZERO_STRUCT(arn_06);
+    /* arn prefix isn't present/correct */
+    ASSERT_ERROR(AWS_ERROR_MALFORMED_INPUT_STRING, aws_resource_name_init_from_cur(&arn_06, &arn_string_06));
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(resource_name_tostring_test, s_test_resource_name_tostring)
+static int s_test_resource_name_tostring(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_byte_buf buffer;
+    AWS_ZERO_STRUCT(buffer);
+    ASSERT_SUCCESS(aws_byte_buf_init(&buffer, allocator, 1600));
+
+    struct aws_resource_name arn_01 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws-us-gov"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("iam"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(""),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("123456789"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("group/crt")};
+    ASSERT_SUCCESS(aws_byte_buf_append_resource_name(&buffer, &arn_01));
+    ASSERT_BIN_ARRAYS_EQUALS(
+        "arn:aws-us-gov:iam::123456789:group/crt",
+        strlen("arn:aws-us-gov:iam::123456789:group/crt"),
+        buffer.buffer,
+        buffer.len);
+
+    aws_byte_buf_reset(&buffer, false);
+    struct aws_resource_name arn_02 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("cloudformation"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("us-west-2"),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("12345678910"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("stack/MyStack")};
+    ASSERT_SUCCESS(aws_byte_buf_append_resource_name(&buffer, &arn_02));
+    ASSERT_BIN_ARRAYS_EQUALS(
+        "arn:aws:cloudformation:us-west-2:12345678910:stack/MyStack",
+        strlen("arn:aws:cloudformation:us-west-2:12345678910:stack/MyStack"),
+        buffer.buffer,
+        buffer.len);
+    aws_byte_buf_clean_up(&buffer);
+
+    uint8_t static_space[120];
+    struct aws_byte_buf static_buffer = {.len = 0, .buffer = static_space, .capacity = 120, .allocator = NULL};
+    struct aws_resource_name arn_03 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("s3"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(""),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("123456789"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("bucket/key")};
+    ASSERT_SUCCESS(aws_byte_buf_append_resource_name(&static_buffer, &arn_03));
+    ASSERT_BIN_ARRAYS_EQUALS(
+        "arn:aws:s3::123456789:bucket/key",
+        strlen("arn:aws:s3::123456789:bucket/key"),
+        static_buffer.buffer,
+        static_buffer.len);
+    aws_byte_buf_clean_up(&static_buffer);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(resource_name_tostring_failure_test, s_test_resource_name_tostring_failure)
+static int s_test_resource_name_tostring_failure(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_byte_buf too_small_buffer;
+    AWS_ZERO_STRUCT(too_small_buffer);
+    ASSERT_SUCCESS(aws_byte_buf_init(&too_small_buffer, allocator, 16));
+    struct aws_resource_name arn_01 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws-cn"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("dynamodb"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("cn-northwest-1"),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("123456789"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Table/Books")};
+    ASSERT_ERROR(AWS_ERROR_DEST_COPY_TOO_SMALL, aws_byte_buf_append_resource_name(&too_small_buffer, &arn_01));
+    aws_byte_buf_clean_up(&too_small_buffer);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(resource_name_length_test, s_test_resource_name_length)
+static int s_test_resource_name_length(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    size_t arn_length;
+    struct aws_byte_buf buffer;
+    AWS_ZERO_STRUCT(buffer);
+    ASSERT_SUCCESS(aws_byte_buf_init(&buffer, allocator, 1600));
+
+    struct aws_resource_name arn_01 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws-us-gov"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("iam"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(""),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("123456789"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("group:crt")};
+    ASSERT_SUCCESS(aws_resource_name_length(&arn_01, &arn_length));
+    ASSERT_UINT_EQUALS(strlen("arn:aws-us-gov:iam::123456789:group:crt"), arn_length);
+
+    aws_byte_buf_reset(&buffer, false);
+    struct aws_resource_name arn_02 = {.partition = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("aws"),
+                                       .service = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("cloudformation"),
+                                       .region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("us-west-2"),
+                                       .account_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("12345678910"),
+                                       .resource_id = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("stack/MyStack")};
+    ASSERT_SUCCESS(aws_resource_name_length(&arn_02, &arn_length));
+    ASSERT_UINT_EQUALS(strlen("arn:aws:cloudformation:us-west-2:12345678910:stack/MyStack"), arn_length);
+
+    aws_byte_buf_clean_up(&buffer);
+    return AWS_OP_SUCCESS;
+}

--- a/tests/resource_name_test.c
+++ b/tests/resource_name_test.c
@@ -31,7 +31,6 @@ static int s_test_parse_resource_name(struct aws_allocator *allocator, void *ctx
     ASSERT_BIN_ARRAYS_EQUALS("iam", strlen("iam"), arn_01.service.ptr, arn_01.service.len);
     ASSERT_BIN_ARRAYS_EQUALS("", strlen(""), arn_01.region.ptr, arn_01.region.len);
     ASSERT_BIN_ARRAYS_EQUALS("123456789012", strlen("123456789012"), arn_01.account_id.ptr, arn_01.account_id.len);
-    printf("ResourceID: [" PRInSTR "]\n", AWS_BYTE_CURSOR_PRI(arn_01.resource_id));
     ASSERT_BIN_ARRAYS_EQUALS("user:ooo", strlen("user:ooo"), arn_01.resource_id.ptr, arn_01.resource_id.len);
 
     struct aws_byte_cursor arn_string_02 =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* One new structure 'aws_resource_name' representing an ARN defined here: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
* Methods to parse ARNs from strings and serialize to strings. aws_parse_resource_name / aws_resource_name_to_str 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
