### PR TITLE
Caches

### DIFF
--- a/include/aws/common/cache.h
+++ b/include/aws/common/cache.h
@@ -25,10 +25,6 @@ struct aws_cache_vtable {
     int (*remove)(struct aws_cache *cache, const void *key);
     void (*clear)(struct aws_cache *cache);
     size_t (*get_element_count)(const struct aws_cache *cache);
-
-    /* LRU-only functions */
-    void *(*use_lru_element)(struct aws_cache *cache);
-    void *(*get_mru_element)(const struct aws_cache *cache);
 };
 
 /**
@@ -39,6 +35,8 @@ struct aws_cache {
     const struct aws_cache_vtable *vtable;
     struct aws_linked_hash_table table;
     size_t max_items;
+
+    void *impl;
 };
 
 /* Default implementations */
@@ -66,7 +64,7 @@ int aws_cache_find(struct aws_cache *cache, const void *key, void **p_value);
 
 /**
  * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
- * item will be removed based on the implementation.
+ * an item will be removed based on the cache policy.
  */
 AWS_COMMON_API
 int aws_cache_put(struct aws_cache *cache, const void *key, void *p_value);

--- a/include/aws/common/cache.h
+++ b/include/aws/common/cache.h
@@ -1,0 +1,94 @@
+#ifndef AWS_COMMON_CACHE_H
+#define AWS_COMMON_CACHE_H
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/linked_hash_table.h>
+
+struct aws_cache;
+
+struct aws_cache_vtable {
+    void (*clean_up)(struct aws_cache *cache);
+    int (*find)(struct aws_cache *cache, const void *key, void **p_value);
+    int (*put)(struct aws_cache *cache, const void *key, void *p_value);
+    int (*remove)(struct aws_cache *cache, const void *key);
+    void (*clear)(struct aws_cache *cache);
+    size_t (*get_element_count)(const struct aws_cache *cache);
+
+    /* LRU-only functions */
+    void *(*use_lru_element)(struct aws_cache *cache);
+    void *(*get_mru_element)(const struct aws_cache *cache);
+};
+
+/**
+ * Base stucture for caches using the linked hash table implementation.
+ */
+struct aws_cache {
+    struct aws_allocator *allocator;
+    const struct aws_cache_vtable *vtable;
+    struct aws_linked_hash_table table;
+    size_t max_items;
+};
+
+int aws_cache_base_find(struct aws_cache *cache, const void *key, void **p_value);
+int aws_cache_base_remove(struct aws_cache *cache, const void *key);
+void aws_cache_base_clear(struct aws_cache *cache);
+size_t aws_cache_base_get_element_count(const struct aws_cache *cache);
+
+AWS_EXTERN_C_BEGIN
+/**
+ * Cleans up the cache. Elements in the cache will be evicted and cleanup
+ * callbacks will be invoked.
+ */
+AWS_COMMON_API
+void aws_cache_clean_up(struct aws_cache *cache);
+
+/**
+ * Finds element in the cache by key. If found, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
+ * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be NULL.
+ *
+ * If any errors occur AWS_OP_ERR will be returned.
+ */
+AWS_COMMON_API
+int aws_cache_find(struct aws_cache *cache, const void *key, void **p_value);
+
+/**
+ * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
+ * based on the implementation, item will be removed.
+ */
+AWS_COMMON_API
+int aws_cache_put(struct aws_cache *cache, const void *key, void *p_value);
+
+/**
+ * Removes item at `key` from the cache.
+ */
+AWS_COMMON_API
+int aws_cache_remove(struct aws_cache *cache, const void *key);
+
+/**
+ * Clears all items from the cache.
+ */
+AWS_COMMON_API
+void aws_cache_clear(struct aws_cache *cache);
+
+/**
+ * Returns the number of elements in the cache.
+ */
+AWS_COMMON_API
+size_t aws_cache_get_element_count(const struct aws_cache *cache);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_FIFO_CACHE_H */

