### PR TITLE
Fixing SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,6 @@ if (AWS_NUM_CPU_CORES)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DAWS_NUM_CPU_CORES=${AWS_NUM_CPU_CORES})
 endif()
 
-# Our ABI is not yet stable
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ endif()
 
 # Our ABI is not yet stable
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-c-common/issues/698

*Description of changes:*
Fixing SOVERSION so that resulting SONAME is libaws-c-common.so.1 and not libaws-c-common.so.1.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
