### PR TITLE
Add aws_run_command()

### DIFF
--- a/include/aws/common/process.h
+++ b/include/aws/common/process.h
@@ -21,6 +21,47 @@ AWS_EXTERN_C_BEGIN
 
 AWS_COMMON_API int aws_get_pid(void);
 
+struct aws_run_command_result {
+    struct aws_allocator *allocator;
+
+    /* return code from running the command. */
+    int ret_code;
+
+    /**
+     * captured stdout message from running the command,
+     * caller is responsible for releasing the memory.
+     */
+    struct aws_string *std_out;
+
+    /**
+     * captured stderr message from running the command,
+     * caller is responsible for releasing the memory.
+     * It's currently not implemented and the value will be set to NULL.
+     */
+    struct aws_string *std_err;
+};
+
+struct aws_run_command_options {
+    struct aws_allocator *allocator;
+
+    /* command path and commandline options of running that command. */
+    const char *command;
+};
+
+AWS_COMMON_API struct aws_run_command_result *aws_run_command_result_new(struct aws_allocator *allocator);
+
+AWS_COMMON_API void aws_run_command_result_destroy(struct aws_run_command_result *result);
+
+/**
+ * Currently this API is implemented using popen on Posix system and
+ * _popen on Windows to capture output from running a command. Note
+ * that popen only captures stdout, and doesn't provide an option to
+ * capture stderr. We will add more options, such as acquire stderr
+ * in the future so probably will alter the underlying implementation
+ * as well.
+ */
+AWS_COMMON_API struct aws_run_command_result *aws_run_command(struct aws_run_command_options options);
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_PROCESS_H */

--- a/include/aws/common/process.h
+++ b/include/aws/common/process.h
@@ -22,8 +22,6 @@ AWS_EXTERN_C_BEGIN
 AWS_COMMON_API int aws_get_pid(void);
 
 struct aws_run_command_result {
-    struct aws_allocator *allocator;
-
     /* return code from running the command. */
     int ret_code;
 
@@ -42,15 +40,13 @@ struct aws_run_command_result {
 };
 
 struct aws_run_command_options {
-    struct aws_allocator *allocator;
-
     /* command path and commandline options of running that command. */
     const char *command;
 };
 
-AWS_COMMON_API struct aws_run_command_result *aws_run_command_result_new(struct aws_allocator *allocator);
+AWS_COMMON_API int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
 
-AWS_COMMON_API void aws_run_command_result_destroy(struct aws_run_command_result *result);
+AWS_COMMON_API void aws_run_command_result_cleanup(struct aws_run_command_result *result);
 
 /**
  * Currently this API is implemented using popen on Posix system and
@@ -60,7 +56,10 @@ AWS_COMMON_API void aws_run_command_result_destroy(struct aws_run_command_result
  * in the future so probably will alter the underlying implementation
  * as well.
  */
-AWS_COMMON_API struct aws_run_command_result *aws_run_command(struct aws_run_command_options options);
+AWS_COMMON_API int aws_run_command(
+    struct aws_allocator *allocator,
+    struct aws_run_command_options *options,
+    struct aws_run_command_result *result);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -237,6 +237,12 @@ bool aws_string_is_valid(const struct aws_string *str);
 AWS_STATIC_IMPL
 bool aws_c_string_is_valid(const char *str);
 
+/**
+ * Evaluates if a char is a white character.
+ */
+AWS_STATIC_IMPL
+bool aws_char_is_space(uint8_t c);
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/string.inl>
 #endif /* AWS_NO_STATIC_IMPL */

--- a/include/aws/common/string.inl
+++ b/include/aws/common/string.inl
@@ -14,8 +14,8 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 #include <aws/common/string.h>
+#include <ctype.h>
 
 AWS_EXTERN_C_BEGIN
 /**
@@ -57,5 +57,14 @@ bool aws_c_string_is_valid(const char *str) {
      */
     return str && AWS_MEM_IS_READABLE(str, 1);
 }
+
+/**
+ * Evaluates if a char is a white character.
+ */
+AWS_STATIC_IMPL
+bool aws_char_is_space(uint8_t c) {
+    return isspace((int)c) != 0;
+}
+
 AWS_EXTERN_C_END
 #endif /* AWS_COMMON_STRING_INL */

--- a/source/posix/process.c
+++ b/source/posix/process.c
@@ -14,8 +14,6 @@
  */
 
 #include <aws/common/process.h>
-
-#include <sys/types.h>
 #include <unistd.h>
 
 int aws_get_pid(void) {

--- a/source/process_common.c
+++ b/source/process_common.c
@@ -49,7 +49,7 @@ int aws_run_command(
     FILE *output_stream;
     char output_buffer[MAX_BUFFER_SIZE];
     struct aws_byte_buf result_buffer;
-    bool success = false;
+    int ret = AWS_OP_ERR;
     if (aws_byte_buf_init(&result_buffer, allocator, MAX_BUFFER_SIZE)) {
         goto on_finish;
     }
@@ -84,12 +84,9 @@ int aws_run_command(
             goto on_finish;
         }
     }
-    success = true;
+    ret = AWS_OP_SUCCESS;
 
 on_finish:
     aws_byte_buf_clean_up_secure(&result_buffer);
-    if (success) {
-        return AWS_OP_SUCCESS;
-    }
-    return AWS_OP_ERR;
+    return ret;
 }

