### PR TITLE
aws_hash_combine()

### DIFF
--- a/include/aws/common/hash_table.h
+++ b/include/aws/common/hash_table.h
@@ -394,6 +394,9 @@ uint64_t aws_hash_byte_cursor_ptr(const void *item);
 AWS_COMMON_API
 uint64_t aws_hash_ptr(const void *item);
 
+AWS_COMMON_API
+uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
+
 /**
  * Convenience eq callback for NULL-terminated C-strings
  */

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -992,12 +992,11 @@ uint64_t aws_hash_ptr(const void *item) {
 }
 
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2) {
-    /* Use high and low halves of item2 as input to hashlittle */
-    uint32_t *b = &((uint32_t *)&item2)[0];
-    uint32_t *c = &((uint32_t *)&item2)[1];
+    uint32_t b = (uint32_t)item2;
+    uint32_t c = (uint32_t)(item2 >> 32);
 
-    hashlittle2(&item1, sizeof(item1), c, b);
-    return item2;
+    hashlittle2(&item1, sizeof(item1), &c, &b);
+    return ((uint64_t)b << 32) | c;
 }
 
 bool aws_hash_callback_c_str_eq(const void *a, const void *b) {

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -992,8 +992,8 @@ uint64_t aws_hash_ptr(const void *item) {
 }
 
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2) {
-    uint32_t b = (uint32_t)item2;
-    uint32_t c = (uint32_t)(item2 >> 32);
+    uint32_t b = item2 & 0xFFFFFFFF; /* LSB */
+    uint32_t c = item2 >> 32;        /* MSB */
 
     hashlittle2(&item1, sizeof(item1), &c, &b);
     return ((uint64_t)b << 32) | c;

--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -991,6 +991,15 @@ uint64_t aws_hash_ptr(const void *item) {
     return ((uint64_t)b << 32) | c;
 }
 
+uint64_t aws_hash_combine(uint64_t item1, uint64_t item2) {
+    /* Use high and low halves of item2 as input to hashlittle */
+    uint32_t *b = &((uint32_t *)&item2)[0];
+    uint32_t *c = &((uint32_t *)&item2)[1];
+
+    hashlittle2(&item1, sizeof(item1), c, b);
+    return item2;
+}
+
 bool aws_hash_callback_c_str_eq(const void *a, const void *b) {
     AWS_PRECONDITION(aws_c_string_is_valid(a));
     AWS_PRECONDITION(aws_c_string_is_valid(b));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ add_test_case(test_hash_table_eq)
 add_test_case(test_hash_churn)
 add_test_case(test_hash_table_cleanup_idempotent)
 add_test_case(test_hash_table_byte_cursor_create_find)
+add_test_case(test_hash_combine)
 
 add_test_case(test_is_power_of_two)
 add_test_case(test_round_up_to_power_of_two)

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -1261,14 +1261,15 @@ static int s_test_hash_table_byte_cursor_create_find_fn(struct aws_allocator *al
 
 AWS_TEST_CASE(test_hash_combine, s_test_hash_combine_fn)
 static int s_test_hash_combine_fn(struct aws_allocator *allocator, void *ctx) {
-    uint64_t a, b, c;
+    (void)allocator;
+    (void)ctx;
 
-    /* We're assuming that the underlying hashing function works,
-     * just making sure we hooked it up right for 2 64bit values */
+    /* We're assuming that the underlying hashing function works well.
+     * This test just makes sure we hooked it up right for 2 64bit values */
 
-    a = 0x123456789abcdef;
-    b = 0xfedcba987654321;
-    c = aws_hash_combine(a, b);
+    uint64_t a = 0x123456789abcdef;
+    uint64_t b = 0xfedcba987654321;
+    uint64_t c = aws_hash_combine(a, b);
 
     /* Sanity check */
     ASSERT_TRUE(c != a);
@@ -1277,19 +1278,13 @@ static int s_test_hash_combine_fn(struct aws_allocator *allocator, void *ctx) {
     /* Same inputs gets same results, right? */
     ASSERT_UINT_EQUALS(c, aws_hash_combine(a, b));
 
-    /* Using all bytes, right? */
+    /* Result spread across all bytes, right? */
     uint8_t *c_bytes = (uint8_t *)&c;
     for (size_t i = 0; i < sizeof(c); ++i) {
         ASSERT_TRUE(c_bytes[i] != 0);
     }
 
-    /* Check even low-entropy numbers result in something with high entropy */
-    c = aws_hash_combine(0, 1);
-    for (size_t i = 0; i < sizeof(c); ++i) {
-        ASSERT_TRUE(c_bytes[i] != 0);
-    }
-
-    /* Hash should NOT be cummutative */
+    /* Hash should NOT be commutative */
     ASSERT_TRUE(aws_hash_combine(a, b) != aws_hash_combine(b, a));
 
     return 0;

--- a/tests/hash_table_test.c
+++ b/tests/hash_table_test.c
@@ -1258,3 +1258,39 @@ static int s_test_hash_table_byte_cursor_create_find_fn(struct aws_allocator *al
 
     return 0;
 }
+
+AWS_TEST_CASE(test_hash_combine, s_test_hash_combine_fn)
+static int s_test_hash_combine_fn(struct aws_allocator *allocator, void *ctx) {
+    uint64_t a, b, c;
+
+    /* We're assuming that the underlying hashing function works,
+     * just making sure we hooked it up right for 2 64bit values */
+
+    a = 0x123456789abcdef;
+    b = 0xfedcba987654321;
+    c = aws_hash_combine(a, b);
+
+    /* Sanity check */
+    ASSERT_TRUE(c != a);
+    ASSERT_TRUE(c != b);
+
+    /* Same inputs gets same results, right? */
+    ASSERT_UINT_EQUALS(c, aws_hash_combine(a, b));
+
+    /* Using all bytes, right? */
+    uint8_t *c_bytes = (uint8_t *)&c;
+    for (size_t i = 0; i < sizeof(c); ++i) {
+        ASSERT_TRUE(c_bytes[i] != 0);
+    }
+
+    /* Check even low-entropy numbers result in something with high entropy */
+    c = aws_hash_combine(0, 1);
+    for (size_t i = 0; i < sizeof(c); ++i) {
+        ASSERT_TRUE(c_bytes[i] != 0);
+    }
+
+    /* Hash should NOT be cummutative */
+    ASSERT_TRUE(aws_hash_combine(a, b) != aws_hash_combine(b, a));
+
+    return 0;
+}


### PR DESCRIPTION
We have hashes for single items.
This lets us combine them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
