### PR TITLE
Update CBMC proof harnesses

### DIFF
--- a/include/aws/common/atomics_gnu.inl
+++ b/include/aws/common/atomics_gnu.inl
@@ -69,7 +69,7 @@ size_t aws_atomic_load_int_explicit(volatile const struct aws_atomic_var *var, e
 }
 
 /**
- * Reads an atomic var as an pointer, using the specified ordering, and returns the result.
+ * Reads an atomic var as a pointer, using the specified ordering, and returns the result.
  */
 AWS_STATIC_IMPL
 void *aws_atomic_load_ptr_explicit(volatile const struct aws_atomic_var *var, enum aws_memory_order memory_order) {

--- a/include/aws/common/byte_order.inl
+++ b/include/aws/common/byte_order.inl
@@ -42,7 +42,7 @@ AWS_STATIC_IMPL uint64_t aws_hton64(uint64_t x) {
 #elif defined(_MSC_VER)
     return _byteswap_uint64(x);
 #else
-    uint32_t low = (uint32_t)x;
+    uint32_t low = x & UINT32_MAX;
     uint32_t high = (uint32_t)(x >> 32);
     return ((uint64_t)htonl(low)) << 32 | htonl(high);
 #endif

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -10,7 +10,7 @@
 #ifdef CBMC
 #    define AWS_ATOMIC_LOAD_PTR(ring_buf, dest_ptr, atomic_ptr, memory_order)                                          \
         dest_ptr = aws_atomic_load_ptr_explicit(atomic_ptr, memory_order);                                             \
-        assert(__CPROVER_POINTER_OBJECT(dest_ptr) == __CPROVER_POINTER_OBJECT(ring_buf->allocation));                  \
+        assert(__CPROVER_same_object(dest_ptr, ring_buf->allocation));                                                 \
         assert(aws_ring_buffer_check_atomic_ptr(ring_buf, dest_ptr));
 #    define AWS_ATOMIC_STORE_PTR(ring_buf, atomic_ptr, src_ptr, memory_order)                                          \
         assert(aws_ring_buffer_check_atomic_ptr(ring_buf, src_ptr));                                                   \
@@ -232,8 +232,8 @@ static inline bool s_buf_belongs_to_pool(const struct aws_ring_buffer *ring_buff
 #ifdef CBMC
     /* only continue if buf points-into ring_buffer because comparison of pointers to different objects is undefined
      * (C11 6.5.8) */
-    if ((__CPROVER_POINTER_OBJECT(buf->buffer) != __CPROVER_POINTER_OBJECT(ring_buffer->allocation)) ||
-        (__CPROVER_POINTER_OBJECT(buf->buffer) != __CPROVER_POINTER_OBJECT(ring_buffer->allocation_end))) {
+    if (!__CPROVER_same_object(buf->buffer, ring_buffer->allocation) ||
+        !__CPROVER_same_object(buf->buffer, ring_buffer->allocation_end - 1)) {
         return false;
     }
 #endif

--- a/verification/cbmc/proofs/Makefile-project-defines
+++ b/verification/cbmc/proofs/Makefile-project-defines
@@ -39,8 +39,7 @@ DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
 
 
 # Extra CBMC flags not enabled by Makefile.common
-CHECKFLAGS += --enum-range-check
-CHECKFLAGS += --pointer-primitive-check
+# CHECKFLAGS += --enum-range-check
 CHECKFLAGS += --pointer-primitive-check
 
 

--- a/verification/cbmc/proofs/aws_byte_buf_write_be16/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_buf_write_be16/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--unwindset;memcpy_impl.0:11;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_buf_write_be16/gotos/aws_byte_buf_write_be16_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_byte_buf_write_be16/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_buf_write_be16/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--unwindset;memcpy_impl.0:11;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_buf_write_be16/gotos/aws_byte_buf_write_be16_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_byte_buf_write_be64/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_buf_write_be64/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--unwindset;memcpy_impl.0:11;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_buf_write_be64/gotos/aws_byte_buf_write_be64_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_byte_buf_write_be64/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_buf_write_be64/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--unwindset;memcpy_impl.0:11;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_buf_write_be64/gotos/aws_byte_buf_write_be64_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--unwindset;memcmp.0:11;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_cursor_compare_lexical/gotos/aws_byte_cursor_compare_lexical_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_cursor_compare_lexical/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--unwindset;memcmp.0:11;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_cursor_compare_lexical/gotos/aws_byte_cursor_compare_lexical_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_byte_cursor_read_be16/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_be16/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_cursor_read_be16/gotos/aws_byte_cursor_read_be16_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_byte_cursor_read_be16/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_be16/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_cursor_read_be16/gotos/aws_byte_cursor_read_be16_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_byte_cursor_read_be64/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_be64/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_cursor_read_be64/gotos/aws_byte_cursor_read_be64_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_byte_cursor_read_be64/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_be64/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_byte_cursor_read_be64/gotos/aws_byte_cursor_read_be64_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
+++ b/verification/cbmc/proofs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
@@ -22,10 +22,10 @@ void aws_hash_iter_delete_harness() {
 
     struct aws_hash_iter iter;
     iter.map = &map;
-    __CPROVER_assume(iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
     __CPROVER_assume(aws_hash_iter_is_valid(&iter));
+    __CPROVER_assume(iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
 
     aws_hash_iter_delete(&iter, nondet_bool());
-    assert(iter.status == AWS_HASH_ITER_STATUS_DELETE_CALLED);
     assert(aws_hash_iter_is_valid(&iter));
+    assert(iter.status == AWS_HASH_ITER_STATUS_DELETE_CALLED);
 }

--- a/verification/cbmc/proofs/aws_hash_iter_delete/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_hash_iter_delete/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--unwindset;__CPROVER_file_local_hash_table_c_s_remove_entry.0:5;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_hash_iter_delete/gotos/aws_hash_iter_delete_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_hash_iter_delete/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_hash_iter_delete/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--unwindset;__CPROVER_file_local_hash_table_c_s_remove_entry.0:5;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_hash_iter_delete/gotos/aws_hash_iter_delete_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_hash_iter_done/aws_hash_iter_done_harness.c
+++ b/verification/cbmc/proofs/aws_hash_iter_done/aws_hash_iter_done_harness.c
@@ -17,8 +17,8 @@ void aws_hash_iter_done_harness() {
 
     struct aws_hash_iter iter;
     iter.map = &map;
-    __CPROVER_assume(iter.status == AWS_HASH_ITER_STATUS_DONE || iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
     __CPROVER_assume(aws_hash_iter_is_valid(&iter));
+    __CPROVER_assume(iter.status == AWS_HASH_ITER_STATUS_DONE || iter.status == AWS_HASH_ITER_STATUS_READY_FOR_USE);
     enum aws_hash_iter_status old_status = iter.status;
     struct store_byte_from_buffer old_byte;
     save_byte_from_hash_table(&map, &old_byte);

--- a/verification/cbmc/proofs/aws_hash_iter_done/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_hash_iter_done/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_hash_iter_done/gotos/aws_hash_iter_done_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_hash_iter_done/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_hash_iter_done/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_hash_iter_done/gotos/aws_hash_iter_done_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -18,9 +18,7 @@ void aws_ring_buffer_acquire_harness() {
     size_t ring_buf_size;
 
     /* assumptions */
-    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
-    __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire/aws_ring_buffer_acquire_harness.c
@@ -11,13 +11,16 @@
 
 void aws_ring_buffer_acquire_harness() {
     /* parameters */
-    struct aws_ring_buffer ring_buf;
-    size_t ring_buf_size;
-    size_t requested_size;
     struct aws_byte_buf buf;
+    struct aws_ring_buffer ring_buf;
+
+    size_t requested_size;
+    size_t ring_buf_size;
 
     /* assumptions */
+    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
+    __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_acquire/gotos/aws_ring_buffer_acquire_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_acquire/gotos/aws_ring_buffer_acquire_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
@@ -19,13 +19,11 @@ void aws_ring_buffer_acquire_up_to_harness() {
     size_t ring_buf_size;
 
     /* assumptions */
-    __CPROVER_assume(0 < ring_buf_size);
+    __CPROVER_assume(requested_size >= minimum_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
-    __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
-    __CPROVER_assume(requested_size >= minimum_size);
 
     /* copy of state before call */
     struct aws_ring_buffer ring_buf_old = ring_buf;

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/aws_ring_buffer_acquire_up_to_harness.c
@@ -11,14 +11,17 @@
 
 void aws_ring_buffer_acquire_up_to_harness() {
     /* parameters */
-    struct aws_ring_buffer ring_buf;
-    size_t ring_buf_size;
-    size_t requested_size;
-    size_t minimum_size;
     struct aws_byte_buf buf;
+    struct aws_ring_buffer ring_buf;
+
+    size_t minimum_size;
+    size_t requested_size;
+    size_t ring_buf_size;
 
     /* assumptions */
+    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
+    __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/gotos/aws_ring_buffer_acquire_up_to_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_acquire_up_to/gotos/aws_ring_buffer_acquire_up_to_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
@@ -10,11 +10,13 @@
 
 void aws_ring_buffer_buf_belongs_to_pool_harness() {
     /* parameters */
-    struct aws_ring_buffer ring_buf;
-    size_t ring_buf_size;
     struct aws_byte_buf buf;
+    struct aws_ring_buffer ring_buf;
+    
+    size_t ring_buf_size;
 
     /* assumptions */
+    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
     bool is_member = nondet_bool(); /* nondet assignment required to force true/false */
     if (is_member) {

--- a/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
@@ -16,7 +16,6 @@ void aws_ring_buffer_buf_belongs_to_pool_harness() {
     size_t ring_buf_size;
 
     /* assumptions */
-    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
     bool is_member = nondet_bool(); /* nondet assignment required to force true/false */
     if (is_member) {

--- a/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/aws_ring_buffer_buf_belongs_to_pool_harness.c
@@ -12,7 +12,7 @@ void aws_ring_buffer_buf_belongs_to_pool_harness() {
     /* parameters */
     struct aws_byte_buf buf;
     struct aws_ring_buffer ring_buf;
-    
+
     size_t ring_buf_size;
 
     /* assumptions */

--- a/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/gotos/aws_ring_buffer_buf_belongs_to_pool_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_buf_belongs_to_pool/gotos/aws_ring_buffer_buf_belongs_to_pool_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
@@ -13,9 +13,9 @@ void aws_ring_buffer_release_harness() {
     /* parameters */
     struct aws_byte_buf buf;
     struct aws_ring_buffer ring_buf;
-    
+
     size_t ring_buf_size;
-    
+
     /* assumptions */
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
     __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));

--- a/verification/cbmc/proofs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
@@ -17,7 +17,6 @@ void aws_ring_buffer_release_harness() {
     size_t ring_buf_size;
     
     /* assumptions */
-    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
     __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));

--- a/verification/cbmc/proofs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_release/aws_ring_buffer_release_harness.c
@@ -11,11 +11,13 @@
 
 void aws_ring_buffer_release_harness() {
     /* parameters */
-    struct aws_ring_buffer ring_buf;
-    size_t ring_buf_size;
     struct aws_byte_buf buf;
-
+    struct aws_ring_buffer ring_buf;
+    
+    size_t ring_buf_size;
+    
     /* assumptions */
+    __CPROVER_assume(0 < ring_buf_size);
     ensure_ring_buffer_has_allocated_members(&ring_buf, ring_buf_size);
     __CPROVER_assume(!aws_ring_buffer_is_empty(&ring_buf));
     __CPROVER_assume(aws_ring_buffer_is_valid(&ring_buf));

--- a/verification/cbmc/proofs/aws_ring_buffer_release/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_release/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_release/gotos/aws_ring_buffer_release_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_ring_buffer_release/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_ring_buffer_release/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/aws_ring_buffer_release/gotos/aws_ring_buffer_release_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/memset_using_uint64/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/memset_using_uint64/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--unwindset;memset_impl.0:161,memset_using_uint64_impl.0:21;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/memset_using_uint64/gotos/memset_using_uint64_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/memset_using_uint64/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/memset_using_uint64/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--unwindset;memset_impl.0:161,memset_using_uint64_impl.0:21;--object-bits;8;--pointer-primitive-check;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/saspadhi/Repos/aws-c-common/verification/cbmc/proofs/memset_using_uint64/gotos/memset_using_uint64_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/memset_using_uint64/memset_using_uint64_harness.c
+++ b/verification/cbmc/proofs/memset_using_uint64/memset_using_uint64_harness.c
@@ -15,13 +15,13 @@ void *memset_using_uint64_impl(void *dst, int c, size_t n);
  */
 void memset_using_uint64_harness() {
 
-    short d1[MAX];
-    short d2[MAX];
-    int c;
-    unsigned size;
+    uint8_t d1[MAX];
+    uint8_t d2[MAX];
+    uint8_t c;
+    size_t size;
     __CPROVER_assume(size < MAX);
     memset_impl(d1, c, size);
     memset_using_uint64_impl(d2, c, size);
-    assert_bytes_match((uint8_t *)d1, (uint8_t *)d2, size);
-    assert_all_bytes_are((uint8_t *)d2, c, size);
+    assert_bytes_match(d1, d2, size);
+    assert_all_bytes_are(d2, c, size);
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -25,11 +25,13 @@ void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf)
 
 void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, const size_t size) {
     ring_buf->allocator = can_fail_allocator();
+    /* The `aws_ring_buffer_init` function requires size > 0. */
+    __CPROVER_assume(0 < size);
     ring_buf->allocation = bounded_malloc(sizeof(*(ring_buf->allocation)) * size);
     size_t position_head;
     size_t position_tail;
-    __CPROVER_assume(position_head <= size);
-    __CPROVER_assume(position_tail <= size);
+    __CPROVER_assume(position_head < size);
+    __CPROVER_assume(position_tail < size);
     aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
     aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
     ring_buf->allocation_end = ring_buf->allocation + size;

--- a/verification/cbmc/stubs/memcmp_override.c
+++ b/verification/cbmc/stubs/memcmp_override.c
@@ -10,6 +10,7 @@
 int memcmp(const void *s1, const void *s2, size_t n) {
     //  __CPROVER_HIDE:;
     int res = 0;
+    /* `__CPROVER_r_ok` requires a non-zero value for `n`. */
     __CPROVER_precondition(s1 != NULL && (n == 0 || __CPROVER_r_ok(s1, n)), "memcmp region 1 readable");
     __CPROVER_precondition(s2 != NULL && (n == 0 || __CPROVER_r_ok(s2, n)), "memcpy region 2 readable");
 

--- a/verification/cbmc/stubs/memcmp_override.c
+++ b/verification/cbmc/stubs/memcmp_override.c
@@ -10,8 +10,8 @@
 int memcmp(const void *s1, const void *s2, size_t n) {
     //  __CPROVER_HIDE:;
     int res = 0;
-    __CPROVER_precondition(__CPROVER_r_ok(s1, n), "memcmp region 1 readable");
-    __CPROVER_precondition(__CPROVER_r_ok(s2, n), "memcpy region 2 readable");
+    __CPROVER_precondition(s1 != NULL && (n == 0 || __CPROVER_r_ok(s1, n)), "memcmp region 1 readable");
+    __CPROVER_precondition(s2 != NULL && (n == 0 || __CPROVER_r_ok(s2, n)), "memcpy region 2 readable");
 
 #if 1
     const unsigned char *sc1 = s1, *sc2 = s2;

--- a/verification/cbmc/stubs/memset_override.c
+++ b/verification/cbmc/stubs/memset_override.c
@@ -14,9 +14,9 @@
 void *memset_impl(void *s, int c, size_t n) {
     __CPROVER_precondition(__CPROVER_w_ok(s, n), "memset destination region writeable");
     if (n > 0) {
-        char *sp = (char *)s;
+        unsigned char *sp = (unsigned char *)s;
         for (__CPROVER_size_t i = 0; i < n; i++)
-            sp[i] = c;
+            sp[i] = c & UINT8_MAX;
     }
     return s;
 }


### PR DESCRIPTION
This PR fixes the 12 broken proofs that were disabled in #679.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