--- a/source/process_common.c
+++ b/source/process_common.c
@@ -71,9 +71,9 @@ struct aws_run_command_result *aws_run_command(struct aws_run_command_options op
             }
         }
 #ifdef _WIN32
-        _pclose(output_stream);
+        result->ret_code = _pclose(output_stream);
 #else
-        pclose(output_stream);
+        result->ret_code = pclose(output_stream);
 #endif
     }
 

--- a/source/process_common.c
+++ b/source/process_common.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/process.h>
+#include <aws/common/string.h>
+
+#include <stdio.h>
+#include <sys/types.h>
+
+#define MAX_BUFFER_SIZE (2048)
+struct aws_run_command_result *aws_run_command_result_new(struct aws_allocator *allocator) {
+    if (!allocator) {
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+        return NULL;
+    }
+    struct aws_run_command_result *result = aws_mem_calloc(allocator, 1, sizeof(struct aws_run_command_result));
+    if (!result) {
+        return NULL;
+    }
+    result->allocator = allocator;
+    return result;
+}
+
+void aws_run_command_result_destroy(struct aws_run_command_result *result) {
+    if (!result) {
+        return;
+    }
+    aws_string_destroy_secure(result->std_out);
+    aws_string_destroy_secure(result->std_err);
+    aws_mem_release(result->allocator, result);
+}
+
+struct aws_run_command_result *aws_run_command(struct aws_run_command_options options) {
+    FILE *output_stream;
+    char output_buffer[MAX_BUFFER_SIZE];
+    struct aws_run_command_result *result = aws_run_command_result_new(options.allocator);
+    if (!result) {
+        return NULL;
+    }
+
+#ifdef _WIN32
+    output_stream = _popen(options.command, "r");
+#else
+    output_stream = popen(options.command, "r");
+#endif
+
+    struct aws_byte_buf result_buffer;
+    if (aws_byte_buf_init(&result_buffer, result->allocator, MAX_BUFFER_SIZE)) {
+        goto on_finish;
+    }
+
+    if (output_stream) {
+        while (!feof(output_stream)) {
+            if (fgets(output_buffer, MAX_BUFFER_SIZE, output_stream) != NULL) {
+                struct aws_byte_cursor cursor = aws_byte_cursor_from_c_str(output_buffer);
+                if (aws_byte_buf_append_dynamic(&result_buffer, &cursor)) {
+                    goto on_finish;
+                }
+            }
+        }
+#ifdef _WIN32
+        _pclose(output_stream);
+#else
+        pclose(output_stream);
+#endif
+    }
+
+    struct aws_byte_cursor trim_cursor = aws_byte_cursor_from_buf(&result_buffer);
+    struct aws_byte_cursor trimmed_cursor = aws_byte_cursor_trim_pred(&trim_cursor, aws_char_is_space);
+    result->std_out = aws_string_new_from_array(result->allocator, trimmed_cursor.ptr, trimmed_cursor.len);
+
+on_finish:
+    aws_byte_buf_clean_up_secure(&result_buffer);
+    return result;
+}

--- a/source/windows/process.c
+++ b/source/windows/process.c
@@ -17,7 +17,6 @@
 #include <aws/common/string.h>
 #include <process.h>
 
-
 int aws_get_pid(void) {
     return _getpid();
 }

