### PR TITLE
Reflect presence of aarch64 asm math in macro

### DIFF
--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -26,9 +26,9 @@
 
 AWS_EXTERN_C_BEGIN
 
-#if defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus)) ||                 \
-    defined(__x86_64__) && defined(AWS_HAVE_GCC_INLINE_ASM) || defined(AWS_HAVE_MSVC_MULX) || defined(CBMC) ||         \
-    !defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS)
+#if defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus)) || \
+    (defined(__x86_64__) || defined(__aarch64__)) && defined(AWS_HAVE_GCC_INLINE_ASM) ||               \
+    defined(AWS_HAVE_MSVC_MULX) || defined(CBMC) || !defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS)
 /* In all these cases, we can use fast static inline versions of this code */
 #    define AWS_COMMON_MATH_API AWS_STATIC_IMPL
 #else


### PR DESCRIPTION
This pull request fixes the build for me with `aws-sdk-cpp` depending on the latest release of this package on Aarch64. This is a follow-up to https://github.com/awslabs/aws-c-common/pull/670.

This issue is only occuring when you compile on aarch64 with *shared* linkage. 

I got the following error which is fixed by this PR:

```
FAILED: aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/event/EventHeader.cpp.o 
$BUILD_PREFIX/bin/aarch64-conda-linux-gnu-c++ -DAWS_COMMON_USE_IMPORT_EXPORT -DAWS_EVENT_STREAM_USE_IMPORT_EXPORT -DAWS_SDK_VERSION_MAJOR=1 -DAWS_SDK_VERSION_MINOR=7 -DAWS_SDK_VERSION_PATCH=164 -DCURL_HAS_H2 -DCURL_HAS_TLS_PROXY -DENABLE_CURL_CLIENT -DENABLE_OPENSSL_ENCRYPTION -DHAS_PATHCONF -DHAS_UMASK -DPLATFORM_LINUX -Daws_cpp_sdk_core_EXPORTS -I../aws-cpp-sdk-core/include/aws/core/platform/refs -I../aws-cpp-sdk-core/include -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/aws-sdk-cpp-1.7.164 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -O3 -DNDEBUG -fPIC -fno-exceptions -std=c++11 -Wall -Werror -pedantic -Wextra -pthread -MD -MT aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/event/EventHeader.cpp.o -MF aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/event/EventHeader.cpp.o.d -o aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/event/EventHeader.cpp.o -c ../aws-cpp-sdk-core/source/utils/event/EventHeader.cpp
In file included from $PREFIX/include/aws/common/math.inl:29:0,
                 from $PREFIX/include/aws/common/math.h:202,
                 from $PREFIX/include/aws/common/array_list.h:9,
                 from $PREFIX/include/aws/event-stream/event_stream.h:9,
                 from ../aws-cpp-sdk-core/include/aws/core/utils/event/EventHeader.h:24,
                 from ../aws-cpp-sdk-core/source/utils/event/EventHeader.cpp:16:
$PREFIX/include/aws/common/math.gcc_arm64_asm.inl: In function 'uint64_t aws_mul_u64_saturating(uint64_t, uint64_t)':
$PREFIX/include/aws/common/math.gcc_arm64_asm.inl:23:26: error: 'uint64_t aws_mul_u64_saturating(uint64_t, uint64_t)' was declared 'extern' and later 'static' [-fpermissive]
 AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b) {
                          ^~~~~~~~~~~~~~~~~~~~~~
In file included from $PREFIX/include/aws/common/array_list.h:9:0,
                 from $PREFIX/include/aws/event-stream/event_stream.h:9,
                 from ../aws-cpp-sdk-core/include/aws/core/utils/event/EventHeader.h:24,
                 from ../aws-cpp-sdk-core/source/utils/event/EventHeader.cpp:16:
$PREFIX/include/aws/common/math.h:46:30: note: previous declaration of 'uint64_t aws_mul_u64_saturating(uint64_t, uint64_t)'
 AWS_COMMON_MATH_API uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
                              ^~~~~~~~~~~~~~~~~~~~~~
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
