### PR TITLE
Enable compilation for MinGW with LLVM/Clang toolchain

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -50,6 +50,15 @@ function(aws_set_common_properties target)
     else()
         list(APPEND AWS_C_FLAGS -Wall -Werror -Wstrict-prototypes)
 
+        if (WIN32 AND (MSYS OR MINGW))
+            add_definitions(-DWINVER=0x0601)
+            add_definitions(-D_WIN32_WINNT=0x0601)
+            list(APPEND AWS_C_FLAGS -Wno-unused-local-typedef -Wno-unknown-pragmas)
+        else()
+            # Always enable position independent code, since this code will always end up in a shared lib
+            list(APPEND AWS_C_FLAGS -fPIC)
+        endif()
+
         if(NOT SET_PROPERTIES_NO_WEXTRA)
             list(APPEND AWS_C_FLAGS -Wextra)
         endif()
@@ -60,9 +69,6 @@ function(aws_set_common_properties target)
 
         # Warning disables always go last to avoid future flags re-enabling them
         list(APPEND AWS_C_FLAGS -Wno-long-long)
-
-        # Always enable position independent code, since this code will always end up in a shared lib
-        list(APPEND AWS_C_FLAGS -fPIC)
 
         if (LEGACY_COMPILER_SUPPORT)
             list(APPEND AWS_C_FLAGS -Wno-strict-aliasing)

--- a/include/aws/common/byte_order.inl
+++ b/include/aws/common/byte_order.inl
@@ -9,10 +9,8 @@
 #include <aws/common/byte_order.h>
 #include <aws/common/common.h>
 
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined(_WIN32) && defined(__GNUC__)
 #    include <stdlib.h>
-#elif defined(_WIN32) && defined(__GNUC__)
-#    include <winsock.h>
 #else
 #    include <netinet/in.h>
 #endif /* _MSC_VER */
@@ -61,7 +59,7 @@ AWS_STATIC_IMPL uint64_t aws_ntoh64(uint64_t x) {
  * Convert 32 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_hton32(uint32_t x) {
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined(_WIN32) && defined(__GNUC__)
     return aws_is_big_endian() ? x : _byteswap_ulong(x);
 #else
     return htonl(x);
@@ -118,7 +116,7 @@ AWS_STATIC_IMPL double aws_htonf64(double x) {
  * Convert 32 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint32_t aws_ntoh32(uint32_t x) {
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined(_WIN32) && defined(__GNUC__)
     return aws_is_big_endian() ? x : _byteswap_ulong(x);
 #else
     return ntohl(x);
@@ -143,7 +141,7 @@ AWS_STATIC_IMPL double aws_ntohf64(double x) {
  * Convert 16 bit integer from host to network byte order.
  */
 AWS_STATIC_IMPL uint16_t aws_hton16(uint16_t x) {
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined(_WIN32) && defined(__GNUC__)
     return aws_is_big_endian() ? x : _byteswap_ushort(x);
 #else
     return htons(x);
@@ -154,7 +152,7 @@ AWS_STATIC_IMPL uint16_t aws_hton16(uint16_t x) {
  * Convert 16 bit integer from network to host byte order.
  */
 AWS_STATIC_IMPL uint16_t aws_ntoh16(uint16_t x) {
-#ifdef _MSC_VER
+#if defined (_MSC_VER) || defined(_WIN32) && defined(__GNUC__)
     return aws_is_big_endian() ? x : _byteswap_ushort(x);
 #else
     return ntohs(x);

--- a/include/aws/common/byte_order.inl
+++ b/include/aws/common/byte_order.inl
@@ -11,6 +11,8 @@
 
 #ifdef _MSC_VER
 #    include <stdlib.h>
+#elif defined(_WIN32) && defined(__GNUC__)
+#    include <winsock.h>
 #else
 #    include <netinet/in.h>
 #endif /* _MSC_VER */

--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -199,7 +199,7 @@ char **aws_backtrace_addr2line(void *const *frames, size_t stack_depth) {
 void aws_backtrace_print(FILE *fp, void *call_site_data) {
     struct _EXCEPTION_POINTERS *exception_pointers = call_site_data;
     if (exception_pointers) {
-        fprintf(fp, "** Exception 0x%x occured **\n", exception_pointers->ExceptionRecord->ExceptionCode);
+        fprintf(fp, "** Exception 0x%lx occured **\n", exception_pointers->ExceptionRecord->ExceptionCode);
     }
 
     if (!s_init_dbghelp()) {

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -11,12 +11,14 @@
 
 #include <aws/testing/aws_test_harness.h>
 
-#ifdef _WIN32
+#if defined (_WIN32)
 #    include <malloc.h>
-#    define alloca _alloca
+#    if !defined(__GNUC__) 
+#        define alloca _alloca
+#    endif
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #    include <stdlib.h>
-#else
+#elif
 #    include <alloca.h>
 #endif
 

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -18,7 +18,7 @@
 #    endif
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #    include <stdlib.h>
-#elif
+#else
 #    include <alloca.h>
 #endif
 

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -11,9 +11,9 @@
 
 #include <aws/testing/aws_test_harness.h>
 
-#if defined (_WIN32)
+#ifdef _WIN32
 #    include <malloc.h>
-#    if !defined(__GNUC__) 
+#    ifndef __GNUC__
 #        define alloca _alloca
 #    endif
 #elif defined(__FreeBSD__) || defined(__NetBSD__)


### PR DESCRIPTION
This PR fixes compilation for MinGW with LLVM/Clang toolchain on Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
