### PR TITLE
Fixing bug with aws_cli_getopt_long

### DIFF
--- a/include/aws/common/command_line_parser.h
+++ b/include/aws/common/command_line_parser.h
@@ -31,6 +31,7 @@ struct aws_cli_option {
     int val;
 };
 
+AWS_EXTERN_C_BEGIN
 /**
  * Initialized to 1 (for where the first argument would be). As arguments are parsed, this number is the index
  * of the next argument to parse. Reset this to 1 to parse another set of arguments, or to rerun the parser.
@@ -42,7 +43,6 @@ AWS_COMMON_API extern int aws_cli_optind;
  */
 AWS_COMMON_API extern const char *aws_cli_optarg;
 
-AWS_EXTERN_C_BEGIN
 /**
  * A mostly compliant implementation of posix getopt_long(). Parses command-line arguments. argc is the number of
  * command line arguments passed in argv. optstring contains the legitimate option characters. The option characters

--- a/source/command_line_parser.c
+++ b/source/command_line_parser.c
@@ -94,19 +94,18 @@ int aws_cli_getopt_long(
     aws_cli_optind++;
     if (option) {
         bool has_arg = false;
-        if (option) {
-            char *opt_value = memchr(optstring, option->val, strlen(optstring));
-            if (!opt_value) {
-                return '?';
-            }
 
-            if (opt_value[1] == ':') {
-                has_arg = true;
-            }
+        char *opt_value = memchr(optstring, option->val, strlen(optstring));
+        if (!opt_value) {
+            return '?';
+        }
+
+        if (opt_value[1] == ':') {
+            has_arg = true;
         }
 
         if (has_arg) {
-            if (aws_cli_optind >= argc - 1) {
+            if (aws_cli_optind >= argc) {
                 return '?';
             }
 


### PR DESCRIPTION
*Description of changes:*
* Moving aws_cli_optarg to extern "C" so that it will link for Visual Studio.
* Removing unnecessary if.
* Fixing bug where if a CLI option takes an argument, it will skip the argument if it's the last item in the argv array.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
