### PR TITLE
aws_linked_list_move_all_back()

### DIFF
--- a/include/aws/common/linked_list.h
+++ b/include/aws/common/linked_list.h
@@ -158,21 +158,27 @@ AWS_STATIC_IMPL struct aws_linked_list_node *aws_linked_list_front(const struct 
  */
 AWS_STATIC_IMPL struct aws_linked_list_node *aws_linked_list_pop_front(struct aws_linked_list *list);
 
-AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, struct aws_linked_list *b);
+AWS_STATIC_IMPL void aws_linked_list_swap_contents(
+    struct aws_linked_list *AWS_RESTRICT a,
+    struct aws_linked_list *AWS_RESTRICT b);
 
 /**
  * Remove all nodes from one list, and add them to the back of another.
  *
  * Example: if dst={1,2} and src={3,4}, they become dst={1,2,3,4} and src={}
  */
-AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, struct aws_linked_list *src);
+AWS_STATIC_IMPL void aws_linked_list_move_all_back(
+    struct aws_linked_list *AWS_RESTRICT dst,
+    struct aws_linked_list *AWS_RESTRICT src);
 
 /**
  * Remove all nodes from one list, and add them to the front of another.
  *
  * Example: if dst={2,1} and src={4,3}, they become dst={4,3,2,1} and src={}
  */
-AWS_STATIC_IMPL void aws_linked_list_move_all_front(struct aws_linked_list *dst, struct aws_linked_list *src);
+AWS_STATIC_IMPL void aws_linked_list_move_all_front(
+    struct aws_linked_list *AWS_RESTRICT dst,
+    struct aws_linked_list *AWS_RESTRICT src);
 
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/linked_list.inl>

--- a/include/aws/common/linked_list.h
+++ b/include/aws/common/linked_list.h
@@ -160,6 +160,20 @@ AWS_STATIC_IMPL struct aws_linked_list_node *aws_linked_list_pop_front(struct aw
 
 AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, struct aws_linked_list *b);
 
+/**
+ * Remove all nodes from one list, and add them to the back of another.
+ *
+ * Example: if dst={1,2} and src={3,4}, they become dst={1,2,3,4} and src={}
+ */
+AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, struct aws_linked_list *src);
+
+/**
+ * Remove all nodes from one list, and add them to the front of another.
+ *
+ * Example: if dst={2,1} and src={4,3}, they become dst={4,3,2,1} and src={}
+ */
+AWS_STATIC_IMPL void aws_linked_list_move_all_front(struct aws_linked_list *dst, struct aws_linked_list *src);
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/linked_list.inl>
 #endif /* AWS_NO_STATIC_IMPL */

