### PR TITLE
remove unnecessary uses of __CPROVER_allocated_memory

### DIFF
--- a/.cbmc-batch/jobs/aws_hash_table_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_hash_table_clean_up/Makefile
@@ -12,15 +12,14 @@
 # limitations under the License.
 
 ###########
-#4: 24s
-#8: 50s
+#4: 60s
+#8: 1m50s
 #16: 6m30s
 MAX_TABLE_SIZE ?= 8
 
 include ../Makefile.aws_hash_table
 
 UNWINDSET += aws_hash_table_clear.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
-UNWINDSET += memset_override_0_impl.0:$(shell echo $$((1 + $(TABLE_SIZE_IN_WORDS))))
 
 CBMCFLAGS +=
 
@@ -28,7 +27,6 @@ DEPENDENCIES += $(HELPERDIR)/source/make_common_data_structures.c
 DEPENDENCIES += $(HELPERDIR)/source/proof_allocators.c
 DEPENDENCIES += $(HELPERDIR)/source/utils.c
 DEPENDENCIES += $(HELPERDIR)/stubs/error.c
-DEPENDENCIES += $(HELPERDIR)/stubs/memset_override_0.c
 DEPENDENCIES += $(SRCDIR)/source/common.c
 DEPENDENCIES += $(SRCDIR)/source/hash_table.c
 

--- a/.cbmc-batch/jobs/aws_hash_table_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_hash_table_clean_up/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_hash_table_clear.0:9,memset_override_0_impl.0:35;--object-bits;8"
-goto: aws_hash_table_clean_up_harness.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_hash_table_clear.0:9;--object-bits;8"
 expected: "SUCCESSFUL"
+goto: aws_hash_table_clean_up_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_string_destroy_secure/aws_string_destroy_secure_harness.c
+++ b/.cbmc-batch/jobs/aws_string_destroy_secure/aws_string_destroy_secure_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  * this file except in compliance with the License. A copy of the License is
@@ -21,11 +21,19 @@ void aws_string_destroy_secure_harness() {
     struct aws_string *str = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
     char const *bytes = str->bytes;
     size_t len = str->len;
-    /* Tell CBMC to keep the buffer live after the free */
-    __CPROVER_allocated_memory(bytes, len);
     bool nondet_parameter;
     aws_string_destroy_secure(nondet_parameter ? str : NULL);
+
+    // Check that all bytes are 0.  Since the memory is freed, this will trigger a use-after-free check
+    // Disabiling the check only for this bit of the harness.
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
     if (nondet_parameter) {
-        assert_all_zeroes(bytes, len);
+        if (len > 0) {
+            size_t i;
+            __CPROVER_assume(i < len);
+            assert(bytes[i] == 0);
+        }
     }
+#pragma CPROVER check pop
 }

--- a/.cbmc-batch/jobs/aws_string_destroy_secure/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_string_destroy_secure/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_string_destroy_secure_harness.goto
 expected: "SUCCESSFUL"
+goto: aws_string_destroy_secure_harness.goto
+jobos: ubuntu16


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`__CPOVER_allocated_memory` was used to allow CBMC proofs to check that memory was zeroed before being released.  However, this affects the entire proof, not just the check at the end, and could cause us to miss a use-after-free. Use `#pragma` in a surgical fashion instead.

Supercedes https://github.com/awslabs/aws-c-common/pull/626

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