--- a/source/windows/process.c
+++ b/source/windows/process.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 #include <aws/common/process.h>
-
-#include <aws/common/string.h>
 #include <process.h>
 
 int aws_get_pid(void) {

--- a/source/windows/process.c
+++ b/source/windows/process.c
@@ -14,7 +14,9 @@
  */
 #include <aws/common/process.h>
 
+#include <aws/common/string.h>
 #include <process.h>
+
 
 int aws_get_pid(void) {
     return _getpid();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -387,6 +387,7 @@ if (NOT ANDROID)
 endif() # ANDROID
 
 add_test_case(get_pid_sanity_check_test)
+add_test_case(run_command_test)
 
 add_test_case(test_bigint_from_uint64)
 add_test_case(test_bigint_from_int64)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -387,7 +387,8 @@ if (NOT ANDROID)
 endif() # ANDROID
 
 add_test_case(get_pid_sanity_check_test)
-add_test_case(run_command_test)
+add_test_case(run_command_test_success)
+add_test_case(run_command_test_bad_command)
 
 add_test_case(test_bigint_from_uint64)
 add_test_case(test_bigint_from_int64)

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -38,10 +38,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_expected_output, "{\"Version\": 1, \"AccessKeyI
 
 static int s_run_command_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
-    struct aws_run_command_options options = {
-        .allocator = allocator,
-        .command = aws_string_c_str(s_test_command)
-    };
+    struct aws_run_command_options options = {.allocator = allocator, .command = aws_string_c_str(s_test_command)};
 
     struct aws_run_command_result *result = aws_run_command(options);
     ASSERT_NOT_NULL(result);

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -13,9 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/testing/aws_test_harness.h>
-
 #include <aws/common/process.h>
+#include <aws/common/string.h>
+#include <aws/testing/aws_test_harness.h>
 
 static int s_get_pid_sanity_check_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
@@ -28,3 +28,29 @@ static int s_get_pid_sanity_check_test_fn(struct aws_allocator *allocator, void 
 }
 
 AWS_TEST_CASE(get_pid_sanity_check_test, s_get_pid_sanity_check_test_fn)
+
+#ifdef _WIN32
+AWS_STATIC_STRING_FROM_LITERAL(s_test_command, "echo {\"Version\": 1, \"AccessKeyId\": \"AccessKey123\"}");
+#else
+AWS_STATIC_STRING_FROM_LITERAL(s_test_command, "echo '{\"Version\": 1, \"AccessKeyId\": \"AccessKey123\"}'");
+#endif
+AWS_STATIC_STRING_FROM_LITERAL(s_expected_output, "{\"Version\": 1, \"AccessKeyId\": \"AccessKey123\"}");
+
+static int s_run_command_test_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_run_command_options options = {
+        .allocator = allocator,
+        .command = aws_string_c_str(s_test_command)
+    };
+
+    struct aws_run_command_result *result = aws_run_command(options);
+    ASSERT_NOT_NULL(result);
+
+    ASSERT_BIN_ARRAYS_EQUALS(
+        result->std_out->bytes, result->std_out->len, s_expected_output->bytes, s_expected_output->len);
+
+    aws_run_command_result_destroy(result);
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(run_command_test, s_run_command_test_fn)

--- a/tests/process_test.c
+++ b/tests/process_test.c
@@ -36,18 +36,36 @@ AWS_STATIC_STRING_FROM_LITERAL(s_test_command, "echo '{\"Version\": 1, \"AccessK
 #endif
 AWS_STATIC_STRING_FROM_LITERAL(s_expected_output, "{\"Version\": 1, \"AccessKeyId\": \"AccessKey123\"}");
 
-static int s_run_command_test_fn(struct aws_allocator *allocator, void *ctx) {
+static int s_run_command_test_success_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
-    struct aws_run_command_options options = {.allocator = allocator, .command = aws_string_c_str(s_test_command)};
+    struct aws_run_command_options options = {.command = aws_string_c_str(s_test_command)};
 
-    struct aws_run_command_result *result = aws_run_command(options);
-    ASSERT_NOT_NULL(result);
+    struct aws_run_command_result result;
+    ASSERT_SUCCESS(aws_run_command_result_init(allocator, &result));
+    ASSERT_SUCCESS(aws_run_command(allocator, &options, &result));
+    ASSERT_TRUE(result.ret_code == 0);
+    ASSERT_NOT_NULL(result.std_out);
 
     ASSERT_BIN_ARRAYS_EQUALS(
-        result->std_out->bytes, result->std_out->len, s_expected_output->bytes, s_expected_output->len);
+        result.std_out->bytes, result.std_out->len, s_expected_output->bytes, s_expected_output->len);
 
-    aws_run_command_result_destroy(result);
+    aws_run_command_result_cleanup(&result);
     return AWS_OP_SUCCESS;
 }
+AWS_TEST_CASE(run_command_test_success, s_run_command_test_success_fn)
 
-AWS_TEST_CASE(run_command_test, s_run_command_test_fn)
+AWS_STATIC_STRING_FROM_LITERAL(s_bad_command, "/i/dont/know/what/is/this/command");
+static int s_run_command_test_bad_command_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct aws_run_command_options options = {.command = aws_string_c_str(s_bad_command)};
+
+    struct aws_run_command_result result;
+    ASSERT_SUCCESS(aws_run_command_result_init(allocator, &result));
+    ASSERT_SUCCESS(aws_run_command(allocator, &options, &result));
+    ASSERT_TRUE(result.ret_code != 0);
+    ASSERT_NULL(result.std_out);
+
+    aws_run_command_result_cleanup(&result);
+    return AWS_OP_SUCCESS;
+}
+AWS_TEST_CASE(run_command_test_bad_command, s_run_command_test_bad_command_fn)


### PR DESCRIPTION
*Issue #, if available:*
For process creds provider, we need to capture external executable's output.

*Description of changes:*
Though the code for posix and windows are almost the same, except the difference between `_popen _pclose` and `popen pclose`. I didn't merge them together in case later we will need more functionalities.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
