### PR TITLE
cbmc-batch.sh --lsjobs has fewer prerequisites

### DIFF
--- a/verification/cbmc/cbmc-batch.sh
+++ b/verification/cbmc/cbmc-batch.sh
@@ -7,7 +7,12 @@ opt="$1"; shift
 result="results.txt"
 
 COMMANDS_IN_PATH=true
-for i in cbmc-batch cbmc-status aws cbmc-kill cbmc; do
+if [ "$opt" = "--lsjobs" ]; then
+    PREREQ_COMMANDS=""
+else
+    PREREQ_COMMANDS="cbmc-batch cbmc-status aws cbmc-kill"
+fi
+for i in $PREREQ_COMMANDS ; do
     command -v "$i" >/dev/null 2>&1 || {
         echo >&2 "Command $i required in \$PATH";
         COMMANDS_IN_PATH=false;


### PR DESCRIPTION
Additionally, the `cbmc` command is not needed to be available locally for the scripts in this repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
