### PR TITLE
Don't hardcode the CoreFoundation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,9 @@ else ()
             message(FATAL_ERROR "Core Foundation not found")
         endif ()
 
-        list(APPEND PLATFORM_LIBS Threads::Threads ${CORE_FOUNDATION_LIB})
+        list(APPEND PLATFORM_LIBS Threads::Threads)
+        # Don't add the exact path to CoreFoundation as this would hardcode the SDK version
+        list(APPEND PLATFORM_LINK_FLAGS -framework CoreFoundation)
     elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") # Android does not link to libpthread nor librt, so this is fine
         list(APPEND PLATFORM_LIBS m Threads::Threads rt)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
@@ -153,6 +155,7 @@ add_library(${PROJECT_NAME} ${COMMON_SRC})
 aws_set_common_properties(${PROJECT_NAME} NO_WEXTRA)
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_COMMON")
 target_compile_options(${PROJECT_NAME} PUBLIC ${PLATFORM_CFLAGS})
+target_link_options(${PROJECT_NAME} PUBLIC ${PLATFORM_LINK_FLAGS})
 
 aws_check_headers(${PROJECT_NAME} ${AWS_COMMON_HEADERS} ${AWS_TEST_HEADERS} ${AWS_COMMON_OS_HEADERS})
 


### PR DESCRIPTION
This would otherwise hardcode the Xcode version and we would have to recompile after each Xcode update.

*Issue #, if available:*

Fixes #510

*Description of changes:*

Instead of using the explicit path of the CoreFoundation library, we can instruct the linker to use it. I kept the `find_library` check in place as this gives a much nicer error to the user if not all parts of the Xcode tools are installed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
