### PR TITLE
Updates the postconditions in aws_mul_size_checked proof

### DIFF
--- a/verification/cbmc/proofs/aws_mul_size_checked/aws_mul_size_checked_harness.c
+++ b/verification/cbmc/proofs/aws_mul_size_checked/aws_mul_size_checked_harness.c
@@ -24,7 +24,7 @@ void aws_mul_size_checked_harness() {
         if (!aws_mul_u64_checked(a, b, &r)) {
             assert(r == a * b);
         } else {
-            assert(__CPROVER_overflow_mult(a, b));
+            assert(a > 0 && b > 0 && a > (UINT64_MAX / b));
         }
     } else {
         /*
@@ -37,7 +37,7 @@ void aws_mul_size_checked_harness() {
         if (!aws_mul_u32_checked(a, b, &r)) {
             assert(r == a * b);
         } else {
-            assert(__CPROVER_overflow_mult(a, b));
+            assert(a > 0 && b > 0 && a > (UINT32_MAX / b));
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*

N/A.

*Description of changes:*

Reverts https://github.com/awslabs/aws-c-common/pull/689. We need actually map the same check used in https://github.com/awslabs/aws-c-common/blob/master/include/aws/common/math.fallback.inl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
