### PR TITLE
Revert "Remove unused linked_hash_table datastructure (#490)"

### DIFF
--- a/include/aws/common/linked_hash_table.h
+++ b/include/aws/common/linked_hash_table.h
@@ -1,0 +1,111 @@
+#ifndef AWS_COMMON_LINKED_HASH_TABLE_H
+#define AWS_COMMON_LINKED_HASH_TABLE_H
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/common/hash_table.h>
+#include <aws/common/linked_list.h>
+
+/**
+ * Simple linked hash table. Preserves insertion order, and can be iterated in insertion order.
+ *
+ * You can also change the order safely without altering the shape of the underlying hash table.
+ */
+struct aws_linked_hash_table {
+    struct aws_allocator *allocator;
+    struct aws_linked_list list;
+    struct aws_hash_table table;
+    aws_hash_callback_destroy_fn *user_on_value_destroy;
+};
+
+/**
+ * Linked-List node stored in the table. This is the node type that will be returned in
+ * aws_linked_hash_table_get_iteration_list().
+ */
+struct aws_linked_hash_table_node {
+    struct aws_linked_list_node node;
+    struct aws_linked_hash_table *table;
+    const void *key;
+    void *value;
+};
+
+AWS_EXTERN_C_BEGIN
+
+/**
+ * Initializes the table. Sets up the underlying hash table and linked list.
+ * For the other parameters, see aws/common/hash_table.h. Hash table
+ * semantics of these arguments are preserved.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_init(
+    struct aws_linked_hash_table *table,
+    struct aws_allocator *allocator,
+    aws_hash_fn *hash_fn,
+    aws_hash_callback_eq_fn *equals_fn,
+    aws_hash_callback_destroy_fn *destroy_key_fn,
+    aws_hash_callback_destroy_fn *destroy_value_fn,
+    size_t initial_item_count);
+
+/**
+ * Cleans up the table. Elements in the table will be evicted and cleanup
+ * callbacks will be invoked.
+ */
+AWS_COMMON_API
+void aws_linked_hash_table_clean_up(struct aws_linked_hash_table *table);
+
+/**
+ * Finds element in the table by key. If found, AWS_OP_SUCCESS will be
+ * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be
+ * NULL.
+ *
+ * If any errors occur AWS_OP_ERR will be returned.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *key, void **p_value);
+
+/**
+ * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_put(struct aws_linked_hash_table *table, const void *key, void *p_value);
+
+/**
+ * Removes item at `key` from the table.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_remove(struct aws_linked_hash_table *table, const void *key);
+
+/**
+ * Clears all items from the table.
+ */
+AWS_COMMON_API
+void aws_linked_hash_table_clear(struct aws_linked_hash_table *table);
+
+/**
+ * returns number of elements in the table.
+ */
+AWS_COMMON_API
+size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_table *table);
+
+/**
+ * returns the underlying linked list for iteration.
+ *
+ * The returned list has nodes of the type: aws_linked_hash_table_node. Use AWS_CONTAINER_OF for access to the element.
+ */
+AWS_COMMON_API
+const struct aws_linked_list *aws_linked_hash_table_get_iteration_list(struct aws_linked_hash_table *table);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_LINKED_HASH_TABLE_H */

