### PR TITLE
Add .gitignore from template Makefile

### DIFF
--- a/verification/cbmc/.gitignore
+++ b/verification/cbmc/.gitignore
@@ -1,4 +1,8 @@
-html
-property.xml
-coverage.xml
-cbmc.txt
+# Emitted when running CBMC proofs
+proofs/**/logs
+proofs/**/gotos
+proofs/**/report
+proofs/**/html
+
+# Emitted by CBMC Viewer
+TAGS-*


### PR DESCRIPTION
This commit adds the standard .gitignore from the CBMC template
Makefile, ensuring that all CBMC output directories are ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