--- a/include/aws/common/cache.h
+++ b/include/aws/common/cache.h
@@ -20,7 +20,6 @@
 struct aws_cache;
 
 struct aws_cache_vtable {
-    void (*clean_up)(struct aws_cache *cache);
     int (*find)(struct aws_cache *cache, const void *key, void **p_value);
     int (*put)(struct aws_cache *cache, const void *key, void *p_value);
     int (*remove)(struct aws_cache *cache, const void *key);
@@ -33,7 +32,7 @@ struct aws_cache_vtable {
 };
 
 /**
- * Base stucture for caches using the linked hash table implementation.
+ * Base stucture for caches, used the linked hash table implementation.
  */
 struct aws_cache {
     struct aws_allocator *allocator;
@@ -42,10 +41,11 @@ struct aws_cache {
     size_t max_items;
 };
 
-int aws_cache_base_find(struct aws_cache *cache, const void *key, void **p_value);
-int aws_cache_base_remove(struct aws_cache *cache, const void *key);
-void aws_cache_base_clear(struct aws_cache *cache);
-size_t aws_cache_base_get_element_count(const struct aws_cache *cache);
+/* Default implementations */
+int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
+int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
+void aws_cache_base_default_clear(struct aws_cache *cache);
+size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
 
 AWS_EXTERN_C_BEGIN
 /**
@@ -66,7 +66,7 @@ int aws_cache_find(struct aws_cache *cache, const void *key, void **p_value);
 
 /**
  * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
- * based on the implementation, item will be removed.
+ * item will be removed based on the implementation.
  */
 AWS_COMMON_API
 int aws_cache_put(struct aws_cache *cache, const void *key, void *p_value);

--- a/include/aws/common/fifo_cache.h
+++ b/include/aws/common/fifo_cache.h
@@ -15,14 +15,13 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/linked_hash_table.h>
+#include <aws/common/cache.h>
 
 /**
  * Simple first-in-first-out cache using the linked hash table implementation.
  */
 struct aws_fifo_cache {
-    struct aws_linked_hash_table table;
-    size_t max_items;
+    struct aws_cache base;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -34,55 +33,13 @@ AWS_EXTERN_C_BEGIN
  * semantics of these arguments are preserved.
  */
 AWS_COMMON_API
-int aws_fifo_cache_init(
-    struct aws_fifo_cache *cache,
+struct aws_cache *aws_cache_new_fifo(
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
     aws_hash_callback_destroy_fn *destroy_key_fn,
     aws_hash_callback_destroy_fn *destroy_value_fn,
     size_t max_items);
-
-/**
- * Cleans up the cache. Elements in the cache will be evicted and cleanup
- * callbacks will be invoked.
- */
-AWS_COMMON_API
-void aws_fifo_cache_clean_up(struct aws_fifo_cache *cache);
-
-/**
- * Finds element in the cache by key. If found, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
- * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be NULL.
- *
- * If any errors occur AWS_OP_ERR will be returned.
- */
-AWS_COMMON_API
-int aws_fifo_cache_find(struct aws_fifo_cache *cache, const void *key, void **p_value);
-
-/**
- * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
- * the oldest item will be removed.
- */
-AWS_COMMON_API
-int aws_fifo_cache_put(struct aws_fifo_cache *cache, const void *key, void *p_value);
-
-/**
- * Removes item at `key` from the cache.
- */
-AWS_COMMON_API
-int aws_fifo_cache_remove(struct aws_fifo_cache *cache, const void *key);
-
-/**
- * Clears all items from the cache.
- */
-AWS_COMMON_API
-void aws_fifo_cache_clear(struct aws_fifo_cache *cache);
-
-/**
- * Returns the number of elements in the cache.
- */
-AWS_COMMON_API
-size_t aws_fifo_cache_get_element_count(const struct aws_fifo_cache *cache);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/fifo_cache.h
+++ b/include/aws/common/fifo_cache.h
@@ -1,0 +1,90 @@
+#ifndef AWS_COMMON_FIFO_CACHE_H
+#define AWS_COMMON_FIFO_CACHE_H
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/linked_hash_table.h>
+
+/**
+ * Simple first-in-first-out cache using the linked hash table implementation.
+ */
+struct aws_fifo_cache {
+    struct aws_allocator *allocator;
+    struct aws_linked_hash_table table;
+    size_t max_items;
+};
+
+AWS_EXTERN_C_BEGIN
+
+/**
+ * Initializes the cache. Sets up the underlying linked hash table.
+ * Once `max_items` elements have been added, the oldest(first-in) item will
+ * be removed. For the other parameters, see aws/common/hash_table.h. Hash table
+ * semantics of these arguments are preserved.
+ */
+AWS_COMMON_API
+int aws_fifo_cache_init(
+    struct aws_fifo_cache *cache,
+    struct aws_allocator *allocator,
+    aws_hash_fn *hash_fn,
+    aws_hash_callback_eq_fn *equals_fn,
+    aws_hash_callback_destroy_fn *destroy_key_fn,
+    aws_hash_callback_destroy_fn *destroy_value_fn,
+    size_t max_items);
+
+/**
+ * Cleans up the cache. Elements in the cache will be evicted and cleanup
+ * callbacks will be invoked.
+ */
+AWS_COMMON_API
+void aws_fifo_cache_clean_up(struct aws_fifo_cache *cache);
+
+/**
+ * Finds element in the cache by key. If found, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
+ * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be NULL.
+ *
+ * If any errors occur AWS_OP_ERR will be returned.
+ */
+AWS_COMMON_API
+int aws_fifo_cache_find(struct aws_fifo_cache *cache, const void *key, void **p_value);
+
+/**
+ * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
+ * the oldest item will be removed.
+ */
+AWS_COMMON_API
+int aws_fifo_cache_put(struct aws_fifo_cache *cache, const void *key, void *p_value);
+
+/**
+ * Removes item at `key` from the cache.
+ */
+AWS_COMMON_API
+int aws_fifo_cache_remove(struct aws_fifo_cache *cache, const void *key);
+
+/**
+ * Clears all items from the cache.
+ */
+AWS_COMMON_API
+void aws_fifo_cache_clear(struct aws_fifo_cache *cache);
+
+/**
+ * Returns the number of elements in the cache.
+ */
+AWS_COMMON_API
+size_t aws_fifo_cache_get_element_count(const struct aws_fifo_cache *cache);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_FIFO_CACHE_H */

--- a/include/aws/common/fifo_cache.h
+++ b/include/aws/common/fifo_cache.h
@@ -17,17 +17,10 @@
 
 #include <aws/common/cache.h>
 
-/**
- * Simple first-in-first-out cache using the linked hash table implementation.
- */
-struct aws_fifo_cache {
-    struct aws_cache base;
-};
-
 AWS_EXTERN_C_BEGIN
 
 /**
- * Initializes the cache. Sets up the underlying linked hash table.
+ * Initializes the first-in-first-out cache. Sets up the underlying linked hash table.
  * Once `max_items` elements have been added, the oldest(first-in) item will
  * be removed. For the other parameters, see aws/common/hash_table.h. Hash table
  * semantics of these arguments are preserved.

--- a/include/aws/common/lifo_cache.h
+++ b/include/aws/common/lifo_cache.h
@@ -15,14 +15,13 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/linked_hash_table.h>
+#include <aws/common/cache.h>
 
 /**
  * Simple last-in-first-out cache using the linked hash table implementation.
  */
 struct aws_lifo_cache {
-    struct aws_linked_hash_table table;
-    size_t max_items;
+    struct aws_cache base;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -34,55 +33,13 @@ AWS_EXTERN_C_BEGIN
  * semantics of these arguments are preserved.
  */
 AWS_COMMON_API
-int aws_lifo_cache_init(
-    struct aws_lifo_cache *cache,
+struct aws_cache *aws_cache_new_lifo(
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
     aws_hash_callback_destroy_fn *destroy_key_fn,
     aws_hash_callback_destroy_fn *destroy_value_fn,
     size_t max_items);
-
-/**
- * Cleans up the cache. Elements in the cache will be evicted and cleanup
- * callbacks will be invoked.
- */
-AWS_COMMON_API
-void aws_lifo_cache_clean_up(struct aws_lifo_cache *cache);
-
-/**
- * Finds element in the cache by key. If found, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
- * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be NULL.
- *
- * If any errors occur AWS_OP_ERR will be returned.
- */
-AWS_COMMON_API
-int aws_lifo_cache_find(struct aws_lifo_cache *cache, const void *key, void **p_value);
-
-/**
- * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
- * the latest item will be removed.
- */
-AWS_COMMON_API
-int aws_lifo_cache_put(struct aws_lifo_cache *cache, const void *key, void *p_value);
-
-/**
- * Removes item at `key` from the cache.
- */
-AWS_COMMON_API
-int aws_lifo_cache_remove(struct aws_lifo_cache *cache, const void *key);
-
-/**
- * Clears all items from the cache.
- */
-AWS_COMMON_API
-void aws_lifo_cache_clear(struct aws_lifo_cache *cache);
-
-/**
- * Returns the number of elements in the cache.
- */
-AWS_COMMON_API
-size_t aws_lifo_cache_get_element_count(const struct aws_lifo_cache *cache);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/lifo_cache.h
+++ b/include/aws/common/lifo_cache.h
@@ -17,17 +17,10 @@
 
 #include <aws/common/cache.h>
 
-/**
- * Simple last-in-first-out cache using the linked hash table implementation.
- */
-struct aws_lifo_cache {
-    struct aws_cache base;
-};
-
 AWS_EXTERN_C_BEGIN
 
 /**
- * Initializes the cache. Sets up the underlying linked hash table.
+ * Initializes the last-in-first-out cache. Sets up the underlying linked hash table.
  * Once `max_items` elements have been added, the latest(last-in) item will
  * be removed. For the other parameters, see aws/common/hash_table.h. Hash table
  * semantics of these arguments are preserved.

--- a/include/aws/common/lifo_cache.h
+++ b/include/aws/common/lifo_cache.h
@@ -1,0 +1,90 @@
+#ifndef AWS_COMMON_LIFO_CACHE_H
+#define AWS_COMMON_LIFO_CACHE_H
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/linked_hash_table.h>
+
+/**
+ * Simple last-in-first-out cache using the linked hash table implementation.
+ */
+struct aws_lifo_cache {
+    struct aws_allocator *allocator;
+    struct aws_linked_hash_table table;
+    size_t max_items;
+};
+
+AWS_EXTERN_C_BEGIN
+
+/**
+ * Initializes the cache. Sets up the underlying linked hash table.
+ * Once `max_items` elements have been added, the latest(last-in) item will
+ * be removed. For the other parameters, see aws/common/hash_table.h. Hash table
+ * semantics of these arguments are preserved.
+ */
+AWS_COMMON_API
+int aws_lifo_cache_init(
+    struct aws_lifo_cache *cache,
+    struct aws_allocator *allocator,
+    aws_hash_fn *hash_fn,
+    aws_hash_callback_eq_fn *equals_fn,
+    aws_hash_callback_destroy_fn *destroy_key_fn,
+    aws_hash_callback_destroy_fn *destroy_value_fn,
+    size_t max_items);
+
+/**
+ * Cleans up the cache. Elements in the cache will be evicted and cleanup
+ * callbacks will be invoked.
+ */
+AWS_COMMON_API
+void aws_lifo_cache_clean_up(struct aws_lifo_cache *cache);
+
+/**
+ * Finds element in the cache by key. If found, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
+ * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be NULL.
+ *
+ * If any errors occur AWS_OP_ERR will be returned.
+ */
+AWS_COMMON_API
+int aws_lifo_cache_find(struct aws_lifo_cache *cache, const void *key, void **p_value);
+
+/**
+ * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. If the cache is already full,
+ * the latest item will be removed.
+ */
+AWS_COMMON_API
+int aws_lifo_cache_put(struct aws_lifo_cache *cache, const void *key, void *p_value);
+
+/**
+ * Removes item at `key` from the cache.
+ */
+AWS_COMMON_API
+int aws_lifo_cache_remove(struct aws_lifo_cache *cache, const void *key);
+
+/**
+ * Clears all items from the cache.
+ */
+AWS_COMMON_API
+void aws_lifo_cache_clear(struct aws_lifo_cache *cache);
+
+/**
+ * Returns the number of elements in the cache.
+ */
+AWS_COMMON_API
+size_t aws_lifo_cache_get_element_count(const struct aws_lifo_cache *cache);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_LIFO_CACHE_H */

--- a/include/aws/common/linked_hash_table.h
+++ b/include/aws/common/linked_hash_table.h
@@ -75,12 +75,11 @@ AWS_COMMON_API
 int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *key, void **p_value);
 
 /**
- * Finds element in the table by key. If found, AWS_OP_SUCCESS will be
- * returned. And move it to the back of the list.
- * If not found, AWS_OP_SUCCESS will be returned and *p_value will be
- * NULL.
+ * Finds element in the table by key. If found, AWS_OP_SUCCESS will be returned and the item will be moved to the back
+ * of the list.
+ * If not found, AWS_OP_SUCCESS will be returned and *p_value will be NULL.
  *
- * Note: it will break the order!!
+ * Note: this will change the order of elements
  */
 AWS_COMMON_API
 int aws_linked_hash_table_find_and_move_to_back(struct aws_linked_hash_table *table, const void *key, void **p_value);
@@ -112,7 +111,7 @@ size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_tabl
 /**
  * Move the aws_linked_hash_table_node to the end of the list.
  *
- * Note: it will break the order!!
+ * Note: this will change the order of elements
  */
 AWS_COMMON_API
 void aws_linked_hash_table_move_node_to_end_of_list(

--- a/include/aws/common/linked_hash_table.h
+++ b/include/aws/common/linked_hash_table.h
@@ -76,10 +76,10 @@ int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *
 
 /**
  * Finds element in the table by key. If found, AWS_OP_SUCCESS will be
- * returned. And move it to the back of the list. 
+ * returned. And move it to the back of the list.
  * If not found, AWS_OP_SUCCESS will be returned and *p_value will be
  * NULL.
- * 
+ *
  * Note: it will break the order!!
  */
 AWS_COMMON_API
@@ -110,8 +110,8 @@ AWS_COMMON_API
 size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_table *table);
 
 /**
- * Move the aws_linked_hash_table_node to the end of the list. 
- * 
+ * Move the aws_linked_hash_table_node to the end of the list.
+ *
  * Note: it will break the order!!
  */
 AWS_COMMON_API

--- a/include/aws/common/linked_hash_table.h
+++ b/include/aws/common/linked_hash_table.h
@@ -1,0 +1,111 @@
+#ifndef AWS_COMMON_LINKED_HASH_TABLE_H
+#define AWS_COMMON_LINKED_HASH_TABLE_H
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/common/hash_table.h>
+#include <aws/common/linked_list.h>
+
+/**
+ * Simple linked hash table. Preserves insertion order, and can be iterated in insertion order.
+ *
+ * You can also change the order safely without altering the shape of the underlying hash table.
+ */
+struct aws_linked_hash_table {
+    struct aws_allocator *allocator;
+    struct aws_linked_list list;
+    struct aws_hash_table table;
+    aws_hash_callback_destroy_fn *user_on_value_destroy;
+};
+
+/**
+ * Linked-List node stored in the table. This is the node type that will be returned in
+ * aws_linked_hash_table_get_iteration_list().
+ */
+struct aws_linked_hash_table_node {
+    struct aws_linked_list_node node;
+    struct aws_linked_hash_table *table;
+    const void *key;
+    void *value;
+};
+
+AWS_EXTERN_C_BEGIN
+
+/**
+ * Initializes the table. Sets up the underlying hash table and linked list.
+ * For the other parameters, see aws/common/hash_table.h. Hash table
+ * semantics of these arguments are preserved.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_init(
+    struct aws_linked_hash_table *table,
+    struct aws_allocator *allocator,
+    aws_hash_fn *hash_fn,
+    aws_hash_callback_eq_fn *equals_fn,
+    aws_hash_callback_destroy_fn *destroy_key_fn,
+    aws_hash_callback_destroy_fn *destroy_value_fn,
+    size_t initial_item_count);
+
+/**
+ * Cleans up the table. Elements in the table will be evicted and cleanup
+ * callbacks will be invoked.
+ */
+AWS_COMMON_API
+void aws_linked_hash_table_clean_up(struct aws_linked_hash_table *table);
+
+/**
+ * Finds element in the table by key. If found, AWS_OP_SUCCESS will be
+ * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be
+ * NULL.
+ *
+ * If any errors occur AWS_OP_ERR will be returned.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *key, void **p_value);
+
+/**
+ * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_put(struct aws_linked_hash_table *table, const void *key, void *p_value);
+
+/**
+ * Removes item at `key` from the table.
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_remove(struct aws_linked_hash_table *table, const void *key);
+
+/**
+ * Clears all items from the table.
+ */
+AWS_COMMON_API
+void aws_linked_hash_table_clear(struct aws_linked_hash_table *table);
+
+/**
+ * returns number of elements in the table.
+ */
+AWS_COMMON_API
+size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_table *table);
+
+/**
+ * returns the underlying linked list for iteration.
+ *
+ * The returned list has nodes of the type: aws_linked_hash_table_node. Use AWS_CONTAINER_OF for access to the element.
+ */
+AWS_COMMON_API
+const struct aws_linked_list *aws_linked_hash_table_get_iteration_list(struct aws_linked_hash_table *table);
+
+AWS_EXTERN_C_END
+
+#endif /* AWS_COMMON_LINKED_HASH_TABLE_H */

--- a/include/aws/common/linked_hash_table.h
+++ b/include/aws/common/linked_hash_table.h
@@ -75,6 +75,17 @@ AWS_COMMON_API
 int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *key, void **p_value);
 
 /**
+ * Finds element in the table by key. If found, AWS_OP_SUCCESS will be
+ * returned. And move it to the back of the list. 
+ * If not found, AWS_OP_SUCCESS will be returned and *p_value will be
+ * NULL.
+ * 
+ * Note: it will break the order!!
+ */
+AWS_COMMON_API
+int aws_linked_hash_table_find_and_move_to_back(struct aws_linked_hash_table *table, const void *key, void **p_value);
+
+/**
  * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced.
  */
 AWS_COMMON_API
@@ -99,12 +110,22 @@ AWS_COMMON_API
 size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_table *table);
 
 /**
+ * Move the aws_linked_hash_table_node to the end of the list. 
+ * 
+ * Note: it will break the order!!
+ */
+AWS_COMMON_API
+void aws_linked_hash_table_move_node_to_end_of_list(
+    struct aws_linked_hash_table *table,
+    struct aws_linked_hash_table_node *node);
+
+/**
  * returns the underlying linked list for iteration.
  *
  * The returned list has nodes of the type: aws_linked_hash_table_node. Use AWS_CONTAINER_OF for access to the element.
  */
 AWS_COMMON_API
-const struct aws_linked_list *aws_linked_hash_table_get_iteration_list(struct aws_linked_hash_table *table);
+const struct aws_linked_list *aws_linked_hash_table_get_iteration_list(const struct aws_linked_hash_table *table);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/lru_cache.h
+++ b/include/aws/common/lru_cache.h
@@ -17,22 +17,13 @@
 
 #include <aws/common/cache.h>
 
-/**
- * Simple Least-recently-used cache using the standard lazy linked hash table
- * implementation. (Yes the one that was the answer to that interview question
- * that one time).
- */
-struct aws_lru_cache {
-    struct aws_cache base;
-};
-
 AWS_EXTERN_C_BEGIN
 
 /**
- * Initializes the cache. Sets up the underlying hash table and linked list.
- * Once `max_items` elements have been added, the least recently used item will
- * be removed. For the other parameters, see aws/common/hash_table.h. Hash table
- * semantics of these arguments are preserved.
+ * Initializes the Least-recently-used cache. Sets up the underlying linked hash table.
+ * Once `max_items` elements have been added, the least recently used item will be removed. For the other parameters,
+ * see aws/common/hash_table.h. Hash table semantics of these arguments are preserved.(Yes the one that was the answer
+ * to that interview question that one time).
  */
 AWS_COMMON_API
 struct aws_cache *aws_cache_new_lru(

--- a/include/aws/common/lru_cache.h
+++ b/include/aws/common/lru_cache.h
@@ -15,7 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/linked_hash_table.h>
+#include <aws/common/cache.h>
 
 /**
  * Simple Least-recently-used cache using the standard lazy linked hash table
@@ -23,8 +23,7 @@
  * that one time).
  */
 struct aws_lru_cache {
-    struct aws_linked_hash_table table;
-    size_t max_items;
+    struct aws_cache base;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -36,8 +35,7 @@ AWS_EXTERN_C_BEGIN
  * semantics of these arguments are preserved.
  */
 AWS_COMMON_API
-int aws_lru_cache_init(
-    struct aws_lru_cache *cache,
+struct aws_cache *aws_cache_new_lru(
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
@@ -46,60 +44,17 @@ int aws_lru_cache_init(
     size_t max_items);
 
 /**
- * Cleans up the cache. Elements in the cache will be evicted and cleanup
- * callbacks will be invoked.
- */
-AWS_COMMON_API
-void aws_lru_cache_clean_up(struct aws_lru_cache *cache);
-
-/**
- * Finds element in the cache by key. If found, it will become most-recently
- * used, *p_value will hold the stored value, and AWS_OP_SUCCESS will be
- * returned. If not found, AWS_OP_SUCCESS will be returned and *p_value will be
- * NULL.
- *
- * If any errors occur AWS_OP_ERR will be returned.
- */
-AWS_COMMON_API
-int aws_lru_cache_find(struct aws_lru_cache *cache, const void *key, void **p_value);
-
-/**
- * Puts `p_value` at `key`. If an element is already stored at `key` it will be replaced. Added item becomes
- * most-recently used. If the cache is already full, the least-recently-used item will be removed.
- */
-AWS_COMMON_API
-int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_value);
-
-/**
- * Removes item at `key` from the cache.
- */
-AWS_COMMON_API
-int aws_lru_cache_remove(struct aws_lru_cache *cache, const void *key);
-
-/**
- * Clears all items from the cache.
- */
-AWS_COMMON_API
-void aws_lru_cache_clear(struct aws_lru_cache *cache);
-
-/**
  * Accesses the least-recently-used element, sets it to most-recently-used
  * element, and returns the value.
  */
 AWS_COMMON_API
-void *aws_lru_cache_use_lru_element(struct aws_lru_cache *cache);
+void *aws_lru_cache_use_lru_element(struct aws_cache *cache);
 
 /**
  * Accesses the most-recently-used element and returns its value.
  */
 AWS_COMMON_API
-void *aws_lru_cache_get_mru_element(const struct aws_lru_cache *cache);
-
-/**
- * Returns the number of elements in the cache.
- */
-AWS_COMMON_API
-size_t aws_lru_cache_get_element_count(const struct aws_lru_cache *cache);
+void *aws_lru_cache_get_mru_element(const struct aws_cache *cache);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/lru_cache.h
+++ b/include/aws/common/lru_cache.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/hash_table.h>
-#include <aws/common/linked_list.h>
+#include <aws/common/linked_hash_table.h>
 
 /**
  * Simple Least-recently-used cache using the standard lazy linked hash table
@@ -25,9 +24,7 @@
  */
 struct aws_lru_cache {
     struct aws_allocator *allocator;
-    struct aws_linked_list list;
-    struct aws_hash_table table;
-    aws_hash_callback_destroy_fn *user_on_value_destroy;
+    struct aws_linked_hash_table table;
     size_t max_items;
 };
 

--- a/source/cache.c
+++ b/source/cache.c
@@ -16,7 +16,8 @@
 
 void aws_cache_clean_up(struct aws_cache *cache) {
     AWS_ASSERT(cache);
-    cache->vtable->clean_up(cache);
+    aws_linked_hash_table_clean_up(&cache->table);
+    aws_mem_release(cache->allocator, cache);
 }
 
 int aws_cache_find(struct aws_cache *cache, const void *key, void **p_value) {
@@ -44,22 +45,22 @@ size_t aws_cache_get_element_count(const struct aws_cache *cache) {
     return cache->vtable->get_element_count(cache);
 }
 
-int aws_cache_base_find(struct aws_cache *cache, const void *key, void **p_value) {
+int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value) {
     return (aws_linked_hash_table_find(&cache->table, key, p_value));
 }
 
-int aws_cache_base_remove(struct aws_cache *cache, const void *key) {
+int aws_cache_base_default_remove(struct aws_cache *cache, const void *key) {
     /* allocated cache memory and the linked list entry will be removed in the
      * callback. */
     return aws_linked_hash_table_remove(&cache->table, key);
 }
 
-void aws_cache_base_clear(struct aws_cache *cache) {
+void aws_cache_base_default_clear(struct aws_cache *cache) {
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clear(&cache->table);
 }
 
-size_t aws_cache_base_get_element_count(const struct aws_cache *cache) {
+size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache) {
     return aws_linked_hash_table_get_element_count(&cache->table);
 }

--- a/source/cache.c
+++ b/source/cache.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/common/cache.h>
+
+void aws_cache_clean_up(struct aws_cache *cache) {
+    AWS_ASSERT(cache);
+    cache->vtable->clean_up(cache);
+}
+
+int aws_cache_find(struct aws_cache *cache, const void *key, void **p_value) {
+    AWS_ASSERT(cache);
+    return cache->vtable->find(cache, key, p_value);
+}
+
+int aws_cache_put(struct aws_cache *cache, const void *key, void *p_value) {
+    AWS_ASSERT(cache);
+    return cache->vtable->put(cache, key, p_value);
+}
+
+int aws_cache_remove(struct aws_cache *cache, const void *key) {
+    AWS_ASSERT(cache);
+    return cache->vtable->remove(cache, key);
+}
+
+void aws_cache_clear(struct aws_cache *cache) {
+    AWS_ASSERT(cache);
+    cache->vtable->clear(cache);
+}
+
+size_t aws_cache_get_element_count(const struct aws_cache *cache) {
+    AWS_ASSERT(cache);
+    return cache->vtable->get_element_count(cache);
+}
+
+int aws_cache_base_find(struct aws_cache *cache, const void *key, void **p_value) {
+    return (aws_linked_hash_table_find(&cache->table, key, p_value));
+}
+
+int aws_cache_base_remove(struct aws_cache *cache, const void *key) {
+    /* allocated cache memory and the linked list entry will be removed in the
+     * callback. */
+    return aws_linked_hash_table_remove(&cache->table, key);
+}
+
+void aws_cache_base_clear(struct aws_cache *cache) {
+    /* clearing the table will remove all elements. That will also deallocate
+     * any cache entries we currently have. */
+    aws_linked_hash_table_clear(&cache->table);
+}
+
+size_t aws_cache_base_get_element_count(const struct aws_cache *cache) {
+    return aws_linked_hash_table_get_element_count(&cache->table);
+}

--- a/source/cache.c
+++ b/source/cache.c
@@ -15,33 +15,33 @@
 #include <aws/common/cache.h>
 
 void aws_cache_clean_up(struct aws_cache *cache) {
-    AWS_ASSERT(cache);
+    AWS_PRECONDITION(cache);
     aws_linked_hash_table_clean_up(&cache->table);
     aws_mem_release(cache->allocator, cache);
 }
 
 int aws_cache_find(struct aws_cache *cache, const void *key, void **p_value) {
-    AWS_ASSERT(cache);
+    AWS_PRECONDITION(cache);
     return cache->vtable->find(cache, key, p_value);
 }
 
 int aws_cache_put(struct aws_cache *cache, const void *key, void *p_value) {
-    AWS_ASSERT(cache);
+    AWS_PRECONDITION(cache);
     return cache->vtable->put(cache, key, p_value);
 }
 
 int aws_cache_remove(struct aws_cache *cache, const void *key) {
-    AWS_ASSERT(cache);
+    AWS_PRECONDITION(cache);
     return cache->vtable->remove(cache, key);
 }
 
 void aws_cache_clear(struct aws_cache *cache) {
-    AWS_ASSERT(cache);
+    AWS_PRECONDITION(cache);
     cache->vtable->clear(cache);
 }
 
 size_t aws_cache_get_element_count(const struct aws_cache *cache) {
-    AWS_ASSERT(cache);
+    AWS_PRECONDITION(cache);
     return cache->vtable->get_element_count(cache);
 }
 

--- a/source/fifo_cache.c
+++ b/source/fifo_cache.c
@@ -22,9 +22,6 @@ static struct aws_cache_vtable s_fifo_cache_vtable = {
     .remove = aws_cache_base_default_remove,
     .clear = aws_cache_base_default_clear,
     .get_element_count = aws_cache_base_default_get_element_count,
-
-    .use_lru_element = NULL,
-    .get_mru_element = NULL,
 };
 
 struct aws_cache *aws_cache_new_fifo(

--- a/source/fifo_cache.c
+++ b/source/fifo_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-#include <aws/common/lru_cache.h>
+#include <aws/common/fifo_cache.h>
 
-int aws_lru_cache_init(
-    struct aws_lru_cache *cache,
+int aws_fifo_cache_init(
+    struct aws_fifo_cache *cache,
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
@@ -32,19 +32,19 @@ int aws_lru_cache_init(
         &cache->table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items);
 }
 
-void aws_lru_cache_clean_up(struct aws_lru_cache *cache) {
+void aws_fifo_cache_clean_up(struct aws_fifo_cache *cache) {
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clean_up(&cache->table);
     AWS_ZERO_STRUCT(*cache);
 }
 
-int aws_lru_cache_find(struct aws_lru_cache *cache, const void *key, void **p_value) {
+int aws_fifo_cache_find(struct aws_fifo_cache *cache, const void *key, void **p_value) {
 
-    return(aws_linked_hash_table_find_and_move_to_back(&cache->table, key, p_value));
+    return(aws_linked_hash_table_find(&cache->table, key, p_value));
 }
 
-int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_value) {
+int aws_fifo_cache_put(struct aws_fifo_cache *cache, const void *key, void *p_value) {
 
     if(!cache->max_items) {
         /* Just for efficiency */
@@ -58,7 +58,7 @@ int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_valu
     /* Manage the space if we actually added a new element and the cache is full. */
     if (aws_linked_hash_table_get_element_count(&cache->table) > cache->max_items) {
         /* we're over the cache size limit. Remove whatever is in the front of
-         * the linked_hash_table, which is the LRU element */
+         * the linked_hash_table, which is the oldest element */
         const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
         struct aws_linked_list_node *node = aws_linked_list_front(list);
         struct aws_linked_hash_table_node *table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
@@ -68,40 +68,18 @@ int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_valu
     return AWS_OP_SUCCESS;
 }
 
-int aws_lru_cache_remove(struct aws_lru_cache *cache, const void *key) {
+int aws_fifo_cache_remove(struct aws_fifo_cache *cache, const void *key) {
     /* allocated cache memory and the linked list entry will be removed in the
      * callback. */
     return aws_linked_hash_table_remove(&cache->table, key);
 }
 
-void aws_lru_cache_clear(struct aws_lru_cache *cache) {
+void aws_fifo_cache_clear(struct aws_fifo_cache *cache) {
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clear(&cache->table);
 }
 
-void *aws_lru_cache_use_lru_element(struct aws_lru_cache *cache) {
-    const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-    if(aws_linked_list_empty(list)) {
-        return NULL;
-    }
-    struct aws_linked_list_node *node = aws_linked_list_front(list);
-    struct aws_linked_hash_table_node *lru_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
-    
-    aws_linked_hash_table_move_node_to_end_of_list(&cache->table, lru_node);
-    return lru_node->value;
-}
-
-void *aws_lru_cache_get_mru_element(const struct aws_lru_cache *cache) {
-    const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-    if(aws_linked_list_empty(list)) {
-        return NULL;
-    }
-    struct aws_linked_list_node *node = aws_linked_list_back(list);
-    struct aws_linked_hash_table_node *mru_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
-    return mru_node->value;
-}
-
-size_t aws_lru_cache_get_element_count(const struct aws_lru_cache *cache) {
+size_t aws_fifo_cache_get_element_count(const struct aws_fifo_cache *cache) {
     return aws_linked_hash_table_get_element_count(&cache->table);
 }

--- a/source/lifo_cache.c
+++ b/source/lifo_cache.c
@@ -21,9 +21,6 @@ static struct aws_cache_vtable s_lifo_cache_vtable = {
     .remove = aws_cache_base_default_remove,
     .clear = aws_cache_base_default_clear,
     .get_element_count = aws_cache_base_default_get_element_count,
-
-    .use_lru_element = NULL,
-    .get_mru_element = NULL,
 };
 
 struct aws_cache *aws_cache_new_lifo(

--- a/source/lifo_cache.c
+++ b/source/lifo_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-#include <aws/common/lru_cache.h>
+#include <aws/common/lifo_cache.h>
 
-int aws_lru_cache_init(
-    struct aws_lru_cache *cache,
+int aws_lifo_cache_init(
+    struct aws_lifo_cache *cache,
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
@@ -32,76 +32,58 @@ int aws_lru_cache_init(
         &cache->table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items);
 }
 
-void aws_lru_cache_clean_up(struct aws_lru_cache *cache) {
+void aws_lifo_cache_clean_up(struct aws_lifo_cache *cache) {
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clean_up(&cache->table);
     AWS_ZERO_STRUCT(*cache);
 }
 
-int aws_lru_cache_find(struct aws_lru_cache *cache, const void *key, void **p_value) {
+int aws_lifo_cache_find(struct aws_lifo_cache *cache, const void *key, void **p_value) {
 
-    return(aws_linked_hash_table_find_and_move_to_back(&cache->table, key, p_value));
+    return (aws_linked_hash_table_find(&cache->table, key, p_value));
 }
 
-int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_value) {
+int aws_lifo_cache_put(struct aws_lifo_cache *cache, const void *key, void *p_value) {
 
-    if(!cache->max_items) {
+    if (!cache->max_items) {
         /* Just for efficiency */
         return AWS_OP_SUCCESS;
     }
 
-    if(aws_linked_hash_table_put(&cache->table, key, p_value)) {
+    if (aws_linked_hash_table_put(&cache->table, key, p_value)) {
         return AWS_OP_ERR;
     }
 
     /* Manage the space if we actually added a new element and the cache is full. */
     if (aws_linked_hash_table_get_element_count(&cache->table) > cache->max_items) {
-        /* we're over the cache size limit. Remove whatever is in the front of
-         * the linked_hash_table, which is the LRU element */
+        /* we're over the cache size limit. Remove whatever is in the one before the back of the linked_hash_table,
+         * which was the latest element before we put the new one */
         const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-        struct aws_linked_list_node *node = aws_linked_list_front(list);
-        struct aws_linked_hash_table_node *table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+        struct aws_linked_list_node *node = aws_linked_list_back(list);
+        if (!node->prev) {
+            return AWS_OP_SUCCESS;
+        }
+        struct aws_linked_hash_table_node *table_node =
+            AWS_CONTAINER_OF(node->prev, struct aws_linked_hash_table_node, node);
         return aws_linked_hash_table_remove(&cache->table, table_node->key);
     }
 
     return AWS_OP_SUCCESS;
 }
 
-int aws_lru_cache_remove(struct aws_lru_cache *cache, const void *key) {
+int aws_lifo_cache_remove(struct aws_lifo_cache *cache, const void *key) {
     /* allocated cache memory and the linked list entry will be removed in the
      * callback. */
     return aws_linked_hash_table_remove(&cache->table, key);
 }
 
-void aws_lru_cache_clear(struct aws_lru_cache *cache) {
+void aws_lifo_cache_clear(struct aws_lifo_cache *cache) {
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clear(&cache->table);
 }
 
-void *aws_lru_cache_use_lru_element(struct aws_lru_cache *cache) {
-    const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-    if(aws_linked_list_empty(list)) {
-        return NULL;
-    }
-    struct aws_linked_list_node *node = aws_linked_list_front(list);
-    struct aws_linked_hash_table_node *lru_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
-    
-    aws_linked_hash_table_move_node_to_end_of_list(&cache->table, lru_node);
-    return lru_node->value;
-}
-
-void *aws_lru_cache_get_mru_element(const struct aws_lru_cache *cache) {
-    const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-    if(aws_linked_list_empty(list)) {
-        return NULL;
-    }
-    struct aws_linked_list_node *node = aws_linked_list_back(list);
-    struct aws_linked_hash_table_node *mru_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
-    return mru_node->value;
-}
-
-size_t aws_lru_cache_get_element_count(const struct aws_lru_cache *cache) {
+size_t aws_lifo_cache_get_element_count(const struct aws_lifo_cache *cache) {
     return aws_linked_hash_table_get_element_count(&cache->table);
 }

--- a/source/lifo_cache.c
+++ b/source/lifo_cache.c
@@ -14,15 +14,13 @@
  */
 #include <aws/common/lifo_cache.h>
 static int s_lifo_cache_put(struct aws_cache *cache, const void *key, void *p_value);
-static void s_lifo_cache_clean_up(struct aws_cache *cache);
 
 static struct aws_cache_vtable s_lifo_cache_vtable = {
-    .clean_up = s_lifo_cache_clean_up,
-    .find = aws_cache_base_find,
+    .find = aws_cache_base_default_find,
     .put = s_lifo_cache_put,
-    .remove = aws_cache_base_remove,
-    .clear = aws_cache_base_clear,
-    .get_element_count = aws_cache_base_get_element_count,
+    .remove = aws_cache_base_default_remove,
+    .clear = aws_cache_base_default_clear,
+    .get_element_count = aws_cache_base_default_get_element_count,
 
     .use_lru_element = NULL,
     .get_mru_element = NULL,
@@ -38,26 +36,18 @@ struct aws_cache *aws_cache_new_lifo(
     AWS_ASSERT(allocator);
     AWS_ASSERT(max_items);
 
-    struct aws_lifo_cache *lifo_cache = aws_mem_calloc(allocator, 1, sizeof(struct aws_lifo_cache));
+    struct aws_cache *lifo_cache = aws_mem_calloc(allocator, 1, sizeof(struct aws_cache));
     if (!lifo_cache) {
         return NULL;
     }
-    lifo_cache->base.allocator = allocator;
-    lifo_cache->base.max_items = max_items;
-    lifo_cache->base.vtable = &s_lifo_cache_vtable;
+    lifo_cache->allocator = allocator;
+    lifo_cache->max_items = max_items;
+    lifo_cache->vtable = &s_lifo_cache_vtable;
     if (aws_linked_hash_table_init(
-            &lifo_cache->base.table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)) {
+            &lifo_cache->table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)) {
         return NULL;
     }
-    return &lifo_cache->base;
-}
-
-static void s_lifo_cache_clean_up(struct aws_cache *cache) {
-    struct aws_lifo_cache *lifo_cache = AWS_CONTAINER_OF(cache, struct aws_lifo_cache, base);
-    /* clearing the table will remove all elements. That will also deallocate
-     * any cache entries we currently have. */
-    aws_linked_hash_table_clean_up(&cache->table);
-    aws_mem_release(cache->allocator, lifo_cache);
+    return lifo_cache;
 }
 
 /* fifo cache put implementation */

--- a/source/lifo_cache.c
+++ b/source/lifo_cache.c
@@ -13,9 +13,22 @@
  * permissions and limitations under the License.
  */
 #include <aws/common/lifo_cache.h>
+static int s_lifo_cache_put(struct aws_cache *cache, const void *key, void *p_value);
+static void s_lifo_cache_clean_up(struct aws_cache *cache);
 
-int aws_lifo_cache_init(
-    struct aws_lifo_cache *cache,
+static struct aws_cache_vtable s_lifo_cache_vtable = {
+    .clean_up = s_lifo_cache_clean_up,
+    .find = aws_cache_base_find,
+    .put = s_lifo_cache_put,
+    .remove = aws_cache_base_remove,
+    .clear = aws_cache_base_clear,
+    .get_element_count = aws_cache_base_get_element_count,
+
+    .use_lru_element = NULL,
+    .get_mru_element = NULL,
+};
+
+struct aws_cache *aws_cache_new_lifo(
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
@@ -25,26 +38,30 @@ int aws_lifo_cache_init(
     AWS_ASSERT(allocator);
     AWS_ASSERT(max_items);
 
-    cache->max_items = max_items;
-
-    return aws_linked_hash_table_init(
-        &cache->table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items);
+    struct aws_lifo_cache *lifo_cache = aws_mem_calloc(allocator, 1, sizeof(struct aws_lifo_cache));
+    if (!lifo_cache) {
+        return NULL;
+    }
+    lifo_cache->base.allocator = allocator;
+    lifo_cache->base.max_items = max_items;
+    lifo_cache->base.vtable = &s_lifo_cache_vtable;
+    if (aws_linked_hash_table_init(
+            &lifo_cache->base.table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)) {
+        return NULL;
+    }
+    return &lifo_cache->base;
 }
 
-void aws_lifo_cache_clean_up(struct aws_lifo_cache *cache) {
+static void s_lifo_cache_clean_up(struct aws_cache *cache) {
+    struct aws_lifo_cache *lifo_cache = AWS_CONTAINER_OF(cache, struct aws_lifo_cache, base);
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clean_up(&cache->table);
-    AWS_ZERO_STRUCT(*cache);
+    aws_mem_release(cache->allocator, lifo_cache);
 }
 
-int aws_lifo_cache_find(struct aws_lifo_cache *cache, const void *key, void **p_value) {
-
-    return (aws_linked_hash_table_find(&cache->table, key, p_value));
-}
-
-int aws_lifo_cache_put(struct aws_lifo_cache *cache, const void *key, void *p_value) {
-
+/* fifo cache put implementation */
+static int s_lifo_cache_put(struct aws_cache *cache, const void *key, void *p_value) {
     if (aws_linked_hash_table_put(&cache->table, key, p_value)) {
         return AWS_OP_ERR;
     }
@@ -64,20 +81,4 @@ int aws_lifo_cache_put(struct aws_lifo_cache *cache, const void *key, void *p_va
     }
 
     return AWS_OP_SUCCESS;
-}
-
-int aws_lifo_cache_remove(struct aws_lifo_cache *cache, const void *key) {
-    /* allocated cache memory and the linked list entry will be removed in the
-     * callback. */
-    return aws_linked_hash_table_remove(&cache->table, key);
-}
-
-void aws_lifo_cache_clear(struct aws_lifo_cache *cache) {
-    /* clearing the table will remove all elements. That will also deallocate
-     * any cache entries we currently have. */
-    aws_linked_hash_table_clear(&cache->table);
-}
-
-size_t aws_lifo_cache_get_element_count(const struct aws_lifo_cache *cache) {
-    return aws_linked_hash_table_get_element_count(&cache->table);
 }

--- a/source/lifo_cache.c
+++ b/source/lifo_cache.c
@@ -50,7 +50,7 @@ struct aws_cache *aws_cache_new_lifo(
     return lifo_cache;
 }
 
-/* fifo cache put implementation */
+/* lifo cache put implementation */
 static int s_lifo_cache_put(struct aws_cache *cache, const void *key, void *p_value) {
     if (aws_linked_hash_table_put(&cache->table, key, p_value)) {
         return AWS_OP_ERR;

--- a/source/linked_hash_table.c
+++ b/source/linked_hash_table.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/common/linked_hash_table.h>
+
+static void s_element_destroy(void *value) {
+    struct aws_linked_hash_table_node *node = value;
+
+    if (node->table->user_on_value_destroy) {
+        node->table->user_on_value_destroy(node->value);
+    }
+
+    aws_linked_list_remove(&node->node);
+    aws_mem_release(node->table->allocator, node);
+}
+
+int aws_linked_hash_table_init(
+    struct aws_linked_hash_table *table,
+    struct aws_allocator *allocator,
+    aws_hash_fn *hash_fn,
+    aws_hash_callback_eq_fn *equals_fn,
+    aws_hash_callback_destroy_fn *destroy_key_fn,
+    aws_hash_callback_destroy_fn *destroy_value_fn,
+    size_t initial_item_count) {
+    AWS_ASSERT(table);
+    AWS_ASSERT(allocator);
+    AWS_ASSERT(hash_fn);
+    AWS_ASSERT(equals_fn);
+
+    table->allocator = allocator;
+    table->user_on_value_destroy = destroy_value_fn;
+
+    aws_linked_list_init(&table->list);
+    return aws_hash_table_init(
+        &table->table, allocator, initial_item_count, hash_fn, equals_fn, destroy_key_fn, s_element_destroy);
+}
+
+void aws_linked_hash_table_clean_up(struct aws_linked_hash_table *table) {
+    /* clearing the table will remove all elements. That will also deallocate
+     * any table entries we currently have. */
+    aws_hash_table_clean_up(&table->table);
+    AWS_ZERO_STRUCT(*table);
+}
+
+int aws_linked_hash_table_find(struct aws_linked_hash_table *table, const void *key, void **p_value) {
+
+    struct aws_hash_element *element = NULL;
+    int err_val = aws_hash_table_find(&table->table, key, &element);
+
+    if (err_val || !element) {
+        *p_value = NULL;
+        return err_val;
+    }
+
+    struct aws_linked_hash_table_node *linked_node = element->value;
+    *p_value = linked_node->value;
+
+    return AWS_OP_SUCCESS;
+}
+
+int aws_linked_hash_table_put(struct aws_linked_hash_table *table, const void *key, void *p_value) {
+
+    struct aws_linked_hash_table_node *node =
+        aws_mem_calloc(table->allocator, 1, sizeof(struct aws_linked_hash_table_node));
+
+    if (!node) {
+        return AWS_OP_ERR;
+    }
+
+    struct aws_hash_element *element = NULL;
+    int was_added = 0;
+    int err_val = aws_hash_table_create(&table->table, key, &element, &was_added);
+
+    if (err_val) {
+        aws_mem_release(table->allocator, node);
+        return err_val;
+    }
+
+    if (element->value) {
+        s_element_destroy(element->value);
+    }
+
+    node->value = p_value;
+    node->key = key;
+    node->table = table;
+    element->value = node;
+
+    aws_linked_list_push_back(&table->list, &node->node);
+
+    return AWS_OP_SUCCESS;
+}
+
+int aws_linked_hash_table_remove(struct aws_linked_hash_table *table, const void *key) {
+    /* allocated table memory and the linked list entry will be removed in the
+     * callback. */
+    return aws_hash_table_remove(&table->table, key, NULL, NULL);
+}
+
+void aws_linked_hash_table_clear(struct aws_linked_hash_table *table) {
+    /* clearing the table will remove all elements. That will also deallocate
+     * any entries we currently have. */
+    aws_hash_table_clear(&table->table);
+}
+
+size_t aws_linked_hash_table_get_element_count(const struct aws_linked_hash_table *table) {
+    return aws_hash_table_get_entry_count(&table->table);
+}
+
+const struct aws_linked_list *aws_linked_hash_table_get_iteration_list(struct aws_linked_hash_table *table) {
+    return &table->list;
+}

--- a/source/lru_cache.c
+++ b/source/lru_cache.c
@@ -18,7 +18,7 @@ static int s_lru_cache_find(struct aws_cache *cache, const void *key, void **p_v
 static void *s_lru_cache_use_lru_element(struct aws_cache *cache);
 static void *s_lru_cache_get_mru_element(const struct aws_cache *cache);
 
-struct lru_cache_impl_vatable {
+struct lru_cache_impl_vtable {
     void *(*use_lru_element)(struct aws_cache *cache);
     void *(*get_mru_element)(const struct aws_cache *cache);
 };
@@ -41,10 +41,10 @@ struct aws_cache *aws_cache_new_lru(
     AWS_ASSERT(allocator);
     AWS_ASSERT(max_items);
     struct aws_cache *lru_cache = NULL;
-    struct lru_cache_impl_vatable *impl = NULL;
+    struct lru_cache_impl_vtable *impl = NULL;
 
     if (!aws_mem_acquire_many(
-            allocator, 2, &lru_cache, sizeof(struct aws_cache), &impl, sizeof(struct lru_cache_impl_vatable))) {
+            allocator, 2, &lru_cache, sizeof(struct aws_cache), &impl, sizeof(struct lru_cache_impl_vtable))) {
         return NULL;
     }
     impl->use_lru_element = s_lru_cache_use_lru_element;
@@ -108,7 +108,7 @@ static void *s_lru_cache_get_mru_element(const struct aws_cache *cache) {
 void *aws_lru_cache_use_lru_element(struct aws_cache *cache) {
     AWS_ASSERT(cache);
     if (cache->impl) {
-        struct lru_cache_impl_vatable *impl_vtable = cache->impl;
+        struct lru_cache_impl_vtable *impl_vtable = cache->impl;
         return impl_vtable->use_lru_element(cache);
     }
     return NULL;
@@ -117,7 +117,7 @@ void *aws_lru_cache_use_lru_element(struct aws_cache *cache) {
 void *aws_lru_cache_get_mru_element(const struct aws_cache *cache) {
     AWS_ASSERT(cache);
     if (cache->impl) {
-        struct lru_cache_impl_vatable *impl_vtable = cache->impl;
+        struct lru_cache_impl_vtable *impl_vtable = cache->impl;
         return impl_vtable->get_mru_element(cache);
     }
     return NULL;

--- a/source/lru_cache.c
+++ b/source/lru_cache.c
@@ -106,19 +106,15 @@ static void *s_lru_cache_get_mru_element(const struct aws_cache *cache) {
 }
 
 void *aws_lru_cache_use_lru_element(struct aws_cache *cache) {
-    AWS_ASSERT(cache);
-    if (cache->impl) {
-        struct lru_cache_impl_vtable *impl_vtable = cache->impl;
-        return impl_vtable->use_lru_element(cache);
-    }
-    return NULL;
+    AWS_PRECONDITION(cache);
+    AWS_PRECONDITION(cache->impl);
+    struct lru_cache_impl_vtable *impl_vtable = cache->impl;
+    return impl_vtable->use_lru_element(cache);
 }
 
 void *aws_lru_cache_get_mru_element(const struct aws_cache *cache) {
-    AWS_ASSERT(cache);
-    if (cache->impl) {
-        struct lru_cache_impl_vtable *impl_vtable = cache->impl;
-        return impl_vtable->get_mru_element(cache);
-    }
-    return NULL;
+    AWS_PRECONDITION(cache);
+    AWS_PRECONDITION(cache->impl);
+    struct lru_cache_impl_vtable *impl_vtable = cache->impl;
+    return impl_vtable->get_mru_element(cache);
 }

--- a/source/lru_cache.c
+++ b/source/lru_cache.c
@@ -13,9 +13,25 @@
  * permissions and limitations under the License.
  */
 #include <aws/common/lru_cache.h>
+static int s_lru_cache_put(struct aws_cache *cache, const void *key, void *p_value);
+static int s_lru_cache_find(struct aws_cache *cache, const void *key, void **p_value);
+static void s_lru_cache_clean_up(struct aws_cache *cache);
+static void *s_lru_cache_use_lru_element(struct aws_cache *cache);
+static void *s_lru_cache_get_mru_element(const struct aws_cache *cache);
 
-int aws_lru_cache_init(
-    struct aws_lru_cache *cache,
+static struct aws_cache_vtable s_lru_cache_vtable = {
+    .clean_up = s_lru_cache_clean_up,
+    .find = s_lru_cache_find,
+    .put = s_lru_cache_put,
+    .remove = aws_cache_base_remove,
+    .clear = aws_cache_base_clear,
+    .get_element_count = aws_cache_base_get_element_count,
+
+    .use_lru_element = s_lru_cache_use_lru_element,
+    .get_mru_element = s_lru_cache_get_mru_element,
+};
+
+struct aws_cache *aws_cache_new_lru(
     struct aws_allocator *allocator,
     aws_hash_fn *hash_fn,
     aws_hash_callback_eq_fn *equals_fn,
@@ -25,27 +41,32 @@ int aws_lru_cache_init(
     AWS_ASSERT(allocator);
     AWS_ASSERT(max_items);
 
-    cache->max_items = max_items;
-
-    return aws_linked_hash_table_init(
-        &cache->table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items);
+    struct aws_lru_cache *lru_cache = aws_mem_calloc(allocator, 1, sizeof(struct aws_lru_cache));
+    if (!lru_cache) {
+        return NULL;
+    }
+    lru_cache->base.allocator = allocator;
+    lru_cache->base.max_items = max_items;
+    lru_cache->base.vtable = &s_lru_cache_vtable;
+    if (aws_linked_hash_table_init(
+            &lru_cache->base.table, allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)) {
+        return NULL;
+    }
+    return &lru_cache->base;
 }
 
-void aws_lru_cache_clean_up(struct aws_lru_cache *cache) {
+static void s_lru_cache_clean_up(struct aws_cache *cache) {
+    struct aws_lru_cache *lru_cache = AWS_CONTAINER_OF(cache, struct aws_lru_cache, base);
     /* clearing the table will remove all elements. That will also deallocate
      * any cache entries we currently have. */
     aws_linked_hash_table_clean_up(&cache->table);
-    AWS_ZERO_STRUCT(*cache);
+    aws_mem_release(cache->allocator, lru_cache);
 }
 
-int aws_lru_cache_find(struct aws_lru_cache *cache, const void *key, void **p_value) {
+/* fifo cache put implementation */
+static int s_lru_cache_put(struct aws_cache *cache, const void *key, void *p_value) {
 
-    return(aws_linked_hash_table_find_and_move_to_back(&cache->table, key, p_value));
-}
-
-int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_value) {
-
-    if(aws_linked_hash_table_put(&cache->table, key, p_value)) {
+    if (aws_linked_hash_table_put(&cache->table, key, p_value)) {
         return AWS_OP_ERR;
     }
 
@@ -62,33 +83,25 @@ int aws_lru_cache_put(struct aws_lru_cache *cache, const void *key, void *p_valu
     return AWS_OP_SUCCESS;
 }
 
-int aws_lru_cache_remove(struct aws_lru_cache *cache, const void *key) {
-    /* allocated cache memory and the linked list entry will be removed in the
-     * callback. */
-    return aws_linked_hash_table_remove(&cache->table, key);
+static int s_lru_cache_find(struct aws_cache *cache, const void *key, void **p_value) {
+
+    return (aws_linked_hash_table_find_and_move_to_back(&cache->table, key, p_value));
 }
 
-void aws_lru_cache_clear(struct aws_lru_cache *cache) {
-    /* clearing the table will remove all elements. That will also deallocate
-     * any cache entries we currently have. */
-    aws_linked_hash_table_clear(&cache->table);
-}
-
-void *aws_lru_cache_use_lru_element(struct aws_lru_cache *cache) {
+static void *s_lru_cache_use_lru_element(struct aws_cache *cache) {
     const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-    if(aws_linked_list_empty(list)) {
+    if (aws_linked_list_empty(list)) {
         return NULL;
     }
     struct aws_linked_list_node *node = aws_linked_list_front(list);
     struct aws_linked_hash_table_node *lru_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
-    
+
     aws_linked_hash_table_move_node_to_end_of_list(&cache->table, lru_node);
     return lru_node->value;
 }
-
-void *aws_lru_cache_get_mru_element(const struct aws_lru_cache *cache) {
+static void *s_lru_cache_get_mru_element(const struct aws_cache *cache) {
     const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&cache->table);
-    if(aws_linked_list_empty(list)) {
+    if (aws_linked_list_empty(list)) {
         return NULL;
     }
     struct aws_linked_list_node *node = aws_linked_list_back(list);
@@ -96,6 +109,18 @@ void *aws_lru_cache_get_mru_element(const struct aws_lru_cache *cache) {
     return mru_node->value;
 }
 
-size_t aws_lru_cache_get_element_count(const struct aws_lru_cache *cache) {
-    return aws_linked_hash_table_get_element_count(&cache->table);
+void *aws_lru_cache_use_lru_element(struct aws_cache *cache) {
+    AWS_ASSERT(cache);
+    if (cache->vtable->use_lru_element) {
+        return cache->vtable->use_lru_element(cache);
+    }
+    return NULL;
+}
+
+void *aws_lru_cache_get_mru_element(const struct aws_cache *cache) {
+    AWS_ASSERT(cache);
+    if (cache->vtable->get_mru_element) {
+        return cache->vtable->get_mru_element(cache);
+    }
+    return NULL;
 }

--- a/source/lru_cache.c
+++ b/source/lru_cache.c
@@ -53,7 +53,7 @@ struct aws_cache *aws_cache_new_lru(
     return lru_cache;
 }
 
-/* fifo cache put implementation */
+/* implementation for lru cache put */
 static int s_lru_cache_put(struct aws_cache *cache, const void *key, void *p_value) {
 
     if (aws_linked_hash_table_put(&cache->table, key, p_value)) {
@@ -72,9 +72,8 @@ static int s_lru_cache_put(struct aws_cache *cache, const void *key, void *p_val
 
     return AWS_OP_SUCCESS;
 }
-
+/* implementation for lru cache find */
 static int s_lru_cache_find(struct aws_cache *cache, const void *key, void **p_value) {
-
     return (aws_linked_hash_table_find_and_move_to_back(&cache->table, key, p_value));
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,6 +171,13 @@ add_test_case(test_hash_combine)
 
 add_test_case(test_linked_hash_table_preserves_insertion_order)
 add_test_case(test_linked_hash_table_entries_cleanup)
+add_test_case(test_linked_hash_table_entries_overwrite)
+
+add_test_case(test_lru_cache_overflow_static_members)
+add_test_case(test_lru_cache_lru_ness_static_members)
+add_test_case(test_lru_cache_element_access_members)
+add_test_case(test_fifo_cache_overflow_static_members)
+add_test_case(test_lifo_cache_overflow_static_members)
 
 add_test_case(test_is_power_of_two)
 add_test_case(test_round_up_to_power_of_two)
@@ -283,12 +290,6 @@ add_test_case(test_calloc_from_default_allocator)
 add_test_case(test_calloc_from_given_allocator)
 
 add_test_case(timebomb_allocator)
-
-add_test_case(test_lru_cache_overflow_static_members)
-add_test_case(test_lru_cache_lru_ness_static_members)
-add_test_case(test_lru_cache_entries_cleanup)
-add_test_case(test_lru_cache_overwrite)
-add_test_case(test_lru_cache_element_access_members)
 
 add_test_case(rw_lock_aquire_release_test)
 add_test_case(rw_lock_is_actually_rw_lock_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,8 @@ add_test_case(test_lru_cache_lru_ness_static_members)
 add_test_case(test_lru_cache_element_access_members)
 add_test_case(test_fifo_cache_overflow_static_members)
 add_test_case(test_lifo_cache_overflow_static_members)
+add_test_case(test_cache_entries_cleanup)
+add_test_case(test_cache_entries_overwrite)
 
 add_test_case(test_is_power_of_two)
 add_test_case(test_round_up_to_power_of_two)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,6 +169,9 @@ add_test_case(test_hash_table_cleanup_idempotent)
 add_test_case(test_hash_table_byte_cursor_create_find)
 add_test_case(test_hash_combine)
 
+add_test_case(test_linked_hash_table_preserves_insertion_order)
+add_test_case(test_linked_hash_table_entries_cleanup)
+
 add_test_case(test_is_power_of_two)
 add_test_case(test_round_up_to_power_of_two)
 add_test_case(test_mul_size_checked)

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -13,9 +13,9 @@
  *  permissions and limitations under the License.
  */
 
-#include <aws/common/lru_cache.h>
 #include <aws/common/fifo_cache.h>
 #include <aws/common/lifo_cache.h>
+#include <aws/common/lru_cache.h>
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_lru_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -21,9 +21,9 @@
 static int s_test_lru_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    struct aws_lru_cache cache;
-
-    ASSERT_SUCCESS(aws_lru_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+    struct aws_cache *lru_cache =
+        aws_cache_new_lru(allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3);
+    ASSERT_NOT_NULL(lru_cache);
 
     const char *first_key = "first";
     const char *second_key = "second";
@@ -35,44 +35,44 @@ static int s_test_lru_cache_overflow_static_members_fn(struct aws_allocator *all
     int third = 3;
     int fourth = 4;
 
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, second_key, &second));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, third_key, &third));
-    ASSERT_INT_EQUALS(3, aws_lru_cache_get_element_count(&cache));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, second_key, &second));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_cache_get_element_count(lru_cache));
 
     int *value = NULL;
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, first_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, third_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(third, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, fourth_key, (void **)&fourth));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, fourth_key, (void **)&fourth));
 
     /* make sure the oldest entry was purged. Note, value should now be NULL but
      * the call succeeds. */
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, first_key, (void **)&value));
     ASSERT_NULL(value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, third_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(third, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, fourth_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, fourth_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(fourth, *value);
 
-    aws_lru_cache_clean_up(&cache);
+    aws_cache_clean_up(lru_cache);
     return 0;
 }
 
@@ -81,9 +81,9 @@ AWS_TEST_CASE(test_lru_cache_overflow_static_members, s_test_lru_cache_overflow_
 static int s_test_lru_cache_lru_ness_static_members_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    struct aws_lru_cache cache;
-
-    ASSERT_SUCCESS(aws_lru_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+    struct aws_cache *lru_cache =
+        aws_cache_new_lru(allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3);
+    ASSERT_NOT_NULL(lru_cache);
 
     const char *first_key = "first";
     const char *second_key = "second";
@@ -95,40 +95,40 @@ static int s_test_lru_cache_lru_ness_static_members_fn(struct aws_allocator *all
     int third = 3;
     int fourth = 4;
 
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, second_key, &second));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, third_key, &third));
-    ASSERT_INT_EQUALS(3, aws_lru_cache_get_element_count(&cache));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, second_key, &second));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_cache_get_element_count(lru_cache));
 
     int *value = NULL;
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, first_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, fourth_key, (void **)&fourth));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, fourth_key, (void **)&fourth));
 
     /* The third element is the LRU element (see above). Note, value should now
      * be NULL but the call succeeds. */
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, third_key, (void **)&value));
     ASSERT_NULL(value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, first_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, fourth_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lru_cache, fourth_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(fourth, *value);
 
-    aws_lru_cache_clean_up(&cache);
+    aws_cache_clean_up(lru_cache);
     return 0;
 }
 
@@ -136,14 +136,13 @@ AWS_TEST_CASE(test_lru_cache_lru_ness_static_members, s_test_lru_cache_lru_ness_
 
 static int s_test_lru_cache_element_access_members_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
-
-    struct aws_lru_cache cache;
-
-    ASSERT_SUCCESS(aws_lru_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+    struct aws_cache *lru_cache =
+        aws_cache_new_lru(allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3);
+    ASSERT_NOT_NULL(lru_cache);
 
     int *value = NULL;
-    ASSERT_NULL(aws_lru_cache_use_lru_element(&cache));
-    ASSERT_NULL(aws_lru_cache_get_mru_element(&cache));
+    ASSERT_NULL(aws_lru_cache_use_lru_element(lru_cache));
+    ASSERT_NULL(aws_lru_cache_get_mru_element(lru_cache));
 
     const char *first_key = "first";
     const char *second_key = "second";
@@ -153,24 +152,24 @@ static int s_test_lru_cache_element_access_members_fn(struct aws_allocator *allo
     int second = 2;
     int third = 3;
 
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, second_key, &second));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, third_key, &third));
-    ASSERT_INT_EQUALS(3, aws_lru_cache_get_element_count(&cache));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, second_key, &second));
+    ASSERT_SUCCESS(aws_cache_put(lru_cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_cache_get_element_count(lru_cache));
 
-    value = aws_lru_cache_get_mru_element(&cache);
+    value = aws_lru_cache_get_mru_element(lru_cache);
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(third, *value);
 
-    value = aws_lru_cache_use_lru_element(&cache);
+    value = aws_lru_cache_use_lru_element(lru_cache);
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    value = aws_lru_cache_get_mru_element(&cache);
+    value = aws_lru_cache_get_mru_element(lru_cache);
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    aws_lru_cache_clean_up(&cache);
+    aws_cache_clean_up(lru_cache);
     return 0;
 }
 
@@ -179,10 +178,9 @@ AWS_TEST_CASE(test_lru_cache_element_access_members, s_test_lru_cache_element_ac
 static int s_test_fifo_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    struct aws_fifo_cache cache;
-
-    ASSERT_SUCCESS(
-        aws_fifo_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+    struct aws_cache *fifo_cache =
+        aws_cache_new_fifo(allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3);
+    ASSERT_NOT_NULL(fifo_cache);
 
     const char *first_key = "first";
     const char *second_key = "second";
@@ -194,44 +192,44 @@ static int s_test_fifo_cache_overflow_static_members_fn(struct aws_allocator *al
     int third = 3;
     int fourth = 4;
 
-    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, second_key, &second));
-    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, third_key, &third));
-    ASSERT_INT_EQUALS(3, aws_fifo_cache_get_element_count(&cache));
+    ASSERT_SUCCESS(aws_cache_put(fifo_cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(fifo_cache, second_key, &second));
+    ASSERT_SUCCESS(aws_cache_put(fifo_cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_cache_get_element_count(fifo_cache));
 
     int *value = NULL;
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, third_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(third, *value);
 
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, first_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, fourth_key, (void **)&fourth));
+    ASSERT_SUCCESS(aws_cache_put(fifo_cache, fourth_key, (void **)&fourth));
 
     /* make sure the oldest entry was purged. Note, value should now be NULL but
      * the call succeeds. */
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, first_key, (void **)&value));
     ASSERT_NULL(value);
 
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, third_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(third, *value);
 
-    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, fourth_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(fifo_cache, fourth_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(fourth, *value);
 
-    aws_fifo_cache_clean_up(&cache);
+    aws_cache_clean_up(fifo_cache);
     return 0;
 }
 
@@ -240,10 +238,9 @@ AWS_TEST_CASE(test_fifo_cache_overflow_static_members, s_test_fifo_cache_overflo
 static int s_test_lifo_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    struct aws_lifo_cache cache;
-
-    ASSERT_SUCCESS(
-        aws_lifo_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+    struct aws_cache *lifo_cache =
+        aws_cache_new_lifo(allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3);
+    ASSERT_NOT_NULL(lifo_cache);
 
     const char *first_key = "first";
     const char *second_key = "second";
@@ -255,45 +252,118 @@ static int s_test_lifo_cache_overflow_static_members_fn(struct aws_allocator *al
     int third = 3;
     int fourth = 4;
 
-    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, second_key, &second));
-    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, third_key, &third));
-    ASSERT_INT_EQUALS(3, aws_lifo_cache_get_element_count(&cache));
+    ASSERT_SUCCESS(aws_cache_put(lifo_cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(lifo_cache, second_key, &second));
+    ASSERT_SUCCESS(aws_cache_put(lifo_cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_cache_get_element_count(lifo_cache));
 
     int *value = NULL;
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, third_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(third, *value);
 
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, first_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, fourth_key, (void **)&fourth));
+    ASSERT_SUCCESS(aws_cache_put(lifo_cache, fourth_key, (void **)&fourth));
 
     /* make sure the latest entry was purged. Note, value should now be NULL but
      * the call succeeds. */
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, third_key, (void **)&value));
     ASSERT_NULL(value);
 
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, first_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(first, *value);
 
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, second_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(second, *value);
 
-    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, fourth_key, (void **)&value));
+    ASSERT_SUCCESS(aws_cache_find(lifo_cache, fourth_key, (void **)&value));
     ASSERT_NOT_NULL(value);
     ASSERT_INT_EQUALS(fourth, *value);
 
-    aws_lifo_cache_clean_up(&cache);
+    aws_cache_clean_up(lifo_cache);
     return 0;
 }
 
 AWS_TEST_CASE(test_lifo_cache_overflow_static_members, s_test_lifo_cache_overflow_static_members_fn)
+
+struct cache_test_value_element {
+    bool value_removed;
+};
+
+static void s_cache_element_value_destroy(void *value) {
+    struct cache_test_value_element *value_element = value;
+    value_element->value_removed = true;
+}
+
+static int s_test_cache_entries_cleanup_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    /* take fifo cache as example, others are the same as it */
+    struct aws_cache *cache = aws_cache_new_fifo(
+        allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, s_cache_element_value_destroy, 3);
+    ASSERT_NOT_NULL(cache);
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+
+    struct cache_test_value_element first = {.value_removed = false};
+    struct cache_test_value_element second = {.value_removed = false};
+
+    ASSERT_SUCCESS(aws_cache_put(cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(cache, second_key, &second));
+    ASSERT_INT_EQUALS(2, aws_cache_get_element_count(cache));
+
+    ASSERT_SUCCESS(aws_cache_remove(cache, second_key));
+
+    ASSERT_TRUE(second.value_removed);
+    ASSERT_INT_EQUALS(1, aws_cache_get_element_count(cache));
+
+    aws_cache_clear(cache);
+    ASSERT_INT_EQUALS(0, aws_cache_get_element_count(cache));
+
+    ASSERT_TRUE(first.value_removed);
+
+    aws_cache_clean_up(cache);
+    return 0;
+}
+
+AWS_TEST_CASE(test_cache_entries_cleanup, s_test_cache_entries_cleanup_fn)
+
+static int s_test_cache_entries_overwrite_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    /* take fifo cache as example, others are the same as it */
+    struct aws_cache *cache = aws_cache_new_fifo(
+        allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, s_cache_element_value_destroy, 3);
+    ASSERT_NOT_NULL(cache);
+
+    const char *first_key = "first";
+
+    struct cache_test_value_element first = {.value_removed = false};
+    struct cache_test_value_element second = {.value_removed = false};
+
+    ASSERT_SUCCESS(aws_cache_put(cache, first_key, &first));
+    ASSERT_SUCCESS(aws_cache_put(cache, first_key, &second));
+    ASSERT_INT_EQUALS(1, aws_cache_get_element_count(cache));
+
+    ASSERT_TRUE(first.value_removed);
+    ASSERT_FALSE(second.value_removed);
+
+    struct cache_test_value_element *value = NULL;
+    ASSERT_SUCCESS(aws_cache_find(cache, first_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_PTR_EQUALS(&second, value);
+
+    aws_cache_clean_up(cache);
+    return 0;
+}
+
+AWS_TEST_CASE(test_cache_entries_overwrite, s_test_cache_entries_overwrite_fn)

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -14,6 +14,8 @@
  */
 
 #include <aws/common/lru_cache.h>
+#include <aws/common/fifo_cache.h>
+#include <aws/common/lifo_cache.h>
 #include <aws/testing/aws_test_harness.h>
 
 static int s_test_lru_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
@@ -132,97 +134,6 @@ static int s_test_lru_cache_lru_ness_static_members_fn(struct aws_allocator *all
 
 AWS_TEST_CASE(test_lru_cache_lru_ness_static_members, s_test_lru_cache_lru_ness_static_members_fn)
 
-struct lru_test_value_element {
-    bool value_removed;
-};
-
-static void s_lru_test_element_value_destroy(void *value) {
-    struct lru_test_value_element *value_element = value;
-    value_element->value_removed = true;
-}
-
-static int s_test_lru_cache_entries_cleanup_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-
-    struct aws_lru_cache cache;
-
-    ASSERT_SUCCESS(aws_lru_cache_init(
-        &cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, s_lru_test_element_value_destroy, 2));
-
-    const char *first_key = "first";
-    const char *second_key = "second";
-    const char *third_key = "third";
-
-    struct lru_test_value_element first = {.value_removed = false};
-    struct lru_test_value_element second = {.value_removed = false};
-    struct lru_test_value_element third = {.value_removed = false};
-
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, second_key, &second));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, third_key, &third));
-    ASSERT_INT_EQUALS(2, aws_lru_cache_get_element_count(&cache));
-
-    ASSERT_TRUE(first.value_removed);
-    ASSERT_FALSE(second.value_removed);
-    ASSERT_FALSE(third.value_removed);
-
-    struct lru_test_value_element *value = NULL;
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, first_key, (void **)&value));
-    ASSERT_NULL(value);
-
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, second_key, (void **)&value));
-    ASSERT_NOT_NULL(value);
-    ASSERT_FALSE(value->value_removed);
-
-    ASSERT_SUCCESS(aws_lru_cache_remove(&cache, second_key));
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, second_key, (void **)&value));
-    ASSERT_NULL(value);
-    ASSERT_TRUE(second.value_removed);
-
-    aws_lru_cache_clear(&cache);
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, third_key, (void **)&value));
-    ASSERT_NULL(value);
-    ASSERT_TRUE(third.value_removed);
-
-    aws_lru_cache_clean_up(&cache);
-    return 0;
-}
-
-AWS_TEST_CASE(test_lru_cache_entries_cleanup, s_test_lru_cache_entries_cleanup_fn)
-
-static int s_test_lru_cache_overwrite_fn(struct aws_allocator *allocator, void *ctx) {
-    (void)ctx;
-
-    struct aws_lru_cache cache;
-
-    ASSERT_SUCCESS(aws_lru_cache_init(
-        &cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, s_lru_test_element_value_destroy, 2));
-
-    const char *first_key = "first";
-
-    struct lru_test_value_element first = {.value_removed = false};
-    struct lru_test_value_element second = {.value_removed = false};
-
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, first_key, &first));
-    ASSERT_SUCCESS(aws_lru_cache_put(&cache, first_key, &second));
-    ASSERT_INT_EQUALS(1, aws_lru_cache_get_element_count(&cache));
-
-    ASSERT_TRUE(first.value_removed);
-    ASSERT_FALSE(second.value_removed);
-
-    struct lru_test_value_element *value = NULL;
-    ASSERT_SUCCESS(aws_lru_cache_find(&cache, first_key, (void **)&value));
-    ASSERT_NOT_NULL(value);
-    ASSERT_PTR_EQUALS(&second, value);
-
-    aws_lru_cache_clean_up(&cache);
-    ASSERT_TRUE(second.value_removed);
-
-    return 0;
-}
-
-AWS_TEST_CASE(test_lru_cache_overwrite, s_test_lru_cache_overwrite_fn)
-
 static int s_test_lru_cache_element_access_members_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
@@ -264,3 +175,125 @@ static int s_test_lru_cache_element_access_members_fn(struct aws_allocator *allo
 }
 
 AWS_TEST_CASE(test_lru_cache_element_access_members, s_test_lru_cache_element_access_members_fn)
+
+static int s_test_fifo_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_fifo_cache cache;
+
+    ASSERT_SUCCESS(
+        aws_fifo_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+    const char *third_key = "third";
+    const char *fourth_key = "fourth";
+
+    int first = 1;
+    int second = 2;
+    int third = 3;
+    int fourth = 4;
+
+    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, first_key, &first));
+    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, second_key, &second));
+    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_fifo_cache_get_element_count(&cache));
+
+    int *value = NULL;
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(third, *value);
+
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(second, *value);
+
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(first, *value);
+
+    ASSERT_SUCCESS(aws_fifo_cache_put(&cache, fourth_key, (void **)&fourth));
+
+    /* make sure the oldest entry was purged. Note, value should now be NULL but
+     * the call succeeds. */
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_NULL(value);
+
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(second, *value);
+
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(third, *value);
+
+    ASSERT_SUCCESS(aws_fifo_cache_find(&cache, fourth_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(fourth, *value);
+
+    aws_fifo_cache_clean_up(&cache);
+    return 0;
+}
+
+AWS_TEST_CASE(test_fifo_cache_overflow_static_members, s_test_fifo_cache_overflow_static_members_fn)
+
+static int s_test_lifo_cache_overflow_static_members_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_lifo_cache cache;
+
+    ASSERT_SUCCESS(
+        aws_lifo_cache_init(&cache, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+    const char *third_key = "third";
+    const char *fourth_key = "fourth";
+
+    int first = 1;
+    int second = 2;
+    int third = 3;
+    int fourth = 4;
+
+    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, first_key, &first));
+    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, second_key, &second));
+    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, third_key, &third));
+    ASSERT_INT_EQUALS(3, aws_lifo_cache_get_element_count(&cache));
+
+    int *value = NULL;
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(third, *value);
+
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(second, *value);
+
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(first, *value);
+
+    ASSERT_SUCCESS(aws_lifo_cache_put(&cache, fourth_key, (void **)&fourth));
+
+    /* make sure the latest entry was purged. Note, value should now be NULL but
+     * the call succeeds. */
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, third_key, (void **)&value));
+    ASSERT_NULL(value);
+
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, first_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(first, *value);
+
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, second_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(second, *value);
+
+    ASSERT_SUCCESS(aws_lifo_cache_find(&cache, fourth_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(fourth, *value);
+
+    aws_lifo_cache_clean_up(&cache);
+    return 0;
+}
+
+AWS_TEST_CASE(test_lifo_cache_overflow_static_members, s_test_lifo_cache_overflow_static_members_fn)

--- a/tests/linked_hash_table_test.c
+++ b/tests/linked_hash_table_test.c
@@ -1,0 +1,141 @@
+/*
+ *  Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+#include <aws/common/linked_hash_table.h>
+#include <aws/testing/aws_test_harness.h>
+
+static int s_test_linked_hash_table_preserves_insertion_order_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_linked_hash_table table;
+
+    ASSERT_SUCCESS(
+        aws_linked_hash_table_init(&table, allocator, aws_hash_c_string, aws_hash_callback_c_str_eq, NULL, NULL, 3));
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+    const char *third_key = "third";
+    const char *fourth_key = "fourth";
+
+    int first = 1;
+    int second = 2;
+    int third = 3;
+    int fourth = 4;
+
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, first_key, &first));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, second_key, &second));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, third_key, &third));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, fourth_key, &fourth));
+
+    ASSERT_INT_EQUALS(4, aws_linked_hash_table_get_element_count(&table));
+
+    int *value = NULL;
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, first_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(first, *value);
+
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, second_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(second, *value);
+
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, third_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(third, *value);
+
+    ASSERT_SUCCESS(aws_linked_hash_table_find(&table, fourth_key, (void **)&value));
+    ASSERT_NOT_NULL(value);
+    ASSERT_INT_EQUALS(fourth, *value);
+
+    const struct aws_linked_list *list = aws_linked_hash_table_get_iteration_list(&table);
+    ASSERT_NOT_NULL(list);
+
+    struct aws_linked_list_node *node = aws_linked_list_front(list);
+
+    struct aws_linked_hash_table_node *table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(first, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_NOT_NULL(node);
+    table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(second, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_NOT_NULL(node);
+    table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(third, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_NOT_NULL(node);
+    table_node = AWS_CONTAINER_OF(node, struct aws_linked_hash_table_node, node);
+    ASSERT_INT_EQUALS(fourth, *(int *)table_node->value);
+
+    node = aws_linked_list_next(node);
+    ASSERT_PTR_EQUALS(aws_linked_list_end(list), node);
+
+    aws_linked_hash_table_clean_up(&table);
+    return 0;
+}
+
+AWS_TEST_CASE(test_linked_hash_table_preserves_insertion_order, s_test_linked_hash_table_preserves_insertion_order_fn)
+
+struct linked_hash_table_test_value_element {
+    bool value_removed;
+};
+
+static void s_linked_hash_table_element_value_destroy(void *value) {
+    struct linked_hash_table_test_value_element *value_element = value;
+    value_element->value_removed = true;
+}
+
+static int s_test_linked_hash_table_entries_cleanup_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_linked_hash_table table;
+
+    ASSERT_SUCCESS(aws_linked_hash_table_init(
+        &table,
+        allocator,
+        aws_hash_c_string,
+        aws_hash_callback_c_str_eq,
+        NULL,
+        s_linked_hash_table_element_value_destroy,
+        2));
+
+    const char *first_key = "first";
+    const char *second_key = "second";
+
+    struct linked_hash_table_test_value_element first = {.value_removed = false};
+    struct linked_hash_table_test_value_element second = {.value_removed = false};
+
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, first_key, &first));
+    ASSERT_SUCCESS(aws_linked_hash_table_put(&table, second_key, &second));
+    ASSERT_INT_EQUALS(2, aws_linked_hash_table_get_element_count(&table));
+
+    ASSERT_SUCCESS(aws_linked_hash_table_remove(&table, second_key));
+
+    ASSERT_TRUE(second.value_removed);
+    ASSERT_INT_EQUALS(1, aws_linked_hash_table_get_element_count(&table));
+
+    aws_linked_hash_table_clear(&table);
+    ASSERT_INT_EQUALS(0, aws_linked_hash_table_get_element_count(&table));
+
+    ASSERT_TRUE(first.value_removed);
+    ASSERT_TRUE(aws_linked_list_empty(aws_linked_hash_table_get_iteration_list(&table)));
+
+    aws_linked_hash_table_clean_up(&table);
+    return 0;
+}
+
+AWS_TEST_CASE(test_linked_hash_table_entries_cleanup, s_test_linked_hash_table_entries_cleanup_fn)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- revet [remove linked_hash_table](https://github.com/awslabs/aws-c-common/pull/490)

- FIFO/LIFO/LRU caches based on aws_linked_hash_table

- APIs for LRU cache is changed here

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
