### PR TITLE
Moved use of GCC builtin intrinsics to their own math inline file

### DIFF
--- a/include/aws/common/math.fallback.inl
+++ b/include/aws/common/math.fallback.inl
@@ -104,6 +104,12 @@ AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r) {
     return AWS_OP_SUCCESS;
 }
 
+/*
+ * These are pure C implementations of the count leading/trailing zeros calls
+ * They should not be necessary unless using a really esoteric compiler with
+ * no intrinsics for these functions whatsoever.
+ */
+#if !defined(__clang__) && !defined(__GNUC__)
 /**
  * Search from the MSB to LSB, looking for a 1
  */
@@ -148,11 +154,11 @@ AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n) {
 }
 
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n) {
-#if SIZE_BITS == 64
+#    if SIZE_BITS == 64
     return aws_clz_u64(n);
-#else
+#    else
     return aws_clz_u32(n);
-#endif
+#    endif
 }
 
 /**
@@ -197,12 +203,14 @@ AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n) {
 }
 
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n) {
-#if SIZE_BITS == 64
+#    if SIZE_BITS == 64
     return aws_ctz_u64(n);
-#else
+#    else
     return aws_ctz_u32(n);
-#endif
+#    endif
 }
+
+#endif
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/math.gcc_builtin.inl
+++ b/include/aws/common/math.gcc_builtin.inl
@@ -1,0 +1,88 @@
+#ifndef AWS_COMMON_MATH_GCC_BUILTIN_INL
+#define AWS_COMMON_MATH_GCC_BUILTIN_INL
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * This header is already included, but include it again to make editor
+ * highlighting happier.
+ */
+#include <aws/common/common.h>
+#include <aws/common/math.h>
+
+/* clang-format off */
+
+AWS_EXTERN_C_BEGIN
+
+/**
+ * Search from the MSB to LSB, looking for a 1
+ */
+AWS_STATIC_IMPL size_t aws_clz_u32(uint32_t n) {
+    return __builtin_clzl(n);
+}
+
+AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n) {
+    return __builtin_clz(n);
+}
+
+AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n) {
+    return __builtin_clzll(n);
+}
+
+AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n) {
+    return __builtin_clzll(n);
+}
+
+AWS_STATIC_IMPL size_t aws_clz_size(size_t n) {
+#if SIZE_BITS == 64
+    return aws_clz_u64(n);
+#else
+    return aws_clz_u32(n);
+#endif
+}
+
+/**
+ * Search from the LSB to MSB, looking for a 1
+ */
+AWS_STATIC_IMPL size_t aws_ctz_u32(uint32_t n) {
+    return __builtin_ctzl(n);
+}
+
+AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n) {
+    return __builtin_ctz(n);
+}
+
+AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n) {
+    return __builtin_ctzll(n);
+}
+
+AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n) {
+    return __builtin_ctzll(n);
+}
+
+AWS_STATIC_IMPL size_t aws_ctz_size(size_t n) {
+#if SIZE_BITS == 64
+    return aws_ctz_u64(n);
+#else
+    return aws_ctz_u32(n);
+#endif
+}
+
+AWS_EXTERN_C_END
+
+/* clang-format on */
+
+#endif /* AWS_COMMON_MATH_GCC_BUILTIN_INL */

--- a/include/aws/common/math.gcc_overflow.inl
+++ b/include/aws/common/math.gcc_overflow.inl
@@ -120,60 +120,6 @@ AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
     return res;
 }
 
-/**
- * Search from the MSB to LSB, looking for a 1
- */
-AWS_STATIC_IMPL size_t aws_clz_u32(uint32_t n) {
-    return __builtin_clzl(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n) {
-    return __builtin_clz(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n) {
-    return __builtin_clzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n) {
-    return __builtin_clzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_size(size_t n) {
-#if SIZE_BITS == 64
-    return aws_clz_u64(n);
-#else
-    return aws_clz_u32(n);
-#endif
-}
-
-/**
- * Search from the LSB to MSB, looking for a 1
- */
-AWS_STATIC_IMPL size_t aws_ctz_u32(uint32_t n) {
-    return __builtin_ctzl(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n) {
-    return __builtin_ctz(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n) {
-    return __builtin_ctzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n) {
-    return __builtin_ctzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_size(size_t n) {
-#if SIZE_BITS == 64
-    return aws_ctz_u64(n);
-#else
-    return aws_ctz_u32(n);
-#endif
-}
-
 AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_MATH_GCC_OVERFLOW_INL */

--- a/include/aws/common/math.gcc_x64_asm.inl
+++ b/include/aws/common/math.gcc_x64_asm.inl
@@ -187,60 +187,6 @@ AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b) {
     return b;
 }
 
-/**
- * Search from the MSB to LSB, looking for a 1
- */
-AWS_STATIC_IMPL size_t aws_clz_u32(uint32_t n) {
-    return __builtin_clzl(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n) {
-    return __builtin_clz(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n) {
-    return __builtin_clzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n) {
-    return __builtin_clzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_clz_size(size_t n) {
-#if SIZE_BITS == 64
-    return aws_clz_u64(n);
-#else
-    return aws_clz_u32(n);
-#endif
-}
-
-/**
- * Search from the LSB to MSB, looking for a 1
- */
-AWS_STATIC_IMPL size_t aws_ctz_u32(uint32_t n) {
-    return __builtin_ctzl(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n) {
-    return __builtin_ctz(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n) {
-    return __builtin_ctzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n) {
-    return __builtin_ctzll(n);
-}
-
-AWS_STATIC_IMPL size_t aws_ctz_size(size_t n) {
-#if SIZE_BITS == 64
-    return aws_ctz_u64(n);
-#else
-    return aws_ctz_u32(n);
-#endif
-}
-
 AWS_EXTERN_C_END
 
 /* clang-format on */

--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -52,6 +52,10 @@ AWS_EXTERN_C_BEGIN
 #    endif /*  AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS */
 #endif     /*  defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus)) */
 
+#if defined(__clang__) || defined(_GNUC__)
+#    include <aws/common/math.gcc_builtin.inl>
+#endif
+
 #if _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4127) /*Disable "conditional expression is constant" */

--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -52,7 +52,7 @@ AWS_EXTERN_C_BEGIN
 #    endif /*  AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS */
 #endif     /*  defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus)) */
 
-#if defined(__clang__) || defined(_GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
 #    include <aws/common/math.gcc_builtin.inl>
 #endif
 


### PR DESCRIPTION
Fixes downstream C++ compile failures on ARM with GCC

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
