### PR TITLE
Adding `length` for `aws_linked_list`

### DIFF
--- a/include/aws/common/linked_list.h
+++ b/include/aws/common/linked_list.h
@@ -7,6 +7,7 @@
  */
 
 #include <aws/common/common.h>
+#include <aws/common/math.h>
 
 #include <stddef.h>
 
@@ -18,6 +19,7 @@ struct aws_linked_list_node {
 struct aws_linked_list {
     struct aws_linked_list_node head;
     struct aws_linked_list_node tail;
+    size_t length;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/verification/cbmc/proofs/aws_linked_list_move_all_back/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_move_all_back/Makefile
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+###########
+
+# Run deep validity checks in is_valid
+AWS_DEEP_CHECKS = 1
+
+include ../Makefile.aws_linked_list
+
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 * (2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION)))))
+UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((2 * (1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION)))))
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = aws_linked_list_move_all_back_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
+
+PROOF_SOURCES += $(PROOF_STUB)/error.c
+
+# The actual implementation that we're proving comes from .inl files
+# that the stubs pull in. Link against an empty file, since we're not
+# using any other files from c-common.
+PROJECT_SOURCES += $(PROOF_STUB)/empty-source-file.c
+
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_linked_list_move_all_back/aws_linked_list_move_all_back_harness.c
+++ b/verification/cbmc/proofs/aws_linked_list_move_all_back/aws_linked_list_move_all_back_harness.c
@@ -1,0 +1,39 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/common/linked_list.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_linked_list_move_all_back_harness() {
+    /* data structure */
+    struct aws_linked_list dst, src;
+
+    ensure_linked_list_is_allocated(&dst, MAX_LINKED_LIST_ITEM_ALLOCATION);
+    ensure_linked_list_is_allocated(&src, MAX_LINKED_LIST_ITEM_ALLOCATION);
+
+    bool src_is_empty = aws_linked_list_empty(&src);
+    size_t old_dst_length = dst.length;
+    size_t old_src_length = src.length;
+    struct aws_linked_list_node *old_dst_back = dst.tail.prev;
+    struct aws_linked_list_node *old_src_front = src.head.next;
+    struct aws_linked_list_node *old_src_back = src.tail.prev;
+
+    /* perform operation under verification */
+    aws_linked_list_move_all_back(&dst, &src);
+
+    /* assertions */
+    assert(aws_linked_list_is_valid(&dst));
+    assert(aws_linked_list_is_valid(&src));
+    assert(dst.length == old_dst_length + old_src_length);
+    assert(src.length == 0);
+
+    if (src_is_empty) {
+        assert(dst.tail.prev == old_dst_back);
+    } else {
+        assert(dst.tail.prev == old_src_back);
+        assert(old_dst_back->next == old_src_front);
+        assert(old_dst_back == old_src_front->prev);
+    }
+}

--- a/verification/cbmc/proofs/aws_linked_list_move_all_back/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_linked_list_move_all_back/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_linked_list_move_all_front/Makefile
+++ b/verification/cbmc/proofs/aws_linked_list_move_all_front/Makefile
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+###########
+
+# Run deep validity checks in is_valid
+AWS_DEEP_CHECKS = 1
+
+include ../Makefile.aws_linked_list
+
+UNWINDSET += __CPROVER_file_local_linked_list_inl_aws_linked_list_is_valid_deep.0:$(shell echo $$((2 * (2 + $(MAX_LINKED_LIST_ITEM_ALLOCATION)))))
+UNWINDSET += ensure_linked_list_is_allocated.0:$(shell echo $$((2 * (1 + $(MAX_LINKED_LIST_ITEM_ALLOCATION)))))
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = aws_linked_list_move_all_front_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
+
+PROOF_SOURCES += $(PROOF_STUB)/error.c
+
+# The actual implementation that we're proving comes from .inl files
+# that the stubs pull in. Link against an empty file, since we're not
+# using any other files from c-common.
+PROJECT_SOURCES += $(PROOF_STUB)/empty-source-file.c
+
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_linked_list_move_all_front/aws_linked_list_move_all_front_harness.c
+++ b/verification/cbmc/proofs/aws_linked_list_move_all_front/aws_linked_list_move_all_front_harness.c
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/common/linked_list.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_linked_list_move_all_front_harness() {
+    /* data structure */
+    struct aws_linked_list dst, src;
+
+    ensure_linked_list_is_allocated(&dst, MAX_LINKED_LIST_ITEM_ALLOCATION);
+    ensure_linked_list_is_allocated(&src, MAX_LINKED_LIST_ITEM_ALLOCATION);
+
+    bool src_is_empty = aws_linked_list_empty(&src);
+    bool dst_is_empty = aws_linked_list_empty(&dst);
+    size_t old_dst_length = dst.length;
+    size_t old_src_length = src.length;
+    struct aws_linked_list_node *old_dst_front = dst.head.next;
+    struct aws_linked_list_node *old_dst_back = dst.tail.prev;
+    struct aws_linked_list_node *old_src_front = src.head.next;
+    struct aws_linked_list_node *old_src_back = src.tail.prev;
+
+    /* perform operation under verification */
+    aws_linked_list_move_all_front(&dst, &src);
+
+    /* assertions */
+    assert(aws_linked_list_is_valid(&dst));
+    assert(aws_linked_list_is_valid(&src));
+    assert(dst.length == old_dst_length + old_src_length);
+    assert(src.length == 0);
+
+    if (src_is_empty) {
+        assert(dst.head.next == old_dst_front);
+        assert(dst.tail.prev == old_dst_back);
+    } else {
+        assert(dst.head.next == old_src_front);
+        if (!dst_is_empty) assert(dst.tail.prev == old_dst_back);
+        assert(old_dst_front->prev == old_src_back);
+        assert(old_dst_front == old_src_back->next);
+    }
+}