--- a/include/aws/common/linked_list.inl
+++ b/include/aws/common/linked_list.inl
@@ -343,6 +343,7 @@ AWS_STATIC_IMPL struct aws_linked_list_node *aws_linked_list_pop_front(struct aw
 AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, struct aws_linked_list *b) {
     AWS_PRECONDITION(aws_linked_list_is_valid(a));
     AWS_PRECONDITION(aws_linked_list_is_valid(b));
+    AWS_PRECONDITION(a != b);
     struct aws_linked_list_node *a_first = a->head.next;
     struct aws_linked_list_node *a_last = a->tail.prev;
 
@@ -372,6 +373,7 @@ AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, st
 AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, struct aws_linked_list *src) {
     AWS_PRECONDITION(aws_linked_list_is_valid(src));
     AWS_PRECONDITION(aws_linked_list_is_valid(dst));
+    AWS_PRECONDITION(dst != src);
 
     if (!aws_linked_list_empty(src)) {
         /* splice src nodes into dst, between the back and tail nodes */
@@ -397,6 +399,7 @@ AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, 
 AWS_STATIC_IMPL void aws_linked_list_move_all_front(struct aws_linked_list *dst, struct aws_linked_list *src) {
     AWS_PRECONDITION(aws_linked_list_is_valid(src));
     AWS_PRECONDITION(aws_linked_list_is_valid(dst));
+    AWS_PRECONDITION(dst != src);
 
     if (!aws_linked_list_empty(src)) {
         /* splice src nodes into dst, between the head and front nodes */

--- a/include/aws/common/linked_list.inl
+++ b/include/aws/common/linked_list.inl
@@ -340,7 +340,10 @@ AWS_STATIC_IMPL struct aws_linked_list_node *aws_linked_list_pop_front(struct aw
     return front;
 }
 
-AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, struct aws_linked_list *b) {
+AWS_STATIC_IMPL void aws_linked_list_swap_contents(
+    struct aws_linked_list *AWS_RESTRICT a,
+    struct aws_linked_list *AWS_RESTRICT b) {
+
     AWS_PRECONDITION(aws_linked_list_is_valid(a));
     AWS_PRECONDITION(aws_linked_list_is_valid(b));
     AWS_PRECONDITION(a != b);
@@ -370,7 +373,10 @@ AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, st
     AWS_POSTCONDITION(aws_linked_list_is_valid(b));
 }
 
-AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, struct aws_linked_list *src) {
+AWS_STATIC_IMPL void aws_linked_list_move_all_back(
+    struct aws_linked_list *AWS_RESTRICT dst,
+    struct aws_linked_list *AWS_RESTRICT src) {
+
     AWS_PRECONDITION(aws_linked_list_is_valid(src));
     AWS_PRECONDITION(aws_linked_list_is_valid(dst));
     AWS_PRECONDITION(dst != src);
@@ -396,7 +402,10 @@ AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, 
     AWS_POSTCONDITION(aws_linked_list_is_valid(dst));
 }
 
-AWS_STATIC_IMPL void aws_linked_list_move_all_front(struct aws_linked_list *dst, struct aws_linked_list *src) {
+AWS_STATIC_IMPL void aws_linked_list_move_all_front(
+    struct aws_linked_list *AWS_RESTRICT dst,
+    struct aws_linked_list *AWS_RESTRICT src) {
+
     AWS_PRECONDITION(aws_linked_list_is_valid(src));
     AWS_PRECONDITION(aws_linked_list_is_valid(dst));
     AWS_PRECONDITION(dst != src);

--- a/include/aws/common/linked_list.inl
+++ b/include/aws/common/linked_list.inl
@@ -369,6 +369,56 @@ AWS_STATIC_IMPL void aws_linked_list_swap_contents(struct aws_linked_list *a, st
     AWS_POSTCONDITION(aws_linked_list_is_valid(b));
 }
 
+AWS_STATIC_IMPL void aws_linked_list_move_all_back(struct aws_linked_list *dst, struct aws_linked_list *src) {
+    AWS_PRECONDITION(aws_linked_list_is_valid(src));
+    AWS_PRECONDITION(aws_linked_list_is_valid(dst));
+
+    if (!aws_linked_list_empty(src)) {
+        /* splice src nodes into dst, between the back and tail nodes */
+        struct aws_linked_list_node *dst_back = dst->tail.prev;
+        struct aws_linked_list_node *src_front = src->head.next;
+        struct aws_linked_list_node *src_back = src->tail.prev;
+
+        dst_back->next = src_front;
+        src_front->prev = dst_back;
+
+        dst->tail.prev = src_back;
+        src_back->next = &dst->tail;
+
+        /* reset src */
+        src->head.next = &src->tail;
+        src->tail.prev = &src->head;
+    }
+
+    AWS_POSTCONDITION(aws_linked_list_is_valid(src));
+    AWS_POSTCONDITION(aws_linked_list_is_valid(dst));
+}
+
+AWS_STATIC_IMPL void aws_linked_list_move_all_front(struct aws_linked_list *dst, struct aws_linked_list *src) {
+    AWS_PRECONDITION(aws_linked_list_is_valid(src));
+    AWS_PRECONDITION(aws_linked_list_is_valid(dst));
+
+    if (!aws_linked_list_empty(src)) {
+        /* splice src nodes into dst, between the head and front nodes */
+        struct aws_linked_list_node *dst_front = dst->head.next;
+        struct aws_linked_list_node *src_front = src->head.next;
+        struct aws_linked_list_node *src_back = src->tail.prev;
+
+        dst->head.next = src_front;
+        src_front->prev = &dst->head;
+
+        src_back->next = dst_front;
+        dst_front->prev = src_back;
+
+        /* reset src */
+        src->head.next = &src->tail;
+        src->tail.prev = &src->head;
+    }
+
+    AWS_POSTCONDITION(aws_linked_list_is_valid(src));
+    AWS_POSTCONDITION(aws_linked_list_is_valid(dst));
+}
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_LINKED_LIST_INL */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,8 @@ add_test_case(linked_list_swap_nodes)
 add_test_case(linked_list_iteration)
 add_test_case(linked_list_reverse_iteration)
 add_test_case(linked_list_swap_contents)
+add_test_case(linked_list_move_all_back)
+add_test_case(linked_list_move_all_front)
 
 add_test_case(hex_encoding_test_case_empty_test)
 add_test_case(hex_encoding_test_case_f_test)

--- a/tests/linked_list_test.c
+++ b/tests/linked_list_test.c
@@ -312,9 +312,209 @@ static int s_test_linked_list_swap_contents(struct aws_allocator *allocator, voi
     return AWS_OP_SUCCESS;
 }
 
+static int s_test_linked_list_move_all_back(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct aws_linked_list a, b;
+    struct aws_linked_list_node a1, a2, b1, b2;
+
+    /* Setup lists like:
+     * a = {a1, a2}
+     * b = {b1, b2}
+     *
+     * After move should be like:
+     * a = {a1, a2, b1, b2}
+     * b = {}
+     */
+    aws_linked_list_init(&a);
+    aws_linked_list_push_back(&a, &a1);
+    aws_linked_list_push_back(&a, &a2);
+
+    aws_linked_list_init(&b);
+    aws_linked_list_push_back(&b, &b1);
+    aws_linked_list_push_back(&b, &b2);
+
+    aws_linked_list_move_all_back(&a, &b);
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&a));
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&b));
+    ASSERT_TRUE(aws_linked_list_empty(&b));
+
+    struct aws_linked_list_node *expected_a1a2b1b2[] = {&a1, &a2, &b1, &b2};
+    struct aws_linked_list_node *it = aws_linked_list_begin(&a);
+    size_t i = 0;
+    while (it != aws_linked_list_end(&a)) {
+        ASSERT_PTR_EQUALS(expected_a1a2b1b2[i], it);
+        it = aws_linked_list_next(it);
+        i++;
+    };
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(expected_a1a2b1b2), i);
+
+    /* Setup lists like:
+     * a = {}
+     * b = {b1, b2}
+     *
+     * After move should be like:
+     * a = {b1, b2}
+     * b = {}
+     */
+    aws_linked_list_init(&a);
+
+    aws_linked_list_init(&b);
+    aws_linked_list_push_back(&b, &b1);
+    aws_linked_list_push_back(&b, &b2);
+
+    aws_linked_list_move_all_back(&a, &b);
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&a));
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&b));
+    ASSERT_TRUE(aws_linked_list_empty(&b));
+
+    struct aws_linked_list_node *expected_b1b2[] = {&b1, &b2};
+    it = aws_linked_list_begin(&a);
+    i = 0;
+    while (it != aws_linked_list_end(&a)) {
+        ASSERT_PTR_EQUALS(expected_b1b2[i], it);
+        it = aws_linked_list_next(it);
+        i++;
+    };
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(expected_b1b2), i);
+
+    /* Setup lists like:
+     * a = {a1}
+     * b = {b1}
+     *
+     * After move should be like:
+     * a = {a1, b1}
+     * b = {}
+     */
+    aws_linked_list_init(&a);
+    aws_linked_list_push_back(&a, &a1);
+
+    aws_linked_list_init(&b);
+    aws_linked_list_push_back(&b, &b1);
+
+    aws_linked_list_move_all_back(&a, &b);
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&a));
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&b));
+    ASSERT_TRUE(aws_linked_list_empty(&b));
+
+    struct aws_linked_list_node *expected_a1b1[] = {&a1, &b1};
+    it = aws_linked_list_begin(&a);
+    i = 0;
+    while (it != aws_linked_list_end(&a)) {
+        ASSERT_PTR_EQUALS(expected_a1b1[i], it);
+        it = aws_linked_list_next(it);
+        i++;
+    };
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(expected_a1b1), i);
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_test_linked_list_move_all_front(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    struct aws_linked_list a, b;
+    struct aws_linked_list_node a1, a2, b1, b2;
+
+    /* Setup lists like:
+     * a = {a2, a1}
+     * b = {b2, b1}
+     *
+     * After move should be like:
+     * a = {b2, b1, a2, a1}
+     * b = {}
+     */
+    aws_linked_list_init(&a);
+    aws_linked_list_push_front(&a, &a1);
+    aws_linked_list_push_front(&a, &a2);
+
+    aws_linked_list_init(&b);
+    aws_linked_list_push_front(&b, &b1);
+    aws_linked_list_push_front(&b, &b2);
+
+    aws_linked_list_move_all_front(&a, &b);
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&a));
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&b));
+    ASSERT_TRUE(aws_linked_list_empty(&b));
+
+    struct aws_linked_list_node *expected_b2b1a2a1[] = {&b2, &b1, &a2, &a1};
+    struct aws_linked_list_node *it = aws_linked_list_begin(&a);
+    size_t i = 0;
+    while (it != aws_linked_list_end(&a)) {
+        ASSERT_PTR_EQUALS(expected_b2b1a2a1[i], it);
+        it = aws_linked_list_next(it);
+        i++;
+    };
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(expected_b2b1a2a1), i);
+
+    /* Setup lists like:
+     * a = {}
+     * b = {b2, b1}
+     *
+     * After move should be like:
+     * a = {b2, b1}
+     * b = {}
+     */
+    aws_linked_list_init(&a);
+
+    aws_linked_list_init(&b);
+    aws_linked_list_push_front(&b, &b1);
+    aws_linked_list_push_front(&b, &b2);
+
+    aws_linked_list_move_all_front(&a, &b);
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&a));
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&b));
+    ASSERT_TRUE(aws_linked_list_empty(&b));
+
+    struct aws_linked_list_node *expected_b2b1[] = {&b2, &b1};
+    it = aws_linked_list_begin(&a);
+    i = 0;
+    while (it != aws_linked_list_end(&a)) {
+        ASSERT_PTR_EQUALS(expected_b2b1[i], it);
+        it = aws_linked_list_next(it);
+        i++;
+    };
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(expected_b2b1), i);
+
+    /* Setup lists like:
+     * a = {a1}
+     * b = {b1}
+     *
+     * After move should be like:
+     * a = {b1, a1}
+     * b = {}
+     */
+    aws_linked_list_init(&a);
+    aws_linked_list_push_front(&a, &a1);
+
+    aws_linked_list_init(&b);
+    aws_linked_list_push_front(&b, &b1);
+
+    aws_linked_list_move_all_front(&a, &b);
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&a));
+    ASSERT_TRUE(aws_linked_list_is_valid_deep(&b));
+    ASSERT_TRUE(aws_linked_list_empty(&b));
+
+    struct aws_linked_list_node *expected_b1a1[] = {&b1, &a1};
+    it = aws_linked_list_begin(&a);
+    i = 0;
+    while (it != aws_linked_list_end(&a)) {
+        ASSERT_PTR_EQUALS(expected_b1a1[i], it);
+        it = aws_linked_list_next(it);
+        i++;
+    };
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(expected_b1a1), i);
+
+    return AWS_OP_SUCCESS;
+}
+
 AWS_TEST_CASE(linked_list_push_back_pop_front, s_test_linked_list_order_push_back_pop_front)
 AWS_TEST_CASE(linked_list_push_front_pop_back, s_test_linked_list_order_push_front_pop_back)
 AWS_TEST_CASE(linked_list_swap_nodes, s_test_linked_list_swap_nodes)
 AWS_TEST_CASE(linked_list_iteration, s_test_linked_list_iteration)
 AWS_TEST_CASE(linked_list_reverse_iteration, s_test_linked_list_reverse_iteration)
 AWS_TEST_CASE(linked_list_swap_contents, s_test_linked_list_swap_contents)
+AWS_TEST_CASE(linked_list_move_all_back, s_test_linked_list_move_all_back)
+AWS_TEST_CASE(linked_list_move_all_front, s_test_linked_list_move_all_front)


### PR DESCRIPTION
O(1) helper functions to move all nodes from one list to another.

This is something we do pretty commonly while holding a lock. It's much less code using these helper functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
