### PR TITLE
aws versions of isspace() isalpha() etc

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -754,6 +754,46 @@ AWS_COMMON_API bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x
  */
 AWS_COMMON_API bool aws_byte_buf_write_float_be64(struct aws_byte_buf *buf, double x);
 
+/**
+ * Returns true if ch has the value of ASCII/UTF-8: 'a'-'z', 'A'-'Z', or '0'-'9'.
+ * Ignores the C locale.
+ */
+AWS_COMMON_API bool aws_isalnum(uint8_t ch);
+
+/**
+ * Return true if ch has the value of ASCII/UTF-8: 'a'-'z' or 'A'-'Z'.
+ * Ignores the C locale.
+ */
+AWS_COMMON_API bool aws_isalpha(uint8_t ch);
+
+/**
+ * Return true if ch has the value of ASCII/UTF-8: '0'-'9'.
+ * Ignores the C locale.
+ *
+ * Note: C's built-in isdigit() is also supposed to ignore the C locale,
+ * but cppreference.com claims "some implementations (e.g. Microsoft in 1252 codepage)
+ * may classify additional single-byte characters as digits"
+ */
+AWS_COMMON_API bool aws_isdigit(uint8_t ch);
+
+/**
+ * Return true if ch has the value of ASCII/UTF-8: '0'-'9', 'a'-'f', or 'A'-'F'.
+ * Ignores the C locale.
+ *
+ * Note: C's built-in isxdigit() is also supposed to ignore the C locale,
+ * but cppreference.com claims "some implementations (e.g. Microsoft in 1252 codepage)
+ * may classify additional single-byte characters as digits"
+ */
+
+AWS_COMMON_API bool aws_isxdigit(uint8_t ch);
+
+/**
+ * Return true if ch has the value of ASCII/UTF-8: space (0x20), form feed (0x0C),
+ * line feed (0x0A), carriage return (0x0D), horizontal tab (0x09), or vertical tab (0x0B).
+ * Ignores the C locale.
+ */
+AWS_COMMON_API bool aws_isspace(uint8_t ch);
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_BYTE_BUF_H */

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -755,20 +755,20 @@ AWS_COMMON_API bool aws_byte_buf_write_be64(struct aws_byte_buf *buf, uint64_t x
 AWS_COMMON_API bool aws_byte_buf_write_float_be64(struct aws_byte_buf *buf, double x);
 
 /**
+ * Like isalnum(), but ignores C locale.
  * Returns true if ch has the value of ASCII/UTF-8: 'a'-'z', 'A'-'Z', or '0'-'9'.
- * Ignores the C locale.
  */
 AWS_COMMON_API bool aws_isalnum(uint8_t ch);
 
 /**
- * Return true if ch has the value of ASCII/UTF-8: 'a'-'z' or 'A'-'Z'.
- * Ignores the C locale.
+ * Like isalpha(), but ignores C locale.
+ * Returns true if ch has the value of ASCII/UTF-8: 'a'-'z' or 'A'-'Z'.
  */
 AWS_COMMON_API bool aws_isalpha(uint8_t ch);
 
 /**
- * Return true if ch has the value of ASCII/UTF-8: '0'-'9'.
- * Ignores the C locale.
+ * Like isdigit().
+ * Returns true if ch has the value of ASCII/UTF-8: '0'-'9'.
  *
  * Note: C's built-in isdigit() is also supposed to ignore the C locale,
  * but cppreference.com claims "some implementations (e.g. Microsoft in 1252 codepage)
@@ -777,8 +777,8 @@ AWS_COMMON_API bool aws_isalpha(uint8_t ch);
 AWS_COMMON_API bool aws_isdigit(uint8_t ch);
 
 /**
- * Return true if ch has the value of ASCII/UTF-8: '0'-'9', 'a'-'f', or 'A'-'F'.
- * Ignores the C locale.
+ * Like isxdigit().
+ * Returns true if ch has the value of ASCII/UTF-8: '0'-'9', 'a'-'f', or 'A'-'F'.
  *
  * Note: C's built-in isxdigit() is also supposed to ignore the C locale,
  * but cppreference.com claims "some implementations (e.g. Microsoft in 1252 codepage)

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -788,9 +788,9 @@ AWS_COMMON_API bool aws_isdigit(uint8_t ch);
 AWS_COMMON_API bool aws_isxdigit(uint8_t ch);
 
 /**
+ * Like isspace(), but ignores C locale.
  * Return true if ch has the value of ASCII/UTF-8: space (0x20), form feed (0x0C),
  * line feed (0x0A), carriage return (0x0D), horizontal tab (0x09), or vertical tab (0x0B).
- * Ignores the C locale.
  */
 AWS_COMMON_API bool aws_isspace(uint8_t ch);
 

--- a/include/aws/common/string.inl
+++ b/include/aws/common/string.inl
@@ -63,7 +63,7 @@ bool aws_c_string_is_valid(const char *str) {
  */
 AWS_STATIC_IMPL
 bool aws_char_is_space(uint8_t c) {
-    return isspace((int)c) != 0;
+    return aws_isspace(c);
 }
 
 AWS_EXTERN_C_END

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -1444,3 +1444,38 @@ static struct aws_byte_cursor s_null_terminator_cursor = AWS_BYTE_CUR_INIT_FROM_
 int aws_byte_buf_append_null_terminator(struct aws_byte_buf *buf) {
     return aws_byte_buf_append_dynamic(buf, &s_null_terminator_cursor);
 }
+
+bool aws_isalnum(uint8_t ch) {
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9');
+}
+
+bool aws_isalpha(uint8_t ch) {
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+}
+
+bool aws_isdigit(uint8_t ch) {
+    return (ch >= '0' && ch <= '9');
+}
+
+bool aws_isxdigit(uint8_t ch) {
+    return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+}
+
+bool aws_isspace(uint8_t ch) {
+    switch (ch) {
+        case 0x20: /* ' ' - space */
+            return true;
+        case 0x09: /* '\t' - horizontal tab */
+            return true;
+        case 0x0A: /* '\n' - line feed */
+            return true;
+        case 0x0B: /* '\v' - vertical tab */
+            return true;
+        case 0x0C: /* '\f' - form feed */
+            return true;
+        case 0x0D: /* '\r' - carriage return */
+            return true;
+        default:
+            return false;
+    }
+}

--- a/source/date_time.c
+++ b/source/date_time.c
@@ -225,7 +225,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
         size_t sub_index = index - state_start_index;
         switch (state) {
             case ON_YEAR:
-                if (isdigit(c)) {
+                if (aws_isdigit(c)) {
                     parsed_time->tm_year = parsed_time->tm_year * 10 + (c - '0');
                     if (sub_index == 3) {
                         state = ON_MONTH;
@@ -238,7 +238,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
                 break;
 
             case ON_MONTH:
-                if (isdigit(c)) {
+                if (aws_isdigit(c)) {
                     parsed_time->tm_mon = parsed_time->tm_mon * 10 + (c - '0');
                     if (sub_index == 1) {
                         state = ON_MONTH_DAY;
@@ -254,7 +254,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
                 if (c == 'T' && sub_index == 2) {
                     state = ON_HOUR;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_mday = parsed_time->tm_mday * 10 + (c - '0');
                 } else {
                     error = true;
@@ -262,7 +262,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
                 break;
 
             case ON_HOUR:
-                if (isdigit(c)) {
+                if (aws_isdigit(c)) {
                     parsed_time->tm_hour = parsed_time->tm_hour * 10 + (c - '0');
                     if (sub_index == 1) {
                         state = ON_MINUTE;
@@ -274,7 +274,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
                 break;
 
             case ON_MINUTE:
-                if (isdigit(c)) {
+                if (aws_isdigit(c)) {
                     parsed_time->tm_min = parsed_time->tm_min * 10 + (c - '0');
                     if (sub_index == 1) {
                         state = ON_SECOND;
@@ -286,7 +286,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
                 break;
 
             case ON_SECOND:
-                if (isdigit(c)) {
+                if (aws_isdigit(c)) {
                     parsed_time->tm_sec = parsed_time->tm_sec * 10 + (c - '0');
                     if (sub_index == 1) {
                         state = ON_TZ;
@@ -300,7 +300,7 @@ static int s_parse_iso_8601_basic(const struct aws_byte_cursor *date_str_cursor,
             case ON_TZ:
                 if (c == 'Z' && (sub_index == 0 || sub_index == 3)) {
                     state = FINISHED;
-                } else if (!isdigit(c) || sub_index > 3) {
+                } else if (!aws_isdigit(c) || sub_index > 3) {
                     error = true;
                 }
                 break;
@@ -334,7 +334,7 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                     state = ON_MONTH;
                     state_start_index = index + 1;
                     parsed_time->tm_year -= 1900;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_year = parsed_time->tm_year * 10 + (c - '0');
                 } else {
                     error = true;
@@ -345,7 +345,7 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                     state = ON_MONTH_DAY;
                     state_start_index = index + 1;
                     parsed_time->tm_mon -= 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_mon = parsed_time->tm_mon * 10 + (c - '0');
                 } else {
                     error = true;
@@ -356,7 +356,7 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                 if (c == 'T' && index - state_start_index == 2) {
                     state = ON_HOUR;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_mday = parsed_time->tm_mday * 10 + (c - '0');
                 } else {
                     error = true;
@@ -368,13 +368,13 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                 if (index - state_start_index == 2) {
                     state = ON_MINUTE;
                     state_start_index = index + 1;
-                    if (isdigit(c)) {
+                    if (aws_isdigit(c)) {
                         state_start_index = index;
                         advance = false;
                     } else if (c != ':') {
                         error = true;
                     }
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_hour = parsed_time->tm_hour * 10 + (c - '0');
                 } else {
                     error = true;
@@ -386,13 +386,13 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                 if (index - state_start_index == 2) {
                     state = ON_SECOND;
                     state_start_index = index + 1;
-                    if (isdigit(c)) {
+                    if (aws_isdigit(c)) {
                         state_start_index = index;
                         advance = false;
                     } else if (c != ':') {
                         error = true;
                     }
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_min = parsed_time->tm_min * 10 + (c - '0');
                 } else {
                     error = true;
@@ -406,7 +406,7 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                 } else if (c == '.' && index - state_start_index == 2) {
                     state = ON_TZ;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_sec = parsed_time->tm_sec * 10 + (c - '0');
                 } else {
                     error = true;
@@ -417,7 +417,7 @@ static int s_parse_iso_8601(const struct aws_byte_cursor *date_str_cursor, struc
                 if (c == 'Z') {
                     state = FINISHED;
                     state_start_index = index + 1;
-                } else if (!isdigit(c)) {
+                } else if (!aws_isdigit(c)) {
                     error = true;
                 }
                 break;
@@ -459,14 +459,14 @@ static int s_parse_rfc_822(
                 if (c == ',') {
                     state = ON_SPACE_DELIM;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     state = ON_MONTH_DAY;
-                } else if (!isalpha(c)) {
+                } else if (!aws_isalpha(c)) {
                     error = true;
                 }
                 break;
             case ON_SPACE_DELIM:
-                if (isspace(c)) {
+                if (aws_isspace(c)) {
                     state = ON_MONTH_DAY;
                     state_start_index = index + 1;
                 } else {
@@ -474,9 +474,9 @@ static int s_parse_rfc_822(
                 }
                 break;
             case ON_MONTH_DAY:
-                if (isdigit(c)) {
+                if (aws_isdigit(c)) {
                     parsed_time->tm_mday = parsed_time->tm_mday * 10 + (c - '0');
-                } else if (isspace(c)) {
+                } else if (aws_isspace(c)) {
                     state = ON_MONTH;
                     state_start_index = index + 1;
                 } else {
@@ -484,7 +484,7 @@ static int s_parse_rfc_822(
                 }
                 break;
             case ON_MONTH:
-                if (isspace(c)) {
+                if (aws_isspace(c)) {
                     int monthNumber =
                         get_month_number_from_str((const char *)date_str_cursor->ptr, state_start_index, index + 1);
 
@@ -495,21 +495,21 @@ static int s_parse_rfc_822(
                     } else {
                         error = true;
                     }
-                } else if (!isalpha(c)) {
+                } else if (!aws_isalpha(c)) {
                     error = true;
                 }
                 break;
             /* year can be 4 or 2 digits. */
             case ON_YEAR:
-                if (isspace(c) && index - state_start_index == 4) {
+                if (aws_isspace(c) && index - state_start_index == 4) {
                     state = ON_HOUR;
                     state_start_index = index + 1;
                     parsed_time->tm_year -= 1900;
-                } else if (isspace(c) && index - state_start_index == 2) {
+                } else if (aws_isspace(c) && index - state_start_index == 2) {
                     state = 5;
                     state_start_index = index + 1;
                     parsed_time->tm_year += 2000 - 1900;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_year = parsed_time->tm_year * 10 + (c - '0');
                 } else {
                     error = true;
@@ -519,7 +519,7 @@ static int s_parse_rfc_822(
                 if (c == ':' && index - state_start_index == 2) {
                     state = ON_MINUTE;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_hour = parsed_time->tm_hour * 10 + (c - '0');
                 } else {
                     error = true;
@@ -529,24 +529,24 @@ static int s_parse_rfc_822(
                 if (c == ':' && index - state_start_index == 2) {
                     state = ON_SECOND;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_min = parsed_time->tm_min * 10 + (c - '0');
                 } else {
                     error = true;
                 }
                 break;
             case ON_SECOND:
-                if (isspace(c) && index - state_start_index == 2) {
+                if (aws_isspace(c) && index - state_start_index == 2) {
                     state = ON_TZ;
                     state_start_index = index + 1;
-                } else if (isdigit(c)) {
+                } else if (aws_isdigit(c)) {
                     parsed_time->tm_sec = parsed_time->tm_sec * 10 + (c - '0');
                 } else {
                     error = true;
                 }
                 break;
             case ON_TZ:
-                if ((isalnum(c) || c == '-' || c == '+') && (index - state_start_index) < 5) {
+                if ((aws_isalnum(c) || c == '-' || c == '+') && (index - state_start_index) < 5) {
                     dt->tz[index - state_start_index] = c;
                 } else {
                     error = true;

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -73,8 +73,8 @@ bool aws_is_debugger_present(void) {
 
     /* If it's not 0, then there's a debugger */
     for (const char *cur = tracer_pid + sizeof(tracerPidString) - 1; cur <= buf + num_read; ++cur) {
-        if (!isspace(*cur)) {
-            return isdigit(*cur) != 0 && *cur != '0';
+        if (!aws_isspace(*cur)) {
+            return aws_isdigit(*cur) && *cur != '0';
         }
     }
 
@@ -118,8 +118,8 @@ struct aws_stack_frame_info {
 char *s_whitelist_chars(char *path) {
     char *cur = path;
     while (*cur) {
-        bool whitelisted =
-            isalnum(*cur) || isspace(*cur) || *cur == '/' || *cur == '_' || *cur == '.' || (cur > path && *cur == '-');
+        bool whitelisted = aws_isalnum(*cur) || aws_isspace(*cur) || *cur == '/' || *cur == '_' || *cur == '.' ||
+                           (cur > path && *cur == '-');
         if (!whitelisted) {
             *cur = '_';
         }
@@ -150,7 +150,7 @@ int s_parse_symbol(const char *symbol, void *addr, struct aws_stack_frame_info *
     const char *current_exe = s_get_executable_path();
     /* parse exe/shared lib */
     const char *exe_start = strstr(symbol, " ");
-    while (isspace(*exe_start)) {
+    while (aws_isspace(*exe_start)) {
         ++exe_start;
     }
     const char *exe_end = strstr(exe_start, " ");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,11 @@ add_test_case(test_byte_buf_reserve_relative)
 add_test_case(test_byte_buf_reset)
 add_test_case(test_byte_cursor_compare_lexical)
 add_test_case(test_byte_cursor_compare_lookup)
+add_test_case(test_isalnum)
+add_test_case(test_isalpha)
+add_test_case(test_isdigit)
+add_test_case(test_isxdigit)
+add_test_case(test_isspace)
 
 add_test_case(byte_swap_test)
 

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -18,6 +18,8 @@
 #include <aws/common/string.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <locale.h>
+
 AWS_TEST_CASE(test_buffer_cat, s_test_buffer_cat_fn)
 static int s_test_buffer_cat_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -814,3 +816,136 @@ static int s_test_byte_buf_append_and_update_success(struct aws_allocator *alloc
     return 0;
 }
 AWS_TEST_CASE(test_byte_buf_append_and_update_success, s_test_byte_buf_append_and_update_success)
+
+static int s_test_isalnum(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    ASSERT_TRUE(aws_isalnum('0'));
+    ASSERT_TRUE(aws_isalnum('a'));
+    ASSERT_TRUE(aws_isalnum('A'));
+
+    ASSERT_FALSE(aws_isalnum(' '));
+    ASSERT_FALSE(aws_isalnum('\0'));
+
+    size_t count = 0;
+    for (size_t i = 0; i <= UINT8_MAX; ++i) {
+        if (aws_isalnum((uint8_t)i)) {
+            count++;
+        }
+    }
+    ASSERT_UINT_EQUALS(62, count);
+
+    /* should not be affected by C locale */
+    setlocale(LC_CTYPE, "de_DE.iso88591");
+    ASSERT_FALSE(aws_isalnum('\xdf')); /* German letter ß in ISO-8859-1 */
+
+    return 0;
+}
+AWS_TEST_CASE(test_isalnum, s_test_isalnum)
+
+static int s_test_isalpha(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    ASSERT_TRUE(aws_isalpha('a'));
+    ASSERT_TRUE(aws_isalpha('A'));
+
+    ASSERT_FALSE(aws_isalpha('0'));
+    ASSERT_FALSE(aws_isalpha('\0'));
+    ASSERT_FALSE(aws_isalpha(' '));
+
+    size_t count = 0;
+    for (size_t i = 0; i <= UINT8_MAX; ++i) {
+        if (aws_isalpha((uint8_t)i)) {
+            count++;
+        }
+    }
+    ASSERT_UINT_EQUALS(52, count);
+
+    /* should not be affected by C locale */
+    setlocale(LC_CTYPE, "de_DE.iso88591");
+    ASSERT_FALSE(aws_isalpha('\xdf')); /* German letter ß in ISO-8859-1 */
+
+    return 0;
+}
+AWS_TEST_CASE(test_isalpha, s_test_isalpha)
+
+static int s_test_isdigit(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    ASSERT_TRUE(aws_isdigit('0'));
+    ASSERT_TRUE(aws_isdigit('9'));
+
+    ASSERT_FALSE(aws_isdigit('a'));
+    ASSERT_FALSE(aws_isdigit('A'));
+    ASSERT_FALSE(aws_isdigit('\0'));
+    ASSERT_FALSE(aws_isdigit(' '));
+
+    size_t count = 0;
+    for (size_t i = 0; i <= UINT8_MAX; ++i) {
+        if (aws_isdigit((uint8_t)i)) {
+            count++;
+        }
+    }
+    ASSERT_UINT_EQUALS(10, count);
+
+    return 0;
+}
+AWS_TEST_CASE(test_isdigit, s_test_isdigit)
+
+static int s_test_isxdigit(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    ASSERT_TRUE(aws_isxdigit('0'));
+    ASSERT_TRUE(aws_isxdigit('9'));
+    ASSERT_TRUE(aws_isxdigit('a'));
+    ASSERT_TRUE(aws_isxdigit('A'));
+    ASSERT_TRUE(aws_isxdigit('f'));
+    ASSERT_TRUE(aws_isxdigit('F'));
+
+    ASSERT_FALSE(aws_isxdigit('g'));
+    ASSERT_FALSE(aws_isxdigit('G'));
+    ASSERT_FALSE(aws_isxdigit('\0'));
+    ASSERT_FALSE(aws_isxdigit(' '));
+
+    size_t count = 0;
+    for (size_t i = 0; i <= UINT8_MAX; ++i) {
+        if (aws_isxdigit((uint8_t)i)) {
+            count++;
+        }
+    }
+    ASSERT_UINT_EQUALS(22, count);
+
+    return 0;
+}
+AWS_TEST_CASE(test_isxdigit, s_test_isxdigit)
+
+static int s_test_isspace(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    ASSERT_TRUE(aws_isspace(' '));
+    ASSERT_TRUE(aws_isspace('\t'));
+    ASSERT_TRUE(aws_isspace('\n'));
+    ASSERT_TRUE(aws_isspace('\v'));
+    ASSERT_TRUE(aws_isspace('\f'));
+    ASSERT_TRUE(aws_isspace('\r'));
+
+    ASSERT_FALSE(aws_isspace('\0'));
+    ASSERT_FALSE(aws_isspace('a'));
+    ASSERT_FALSE(aws_isspace(0xA0)); /* NBSP in some code-pages */
+
+    size_t count = 0;
+    for (size_t i = 0; i <= UINT8_MAX; ++i) {
+        if (aws_isspace((uint8_t)i)) {
+            count++;
+        }
+    }
+    ASSERT_UINT_EQUALS(6, count);
+
+    return 0;
+}
+AWS_TEST_CASE(test_isspace, s_test_isspace)

--- a/tests/cursor_test.c
+++ b/tests/cursor_test.c
@@ -278,17 +278,13 @@ static const char *s_right_whitespace = TEST_STRING " \r \t \n";
 static const char *s_both_whitespace = "  \t \r\n " TEST_STRING " \r \t \n";
 static const char *expected_non_empty_result = TEST_STRING;
 
-static bool s_is_whitespace(uint8_t value) {
-    return isspace(value);
-}
-
 static int s_test_byte_cursor_right_trim_empty(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)allocator;
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_empty);
 
-    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, aws_isspace);
 
     ASSERT_TRUE(result.len == 0);
 
@@ -302,7 +298,7 @@ static int s_test_byte_cursor_right_trim_all_whitespace(struct aws_allocator *al
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_all_whitespace);
 
-    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, aws_isspace);
 
     ASSERT_TRUE(result.len == 0);
 
@@ -316,7 +312,7 @@ static int s_test_byte_cursor_right_trim_basic(struct aws_allocator *allocator, 
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_right_whitespace);
 
-    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, aws_isspace);
 
     size_t expected_length = strlen(expected_non_empty_result);
     ASSERT_TRUE(strncmp((const char *)result.ptr, expected_non_empty_result, expected_length) == 0);
@@ -332,7 +328,7 @@ static int s_test_byte_cursor_left_trim_empty(struct aws_allocator *allocator, v
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_empty);
 
-    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, aws_isspace);
 
     ASSERT_TRUE(result.len == 0);
 
@@ -346,7 +342,7 @@ static int s_test_byte_cursor_left_trim_all_whitespace(struct aws_allocator *all
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_all_whitespace);
 
-    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_right_trim_pred(&test_cursor, aws_isspace);
 
     ASSERT_TRUE(result.len == 0);
 
@@ -360,7 +356,7 @@ static int s_test_byte_cursor_left_trim_basic(struct aws_allocator *allocator, v
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_left_whitespace);
 
-    struct aws_byte_cursor result = aws_byte_cursor_left_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_left_trim_pred(&test_cursor, aws_isspace);
 
     ASSERT_TRUE(strcmp((const char *)result.ptr, expected_non_empty_result) == 0);
 
@@ -374,7 +370,7 @@ static int s_test_byte_cursor_trim_basic(struct aws_allocator *allocator, void *
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_c_str(s_both_whitespace);
 
-    struct aws_byte_cursor result = aws_byte_cursor_trim_pred(&test_cursor, s_is_whitespace);
+    struct aws_byte_cursor result = aws_byte_cursor_trim_pred(&test_cursor, aws_isspace);
 
     size_t expected_length = strlen(expected_non_empty_result);
     ASSERT_TRUE(strncmp((const char *)result.ptr, expected_non_empty_result, expected_length) == 0);


### PR DESCRIPTION
These functions are affected by the user's "locale".
Ex: German letter ß in ISO-8859-1 fits in 1 byte, and would pass `isalpha()`

We need safe versions of these functions that ignore the locale.

Downstream PRs:
https://github.com/awslabs/aws-c-io/pull/278
https://github.com/awslabs/aws-c-auth/pull/84

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
