### PR TITLE
Improves predicates for aws_array_list proofs

### DIFF
--- a/format-check.sh
+++ b/format-check.sh
@@ -10,7 +10,7 @@ if NOT type $CLANG_FORMAT 2> /dev/null ; then
 fi
 
 FAIL=0
-SOURCE_FILES=`find source include tests .cbmc-batch -type f \( -name '*.h' -o -name '*.c' -o -name '*.inl' \)`
+SOURCE_FILES=`find source include tests verification -type f \( -name '*.h' -o -name '*.c' -o -name '*.inl' \)`
 for i in $SOURCE_FILES
 do
     $CLANG_FORMAT -output-replacements-xml $i | grep -c "<replacement " > /dev/null

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -87,9 +87,8 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
     bool required_size_is_valid =
         (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS);
     bool current_size_is_valid = (list->current_size >= required_size);
-    bool data_is_valid =
-        AWS_IMPLIES(list->current_size == 0, list->data == NULL) &&
-        AWS_IMPLIES(list->current_size != 0, AWS_MEM_IS_WRITABLE(list->data, list->current_size));
+    bool data_is_valid = AWS_IMPLIES(list->current_size == 0, list->data == NULL) &&
+                         AWS_IMPLIES(list->current_size != 0, AWS_MEM_IS_WRITABLE(list->data, list->current_size));
     bool item_size_is_valid = (list->item_size != 0);
     return required_size_is_valid && current_size_is_valid && data_is_valid && item_size_is_valid;
 }

--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -88,7 +88,8 @@ bool aws_array_list_is_valid(const struct aws_array_list *AWS_RESTRICT list) {
         (aws_mul_size_checked(list->length, list->item_size, &required_size) == AWS_OP_SUCCESS);
     bool current_size_is_valid = (list->current_size >= required_size);
     bool data_is_valid =
-        ((list->current_size == 0 && list->data == NULL) || AWS_MEM_IS_WRITABLE(list->data, list->current_size));
+        AWS_IMPLIES(list->current_size == 0, list->data == NULL) &&
+        AWS_IMPLIES(list->current_size != 0, AWS_MEM_IS_WRITABLE(list->data, list->current_size));
     bool item_size_is_valid = (list->item_size != 0);
     return required_size_is_valid && current_size_is_valid && data_is_valid && item_size_is_valid;
 }

--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -107,6 +107,15 @@ AWS_EXTERN_C_END
 #define __CPROVER_r_ok(base, len) (AWS_MEM_IS_READABLE(base, len))
 #define __CPROVER_w_ok(base, len) (AWS_MEM_IS_WRITEABLE(base, len))
 
+/* Logical consequence. */
+#define AWS_IMPLIES(a, b) (!(a) || (b))
+
+/**
+ * If and only if (iff) is a biconditional logical connective between statements a and b.
+ * Equivalent to (AWS_IMPLIES(a, b) && AWS_IMPLIES(b, a)).
+ */
+#define AWS_IFF(a, b) (!!(a) == !!(b))
+
 #define AWS_RETURN_ERROR_IF_IMPL(type, cond, err, explanation)                                                         \
     do {                                                                                                               \
         if (!(cond)) {                                                                                                 \

--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -112,6 +112,7 @@ AWS_EXTERN_C_END
 
 /**
  * If and only if (iff) is a biconditional logical connective between statements a and b.
+ * We need double negations (!!) here to work correctly for non-Boolean a and b values.
  * Equivalent to (AWS_IMPLIES(a, b) && AWS_IMPLIES(b, a)).
  */
 #define AWS_IFF(a, b) (!!(a) == !!(b))

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -78,7 +78,7 @@ bool aws_byte_cursor_is_bounded(const struct aws_byte_cursor *const cursor, cons
 }
 
 void ensure_byte_cursor_has_allocated_buffer_member(struct aws_byte_cursor *const cursor) {
-    cursor->ptr = (nondet_bool()) ? NULL : bounded_malloc(cursor->len);
+    cursor->ptr = can_fail_malloc(cursor->len);
 }
 
 bool aws_array_list_is_bounded(
@@ -91,13 +91,8 @@ bool aws_array_list_is_bounded(
 }
 
 void ensure_array_list_has_allocated_data_member(struct aws_array_list *const list) {
-    if (list->current_size == 0 && list->length == 0) {
-        __CPROVER_assume(list->data == NULL);
-        list->alloc = can_fail_allocator();
-    } else {
-        list->data = bounded_malloc(list->current_size);
-        list->alloc = nondet_bool() ? NULL : can_fail_allocator();
-    }
+    list->data = can_fail_malloc(list->current_size);
+    list->alloc = nondet_bool() ? NULL : can_fail_allocator();
 }
 
 void ensure_linked_list_is_allocated(struct aws_linked_list *const list, size_t max_length) {


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

 - Adds `AWS_IMPLIES` and `AWS_IFF` macros;
 - Improves the `aws_array_list` validity function;
 - Improves predicates for CBMC proofs;
 - Fixes `format-check.sh` replacing `.cbmc-batch` with new `verification` dir.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