--- a/verification/cbmc/proofs/aws_linked_list_move_all_front/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_linked_list_move_all_front/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_linked_list_pop_back/aws_linked_list_pop_back_harness.c
+++ b/verification/cbmc/proofs/aws_linked_list_pop_back/aws_linked_list_pop_back_harness.c
@@ -17,6 +17,7 @@ void aws_linked_list_pop_back_harness() {
 
     /* Keep the old last node of the linked list */
     struct aws_linked_list_node *old_prev_last = (list.tail.prev)->prev;
+    size_t old_list_length = list.length;
 
     /* perform operation under verification */
     struct aws_linked_list_node *ret = aws_linked_list_pop_back(&list);
@@ -25,4 +26,5 @@ void aws_linked_list_pop_back_harness() {
     assert(aws_linked_list_is_valid(&list));
     assert(ret->next == NULL && ret->prev == NULL);
     assert(list.tail.prev == old_prev_last);
+    assert(old_list_length == list.length + 1);
 }

--- a/verification/cbmc/proofs/aws_linked_list_pop_front/aws_linked_list_pop_front_harness.c
+++ b/verification/cbmc/proofs/aws_linked_list_pop_front/aws_linked_list_pop_front_harness.c
@@ -17,6 +17,7 @@ void aws_linked_list_pop_front_harness() {
 
     /* Keep the old last node of the linked list */
     struct aws_linked_list_node *old_next_first = (list.head.next)->next;
+    size_t old_list_length = list.length;
 
     /* perform operation under verification */
     struct aws_linked_list_node *ret = aws_linked_list_pop_front(&list);
@@ -25,4 +26,5 @@ void aws_linked_list_pop_front_harness() {
     assert(aws_linked_list_is_valid(&list));
     assert(ret->next == NULL && ret->prev == NULL);
     assert(list.head.next == old_next_first);
+    assert(old_list_length == list.length + 1);
 }

--- a/verification/cbmc/proofs/aws_linked_list_push_back/aws_linked_list_push_back_harness.c
+++ b/verification/cbmc/proofs/aws_linked_list_push_back/aws_linked_list_push_back_harness.c
@@ -15,6 +15,7 @@ void aws_linked_list_push_back_harness() {
 
     /* Keep the old last node of the linked list */
     struct aws_linked_list_node *old_last = list.tail.prev;
+    size_t old_list_length = list.length;
 
     /* perform operation under verification */
     aws_linked_list_push_back(&list, &to_add);
@@ -25,4 +26,5 @@ void aws_linked_list_push_back_harness() {
     assert(aws_linked_list_node_next_is_valid(&to_add));
     assert(list.tail.prev == &to_add);
     assert(to_add.prev == old_last);
+    assert(list.length == old_list_length + 1);
 }

--- a/verification/cbmc/proofs/aws_linked_list_push_front/aws_linked_list_push_front_harness.c
+++ b/verification/cbmc/proofs/aws_linked_list_push_front/aws_linked_list_push_front_harness.c
@@ -14,6 +14,7 @@ void aws_linked_list_push_front_harness() {
     ensure_linked_list_is_allocated(&list, MAX_LINKED_LIST_ITEM_ALLOCATION);
 
     struct aws_linked_list_node *old_first = list.head.next;
+    size_t old_list_length = list.length;
     /* perform operation under verification */
     aws_linked_list_push_front(&list, &to_add);
 
@@ -23,4 +24,5 @@ void aws_linked_list_push_front_harness() {
     assert(aws_linked_list_node_next_is_valid(&to_add));
     assert(list.head.next == &to_add);
     assert(to_add.next == old_first);
+    assert(list.length == old_list_length + 1);
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -120,6 +120,7 @@ void ensure_linked_list_is_allocated(struct aws_linked_list *const list, size_t 
 
     curr->next = &list->tail;
     list->tail.prev = curr;
+    list->length = length;
 }
 
 bool aws_priority_queue_is_bounded(


### PR DESCRIPTION
Hi,

Would you consider adding an additional field `length` in `aws_linked_list` to capture the linked list's length? Using the `length` field could help to avoid the possibility of non-termination in `aws_linked_list_is_valid_deep` when the input is a circular list. With this field, we can also create new assertions in `aws_linked_list_pop_back_harness`, `aws_linked_list_pop_front_harness.c`, `aws_linked_list_push_back_harness`, `aws_linked_list_push_front_harness.c`. I also created two new proof-harnesses for `aws_linked_list_move_all_back` and `aws_linked_list_move_all_front` with assertions on the length property. All linked list's proof harnesses are verified successfully on the extension.

I think using the `length` field is the simplest way to get rid of the non-termination in `aws_linked_list_is_valid_deep` check. Another possible solution is using James Brotherston et al.'s separation logic model checking (http://www0.cs.ucl.ac.uk/staff/J.Brotherston/POPL16/SL_ID_model_checking.pdf) or Huu Hai Nguyen el al.'s runtime checking for SL (http://lara.epfl.ch/~kuncak/papers/NguyenETAL08RuntimeCheckingSeparationLogic.pdf) but these approaches are more complicated since we need to keep track of footprints of the heap.

Best,

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