--- a/source/linked_hash_table.c
+++ b/source/linked_hash_table.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/common/linked_hash_table.h>
+
+static void s_element_destroy(void *value) {
+    struct aws_linked_hash_table_node *node = value;
+
+    if (node->table->user_on_value_destroy) {
+        node->table->user_on_value_destroy(node->value);
+    }
+
+    aws_linked_list_remove(&node->node);
+    aws_mem_release(node->table->allocator, node);
+}
+
+int aws_linked_hash_table_init(
+    struct aws_linked_hash_table *table,
+    struct aws_allocator *allocator,
+    aws_hash_fn *hash_fn,
+    aws_hash_callback_eq_fn *equals_fn,
+    aws_hash_callback_destroy_fn *destroy_key_fn,
+    aws_hash_callback_destroy_fn *destroy_value_fn,
+    size_t initial_item_count) {
+    AWS_ASSERT(table);
+    AWS_ASSERT(allocator);
+    AWS_ASSERT(hash_fn);
+    AWS_ASSERT(equals_fn);
+
+    table->allocator = allocator;
+    table->user_on_value_destroy = destroy_value_fn;
+
+    aws_linked_list_init(&table->list);
+    return aws_hash_table_init(
+        &table->table, allocator, initial_item_count, hash_fn, equals_fn, destroy_key_fn, s_element_destroy);
+}
+
+void aws_linked_hash_table_clean_up(struct aws_linked_hash_table *table) {
+    /* clearing the table will remove all elements. That will also deallocate
+     * any table entries we currently have. */
+    aws_hash_table_clean_up(&table->table);
+    AWS_ZERO_STRUCT(*table);
+}
+
+int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *key, void **p_value) {
+
+    struct aws_hash_element *element = NULL;
+    int err_val = aws_hash_table_find(&table->table, key, &element);
+
+    if (err_val || !element) {
+        *p_value = NULL;
+        return err_val;
+    }
+
+    struct aws_linked_hash_table_node *linked_node = element->value;
+    *p_value = linked_node->value;
+
+    return AWS_OP_SUCCESS;
+}
+
+int aws_linked_hash_table_put(struct aws_linked_hash_table *table, const void *key, void *p_value) {
+
+    struct aws_linked_hash_table_node *node =
+        aws_mem_calloc(table->allocator, 1, sizeof(struct aws_linked_hash_table_node));
+
+    if (!node) {
+        return AWS_OP_ERR;
+    }
+
+    struct aws_hash_element *element = NULL;
+    int was_added = 0;
+    int err_val = aws_hash_table_create(&table->table, key, &element, &was_added);
+
+    if (err_val) {
+        aws_mem_release(table->allocator, node);
+        return err_val;
+    }
+
+    if (element->value) {
+        s_element_destroy(element->value);
+    }
+
+    node->value = p_value;
+    node->key = key;
+    node->table = table;
+    element->value = node;
+
+    aws_linked_list_push_back(&table->list, &node->node);
+
+    return AWS_OP_SUCCESS;
+}
+
+int aws_linked_hash_table_remove(struct aws_linked_hash_table *table, const void *key) {
+    /* allocated table memory and the linked list entry will be removed in the
+     * callback. */
+    return aws_hash_table_remove(&table->table, key, NULL, NULL);
+}
+
+void aws_linked_hash_table_clear(struct aws_linked_hash_table *table) {
+    /* clearing the table will remove all elements. That will also deallocate
+     * any entries we currently have. */
+    aws_hash_table_clear(&table->table);
+}
+
+size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_table *table) {
+    return aws_hash_table_get_entry_count(&table->table);
+}
+
+const struct aws_linked_list *aws_linked_hash_table_get_iteration_list(struct aws_linked_hash_table *table) {
+    return &table->list;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,6 +169,9 @@ add_test_case(test_hash_table_cleanup_idempotent)
 add_test_case(test_hash_table_byte_cursor_create_find)
 add_test_case(test_hash_combine)
 
+add_test_case(test_linked_hash_table_preserves_insertion_order)
+add_test_case(test_linked_hash_table_entries_cleanup)
+
 add_test_case(test_is_power_of_two)
 add_test_case(test_round_up_to_power_of_two)
 add_test_case(test_mul_size_checked)

--- a/tests/linked_hash_table_test.c
+++ b/tests/linked_hash_table_test.c
@@ -1,0 +1,141 @@
+/*
+ *  Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+#include <aws/common/linked_hash_table.h>
+#include <aws/testing/aws_test_harness.h>
+
+static int s_test_linked_hash_table_preserves_insertion_order_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_linked_hash_table table;
+
+    ASSERT_SUCCESS(
+        aws_linked_hash_table_init(&table, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+    const char *third_key = "third";
+    const char *fourth_key = "fourth";
+
+    int first = 1;
+    int second = 2;
+    int third = 3;
+    int fourth = 4;
+
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, first_key, &first));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, second_key, &second));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, third_key, &third));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, fourth_key, &fourth));
+
+    ASSERT_INT_EQUALS(4, aws_linked_hash_table_get_element_count(&table));
+
+    int *value = NULL;
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, first_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(first, *value);
+
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, second_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(second, *value);
+
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, third_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(third, *value);
+
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, fourth_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(fourth, *value);
+
+    const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&table);
+    ASSERT_NOT_NULL(list);
+
+    struct aws_linked_list_node *node = aws_linked_list_front(list);
+
+    struct aws_linked_hash_table_node *table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(first, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_NOT_NULL(node);
+    table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(second, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_NOT_NULL(node);
+    table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(third, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_NOT_NULL(node);
+    table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(fourth, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_PTR_EQUALS(aws_linked_list_end(list), node);
+
+    aws_linked_hash_table_clean_up(&table);
+    return 0;
+}
+
+AWS_TEST_CASE(test_linked_hash_table_preserves_insertion_order, s_test_linked_hash_table_preserves_insertion_order_fn)
+
+struct linked_hash_table_test_value_element {
+    bool value_removed;
+};
+
+static void s_linked_hash_table_element_value_destroy(void *value) {
+    struct linked_hash_table_test_value_element *value_element = value;
+    value_element->value_removed = true;
+}
+
+static int s_test_linked_hash_table_entries_cleanup_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_linked_hash_table table;
+
+    ASSERT_SUCCESS(aws_linked_hash_table_init(
+        &table,
+        allocator,
+        aws_hash_c_string,
+        aws_hash_callback_c_str_eq,
+        NULL,
+        s_linked_hash_table_element_value_destroy,
+        2));
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+
+    struct linked_hash_table_test_value_element first = {.value_removed = false};
+    struct linked_hash_table_test_value_element second = {.value_removed = false};
+
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, first_key, &first));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, second_key, &second));
+    ASSERT_INT_EQUALS(2, aws_linked_hash_table_get_element_count(&table));
+
+    ASSERT_SUCCESS(aws_linked_hash_table_remove(&table, second_key));
+
+    ASSERT_TRUE(second.value_removed);
+    ASSERT_INT_EQUALS(1, aws_linked_hash_table_get_element_count(&table));
+
+    aws_linked_hash_table_clear(&table);
+    ASSERT_INT_EQUALS(0, aws_linked_hash_table_get_element_count(&table));
+
+    ASSERT_TRUE(first.value_removed);
+    ASSERT_TRUE(aws_linked_list_empty(aws_linked_hash_table_get_iteration_list(&table)));
+
+    aws_linked_hash_table_clean_up(&table);
+    return 0;
+}
+
+AWS_TEST_CASE(test_linked_hash_table_entries_cleanup, s_test_linked_hash_table_entries_cleanup_fn)


### PR DESCRIPTION
This reverts commit 049b4812da213644523d8ccd1983fa444928ea05.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
