### PR TITLE
Use correctly mangled loop names in CBMC proofs

### DIFF
--- a/verification/cbmc/proofs/aws_linked_list_end/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_end/Makefile
@@ -8,7 +8,7 @@ include ../Makefile.aws_linked_list
 # Run deep validity checks in linked_list_is_valid
 AWS_DEEP_CHECKS = 1
 
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_front/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_front/Makefile
@@ -8,7 +8,7 @@ AWS_DEEP_CHECKS = 1
 
 include ../Makefile.aws_linked_list
 
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_init/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_init/Makefile
@@ -9,7 +9,7 @@ AWS_DEEP_CHECKS = 1
 # The loops have to be unwinded as many times as the elements of the
 # list + 2. In this case, aws_linked_list_init returns an empty list
 # so it is just 2.
-UNWINDSET += aws_linked_list_is_valid_deep.0:2
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:2
 
 CBMCFLAGS +=
 

--- a/verification/cbmc/proofs/aws_linked_list_pop_back/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_pop_back/Makefile
@@ -8,7 +8,7 @@ AWS_DEEP_CHECKS = 1
 
 include ../Makefile.aws_linked_list
 
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_pop_front/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_pop_front/Makefile
@@ -8,7 +8,7 @@ AWS_DEEP_CHECKS = 1
 
 include ../Makefile.aws_linked_list
 
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_push_back/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_push_back/Makefile
@@ -11,7 +11,7 @@ include ../Makefile.aws_linked_list
 ## This has to take into account that a new element has been added to
 ## the list afterwards so we have to unwind one more time (instead of
 ## the standard 2 + MAX_LINKED_LIST_ITEM_ALLOCATION)
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((3 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((3 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_push_front/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_push_front/Makefile
@@ -11,7 +11,7 @@ include ../Makefile.aws_linked_list
 ## This has to take into account that a new element has been added to
 ## the list afterwards so we have to unwind one more time (instead of
 ## the standard 2 + MAX_LINKED_LIST_ITEM_ALLOCATION)
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((3 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((3 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_rbegin/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_rbegin/Makefile
@@ -8,7 +8,7 @@ AWS_DEEP_CHECKS = 1
 
 include ../Makefile.aws_linked_list
 
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=

--- a/verification/cbmc/proofs/aws_linked_list_swap_contents/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_swap_contents/Makefile
@@ -8,7 +8,7 @@ AWS_DEEP_CHECKS = 1
 
 include ../Makefile.aws_linked_list
 
-UNWINDSET += aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION))))
 
 CBMCFLAGS +=


### PR DESCRIPTION
This commit fixes the name of a loop in several linked_list CBMC proofs.
The loop name had previously been working correctly due to a bug in
CBMC, which has now been addressed. When using up-to-date versions of
CBMC, the changes in this PR will be required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
