### PR TITLE
Modify CBMC proofs to make assumptions about malloc explicit

### DIFF
--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -86,6 +86,8 @@ AWS_EXTERN_C_END
 #    define AWS_POSTCONDITION1(cond) __CPROVER_assert((cond), #    cond " check failed")
 #    define AWS_FATAL_POSTCONDITION2(cond, explanation) __CPROVER_assert((cond), (explanation))
 #    define AWS_FATAL_POSTCONDITION1(cond) __CPROVER_assert((cond), #    cond " check failed")
+#    define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (__CPROVER_r_ok((base), (len))))
+#    define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (__CPROVER_r_ok((base), (len))))
 #else
 #    define AWS_PRECONDITION2(cond, expl) AWS_ASSERT(cond)
 #    define AWS_PRECONDITION1(cond) AWS_ASSERT(cond)
@@ -95,17 +97,12 @@ AWS_EXTERN_C_END
 #    define AWS_POSTCONDITION1(cond) AWS_ASSERT(cond)
 #    define AWS_FATAL_POSTCONDITION2(cond, expl) AWS_FATAL_ASSERT(cond)
 #    define AWS_FATAL_POSTCONDITION1(cond) AWS_FATAL_ASSERT(cond)
+/**
+ * The C runtime does not give a way to check these properties,
+ * but we can at least check that the pointer is valid. */
+#    define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
+#    define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 #endif /* CBMC */
-
-/* the C runtime does not give a way to check these properties,
- * but we can at least check that the pointer is valid.
- * these macros are intended to be used with CBMC proofs, but will not use CBMC
- * intrinsics until https://github.com/diffblue/cbmc/issues/5194 is fixed.*/
-#define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
-#define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
-
-#define __CPROVER_r_ok(base, len) (AWS_MEM_IS_READABLE(base, len))
-#define __CPROVER_w_ok(base, len) (AWS_MEM_IS_WRITEABLE(base, len))
 
 /* Logical consequence. */
 #define AWS_IMPLIES(a, b) (!(a) || (b))

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -752,7 +752,6 @@ int aws_byte_buf_reserve(struct aws_byte_buf *buffer, size_t requested_capacity)
     }
 
     if (aws_mem_realloc(buffer->allocator, (void **)&buffer->buffer, buffer->capacity, requested_capacity)) {
-        AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));
         return AWS_OP_ERR;
     }
 

--- a/verification/cbmc/include/proof_helpers/make_common_data_structures.h
+++ b/verification/cbmc/include/proof_helpers/make_common_data_structures.h
@@ -19,8 +19,15 @@
 
 #include <stdlib.h>
 
-#define ASSUME_VALID_MEMORY(ptr) ptr = bounded_malloc(sizeof(*(ptr)))
-#define ASSUME_VALID_MEMORY_COUNT(ptr, count) ptr = bounded_malloc(sizeof(*(ptr)) * (count))
+/* Assume valid memory for ptr, if count > 0 and count < MAX_MALLOC_SIZE. */
+#define ASSUME_VALID_MEMORY_COUNT(ptr, count)                                                                          \
+    do {                                                                                                               \
+        ptr = bounded_malloc(sizeof(*(ptr)) * (count));                                                                \
+        __CPROVER_assume(ptr != NULL);                                                                                 \
+    } while (0)
+
+#define ASSUME_VALID_MEMORY(ptr) ASSUME_VALID_MEMORY_COUNT(ptr, sizeof(*(ptr)))
+
 #define ASSUME_DEFAULT_ALLOCATOR(allocator) allocator = aws_default_allocator()
 #define ASSUME_CAN_FAIL_ALLOCATOR(allocator) allocator = can_fail_allocator()
 
@@ -127,7 +134,7 @@ struct aws_string *ensure_string_is_allocated_nondet_length();
 /**
  * Ensures a valid string is allocated, with as much nondet as possible, but len < max
  */
-struct aws_string *ensure_string_is_allocated_bounded_length(size_t max_size);
+struct aws_string *nondet_allocate_string_bounded_length(size_t max_size);
 
 /**
  * Ensures a valid string is allocated, with as much nondet as possible, but fixed defined len

--- a/verification/cbmc/proofs/aws_array_eq_c_str/aws_array_eq_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_array_eq_c_str/aws_array_eq_c_str_harness.c
@@ -13,12 +13,12 @@ void aws_array_eq_c_str_harness() {
     size_t array_len;
     __CPROVER_assume(array_len <= MAX_BUFFER_SIZE);
     array = can_fail_malloc(array_len);
-    const char *c_str = nondet_bool() ? NULL : ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* save current state of the parameters */
     struct store_byte_from_buffer old_byte_from_array;
     save_byte_from_array((uint8_t *)array, array_len, &old_byte_from_array);
-    size_t str_len = (c_str) ? strlen(c_str) : 0;
+    size_t str_len = (c_str != NULL) ? strlen(c_str) : 0;
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 

--- a/verification/cbmc/proofs/aws_array_eq_c_str_ignore_case/aws_array_eq_c_str_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_array_eq_c_str_ignore_case/aws_array_eq_c_str_ignore_case_harness.c
@@ -12,12 +12,12 @@ void aws_array_eq_c_str_ignore_case_harness() {
     size_t array_len;
     __CPROVER_assume(array_len <= MAX_BUFFER_SIZE);
     void *array = can_fail_malloc(array_len);
-    const char *c_str = nondet_bool() ? NULL : ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* save current state of the parameters */
     struct store_byte_from_buffer old_byte_from_array;
     save_byte_from_array((uint8_t *)array, array_len, &old_byte_from_array);
-    size_t str_len = (c_str) ? strlen(c_str) : 0;
+    size_t str_len = (c_str != NULL) ? strlen(c_str) : 0;
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 

--- a/verification/cbmc/proofs/aws_array_list_comparator_string/aws_array_list_comparator_string_harness.c
+++ b/verification/cbmc/proofs/aws_array_list_comparator_string/aws_array_list_comparator_string_harness.c
@@ -10,8 +10,11 @@
 #include <stddef.h>
 
 void aws_array_list_comparator_string_harness() {
-    struct aws_string *str_a = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
-    struct aws_string *str_b = nondet_bool() ? str_a : ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str_a = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str_b = nondet_bool() ? str_a : nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(aws_string_is_valid(str_a));
+    __CPROVER_assume(aws_string_is_valid(str_b));
+
     bool nondet_parameter_a;
     bool nondet_parameter_b;
     if (aws_array_list_comparator_string(nondet_parameter_a ? &str_a : NULL, nondet_parameter_b ? &str_b : NULL) == 0) {

--- a/verification/cbmc/proofs/aws_array_list_init_static/aws_array_list_init_static_harness.c
+++ b/verification/cbmc/proofs/aws_array_list_init_static/aws_array_list_init_static_harness.c
@@ -25,6 +25,7 @@ void aws_array_list_init_static_harness() {
 
     /* perform operation under verification */
     uint8_t *raw_array = bounded_malloc(len);
+    __CPROVER_assume(raw_array != NULL);
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(raw_array, len, &old_byte);
 

--- a/verification/cbmc/proofs/aws_byte_buf_eq_c_str/aws_byte_buf_eq_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_eq_c_str/aws_byte_buf_eq_c_str_harness.c
@@ -13,6 +13,7 @@ void aws_byte_buf_eq_c_str_harness() {
     const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* assumptions */
+    __CPROVER_assume(aws_c_string_is_valid(c_str));
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
@@ -21,7 +22,7 @@ void aws_byte_buf_eq_c_str_harness() {
     struct aws_byte_buf old = buf;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(buf.buffer, buf.len, &old_byte);
-    size_t str_len = (c_str) ? strlen(c_str) : 0;
+    size_t str_len = strlen(c_str);
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 

--- a/verification/cbmc/proofs/aws_byte_buf_eq_c_str_ignore_case/aws_byte_buf_eq_c_str_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_eq_c_str_ignore_case/aws_byte_buf_eq_c_str_ignore_case_harness.c
@@ -12,6 +12,7 @@ void aws_byte_buf_eq_c_str_ignore_case_harness() {
     const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* assumptions */
+    __CPROVER_assume(c_str != NULL);
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
@@ -20,7 +21,7 @@ void aws_byte_buf_eq_c_str_ignore_case_harness() {
     struct aws_byte_buf old = buf;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array(buf.buffer, buf.len, &old_byte);
-    size_t str_len = (c_str) ? strlen(c_str) : 0;
+    size_t str_len = strlen(c_str);
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 

--- a/verification/cbmc/proofs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_from_array/aws_byte_buf_from_array_harness.c
@@ -9,7 +9,10 @@
 void aws_byte_buf_from_array_harness() {
     /* parameters */
     size_t length;
-    uint8_t *array = bounded_malloc(length);
+    uint8_t *array;
+
+    /* assumptions. */
+    ASSUME_VALID_MEMORY_COUNT(array, length);
 
     /* operation under verification */
     struct aws_byte_buf buf = aws_byte_buf_from_array(array, length);

--- a/verification/cbmc/proofs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_from_c_str/aws_byte_buf_from_c_str_harness.c
@@ -8,7 +8,7 @@
 
 void aws_byte_buf_from_c_str_harness() {
     /* parameter */
-    const char *c_str = nondet_bool() ? NULL : ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* operation under verification */
     struct aws_byte_buf buf = aws_byte_buf_from_c_str(c_str);

--- a/verification/cbmc/proofs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_reserve/aws_byte_buf_reserve_harness.c
@@ -17,9 +17,9 @@ void aws_byte_buf_reserve_harness() {
     if (aws_byte_buf_reserve(&buf, requested_capacity) == AWS_OP_SUCCESS) {
         assert(buf.capacity >= requested_capacity);
         assert(aws_byte_buf_has_allocator(&buf));
+        assert(aws_byte_buf_is_valid(&buf));
     }
 
-    assert(aws_byte_buf_is_valid(&buf));
     assert(old.len == buf.len);
     assert(old.allocator == buf.allocator);
     if (!buf.buffer) {

--- a/verification/cbmc/proofs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_reserve_relative/aws_byte_buf_reserve_relative_harness.c
@@ -18,6 +18,6 @@ void aws_byte_buf_reserve_relative_harness() {
     if (rval == AWS_OP_SUCCESS) {
         assert(buf.capacity >= (old.len + requested_capacity));
         assert(aws_byte_buf_has_allocator(&buf));
+        assert(aws_byte_buf_is_valid(&buf));
     }
-    assert(aws_byte_buf_is_valid(&buf));
 }

--- a/verification/cbmc/proofs/aws_byte_buf_write/aws_byte_buf_write_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_write/aws_byte_buf_write_harness.c
@@ -10,9 +10,10 @@ void aws_byte_buf_write_harness() {
     /* parameters */
     struct aws_byte_buf buf;
     size_t len;
-    uint8_t *array = bounded_malloc(len);
+    uint8_t *array;
 
     /* assumptions */
+    ASSUME_VALID_MEMORY_COUNT(array, len);
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));
 

--- a/verification/cbmc/proofs/aws_byte_buf_write_from_whole_string/aws_byte_buf_write_from_whole_string_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_write_from_whole_string/aws_byte_buf_write_from_whole_string_harness.c
@@ -10,7 +10,7 @@
 #include <stddef.h>
 
 void aws_byte_buf_write_from_whole_string_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
     struct aws_byte_buf buf;
 
     ensure_byte_buf_has_allocated_buffer_member(&buf);

--- a/verification/cbmc/proofs/aws_byte_cursor_eq_c_str/aws_byte_cursor_eq_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_eq_c_str/aws_byte_cursor_eq_c_str_harness.c
@@ -13,6 +13,7 @@ void aws_byte_cursor_eq_c_str_harness() {
     const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* assumptions */
+    __CPROVER_assume(c_str != NULL);
     __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
@@ -21,7 +22,7 @@ void aws_byte_cursor_eq_c_str_harness() {
     struct aws_byte_cursor old = cur;
     struct store_byte_from_buffer old_byte_from_cursor;
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cursor);
-    size_t str_len = (c_str) ? strlen(c_str) : 0;
+    size_t str_len = strlen(c_str);
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 

--- a/verification/cbmc/proofs/aws_byte_cursor_eq_c_str_ignore_case/aws_byte_cursor_eq_c_str_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_eq_c_str_ignore_case/aws_byte_cursor_eq_c_str_ignore_case_harness.c
@@ -13,6 +13,7 @@ void aws_byte_cursor_eq_c_str_ignore_case_harness() {
     const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* assumptions */
+    __CPROVER_assume(c_str != NULL);
     __CPROVER_assume(aws_byte_cursor_is_bounded(&cur, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&cur);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cur));
@@ -21,7 +22,7 @@ void aws_byte_cursor_eq_c_str_ignore_case_harness() {
     struct aws_byte_cursor old = cur;
     struct store_byte_from_buffer old_byte_from_cursor;
     save_byte_from_array(cur.ptr, cur.len, &old_byte_from_cursor);
-    size_t str_len = (c_str) ? strlen(c_str) : 0;
+    size_t str_len = strlen(c_str);
     struct store_byte_from_buffer old_byte_from_str;
     save_byte_from_array((uint8_t *)c_str, str_len, &old_byte_from_str);
 

--- a/verification/cbmc/proofs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_from_array/aws_byte_cursor_from_array_harness.c
@@ -9,7 +9,10 @@
 void aws_byte_cursor_from_array_harness() {
     /* parameters */
     size_t length;
-    uint8_t *array = bounded_malloc(length);
+    uint8_t *array;
+
+    /* assumption */
+    ASSUME_VALID_MEMORY_COUNT(array, length);
 
     /* operation under verification */
     struct aws_byte_cursor cur = aws_byte_cursor_from_array(array, length);

--- a/verification/cbmc/proofs/aws_byte_cursor_from_c_str/aws_byte_cursor_from_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_from_c_str/aws_byte_cursor_from_c_str_harness.c
@@ -8,7 +8,7 @@
 
 void aws_byte_cursor_from_c_str_harness() {
     /* parameters */
-    const char *c_str = nondet_bool() ? NULL : ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
 
     /* operation under verification */
     struct aws_byte_cursor cur = aws_byte_cursor_from_c_str(c_str);

--- a/verification/cbmc/proofs/aws_byte_cursor_from_string/aws_byte_cursor_from_string_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_from_string/aws_byte_cursor_from_string_harness.c
@@ -9,7 +9,8 @@
 #include <proof_helpers/utils.h>
 
 void aws_byte_cursor_from_string_harness() {
-    struct aws_string *str = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(aws_string_is_valid(str));
     struct aws_byte_cursor cursor = aws_byte_cursor_from_string(str);
     assert(aws_string_is_valid(str));
     assert(aws_byte_cursor_is_valid(&cursor));

--- a/verification/cbmc/proofs/aws_hash_c_string/aws_hash_c_string_harness.c
+++ b/verification/cbmc/proofs/aws_hash_c_string/aws_hash_c_string_harness.c
@@ -11,6 +11,8 @@
 
 void aws_hash_c_string_harness() {
     const char *str = ensure_c_str_is_allocated(MAX_STRING_SIZE);
-    /* This function has no pre or post conditions */
+
+    __CPROVER_assume(aws_c_string_is_valid(str));
+
     uint64_t rval = aws_hash_c_string(str);
 }

--- a/verification/cbmc/proofs/aws_hash_callback_c_str_eq/aws_hash_callback_c_str_eq_harness.c
+++ b/verification/cbmc/proofs/aws_hash_callback_c_str_eq/aws_hash_callback_c_str_eq_harness.c
@@ -12,6 +12,10 @@
 void aws_hash_callback_c_str_eq_harness() {
     const char *str1 = ensure_c_str_is_allocated(MAX_STRING_LEN);
     const char *str2 = nondet_bool() ? str1 : ensure_c_str_is_allocated(MAX_STRING_LEN);
+
+    __CPROVER_assume(aws_c_string_is_valid(str1));
+    __CPROVER_assume(aws_c_string_is_valid(str2));
+
     bool rval = aws_hash_callback_c_str_eq(str1, str2);
     if (rval) {
         size_t len = strlen(str1);

--- a/verification/cbmc/proofs/aws_hash_callback_string_destroy/aws_hash_callback_string_destroy_harness.c
+++ b/verification/cbmc/proofs/aws_hash_callback_string_destroy/aws_hash_callback_string_destroy_harness.c
@@ -10,6 +10,9 @@
 #include <stddef.h>
 
 void aws_hash_callback_string_destroy_harness() {
-    struct aws_string *str = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+
+    __CPROVER_assume(aws_c_string_is_valid(str));
+
     aws_hash_callback_string_destroy(str);
 }

--- a/verification/cbmc/proofs/aws_hash_callback_string_eq/aws_hash_callback_string_eq_harness.c
+++ b/verification/cbmc/proofs/aws_hash_callback_string_eq/aws_hash_callback_string_eq_harness.c
@@ -10,8 +10,12 @@
 #include <stddef.h>
 
 void aws_hash_callback_string_eq_harness() {
-    const struct aws_string *str1 = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
-    const struct aws_string *str2 = nondet_bool() ? str1 : ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    const struct aws_string *str1 = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    const struct aws_string *str2 = nondet_bool() ? str1 : nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+
+    __CPROVER_assume(aws_c_string_is_valid(str1));
+    __CPROVER_assume(aws_c_string_is_valid(str2));
+
     bool rval = aws_hash_callback_string_eq(str1, str2);
     if (rval) {
         assert(str1->len == str2->len);

--- a/verification/cbmc/proofs/aws_hash_iter_delete/Makefile
+++ b/verification/cbmc/proofs/aws_hash_iter_delete/Makefile
@@ -1,12 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-###########
 #4: 4m40s (smallest size that gives full coverage)
 MAX_TABLE_SIZE ?= 4
-DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE) 
-
-UNWINDSET +=  __CPROVER_file_local_hash_table_c_s_remove_entry.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
 
 CBMCFLAGS +=
 
@@ -17,12 +14,13 @@ PROOF_SOURCES += $(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(PROOF_STUB)/s_remove_entry_override.c
 
 PROOF_SOURCES += $(PROOF_STUB)/error.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/common.c
 PROJECT_SOURCES += $(SRCDIR)/source/hash_table.c
 
-###########
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_hash_table_c_s_remove_entry
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
+++ b/verification/cbmc/proofs/aws_hash_iter_delete/aws_hash_iter_delete_harness.c
@@ -10,14 +10,16 @@
 #include <proof_helpers/utils.h>
 
 void aws_hash_iter_delete_harness() {
-
     struct aws_hash_table map;
+
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));
     __CPROVER_assume(map.p_impl->destroy_key_fn == hash_proof_destroy_noop || !map.p_impl->destroy_key_fn);
     __CPROVER_assume(map.p_impl->destroy_value_fn == hash_proof_destroy_noop || !map.p_impl->destroy_value_fn);
+
     size_t empty_slot_idx;
     __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
+
     struct hash_table_state *state = map.p_impl;
 
     struct aws_hash_iter iter;

--- a/verification/cbmc/proofs/aws_hash_iter_done/aws_hash_iter_done_harness.c
+++ b/verification/cbmc/proofs/aws_hash_iter_done/aws_hash_iter_done_harness.c
@@ -10,7 +10,6 @@
 #include <proof_helpers/utils.h>
 
 void aws_hash_iter_done_harness() {
-
     struct aws_hash_table map;
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));

--- a/verification/cbmc/proofs/aws_hash_iter_next/aws_hash_iter_next_harness.c
+++ b/verification/cbmc/proofs/aws_hash_iter_next/aws_hash_iter_next_harness.c
@@ -10,7 +10,6 @@
 #include <proof_helpers/utils.h>
 
 void aws_hash_iter_next_harness() {
-
     struct aws_hash_table map;
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));

--- a/verification/cbmc/proofs/aws_hash_string/aws_hash_string_harness.c
+++ b/verification/cbmc/proofs/aws_hash_string/aws_hash_string_harness.c
@@ -10,14 +10,14 @@
 #include <proof_helpers/utils.h>
 
 void aws_hash_string_harness() {
-    struct aws_string *str = ensure_string_is_allocated_bounded_length(MAX_STRING_SIZE);
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_SIZE);
+    __CPROVER_assume(aws_string_is_valid(str));
     /*
-     * aws_hash_string has no pre or post conditions. #TODO: Currently, CBMC is unable to
-     * check all possible paths in these proof. aws_hash_string function calls hashlittle2
-     * function, which calculates two 32-bit hash values. Internally, it contains two
-     * conditions that test for alignment to 4 byte/2 byte boundaries, but CBMC is unable
-     * to correctly evaluate such conditions, due to its pointer encoding. A potential
-     * fix to this problem is under development.
+     * #TODO: Currently, CBMC is unable to check all possible paths in these proof.
+     * aws_hash_string function calls hashlittle2 function, which calculates two 32-bit
+     * hash values. Internally, it contains two conditions that test for alignment to
+     * 4 byte/2 byte boundaries, but CBMC is unable to correctly evaluate such conditions,
+     * due to its pointer encoding. A potential fix to this problem is under development.
      * For more details, see https://github.com/diffblue/cbmc/pull/1086.
      */
     uint64_t rval = aws_hash_string(str);

--- a/verification/cbmc/proofs/aws_hash_table_clean_up/aws_hash_table_clean_up_harness.c
+++ b/verification/cbmc/proofs/aws_hash_table_clean_up/aws_hash_table_clean_up_harness.c
@@ -10,7 +10,6 @@
 #include <proof_helpers/utils.h>
 
 void aws_hash_table_clean_up_harness() {
-
     struct aws_hash_table map;
     ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
     __CPROVER_assume(aws_hash_table_is_valid(&map));

--- a/verification/cbmc/proofs/aws_hash_table_create/aws_hash_table_create_harness.c
+++ b/verification/cbmc/proofs/aws_hash_table_create/aws_hash_table_create_harness.c
@@ -8,7 +8,6 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 #include <proof_helpers/utils.h>
-// Currently takes 4m40s
 
 void aws_hash_table_create_harness() {
     struct aws_hash_table map;

--- a/verification/cbmc/proofs/aws_hash_table_remove/Makefile
+++ b/verification/cbmc/proofs/aws_hash_table_remove/Makefile
@@ -8,7 +8,6 @@ MAX_TABLE_SIZE ?= 4
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
 
 UNWINDSET +=__CPROVER_file_local_hash_table_c_s_find_entry1.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
-UNWINDSET +=__CPROVER_file_local_hash_table_c_s_remove_entry.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
 
 CBMCFLAGS +=
 
@@ -24,14 +23,14 @@ PROOF_SOURCES += $(PROOF_STUB)/error.c
 PROOF_SOURCES += $(PROOF_STUB)/memset_override_no_op.c
 PROOF_SOURCES += $(PROOF_STUB)/s_emplace_item_override.c
 PROOF_SOURCES += $(PROOF_STUB)/s_expand_table_override.c
+PROOF_SOURCES += $(PROOF_STUB)/s_remove_entry_override.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/common.c
 PROJECT_SOURCES += $(SRCDIR)/source/hash_table.c
 
 REMOVE_FUNCTION_BODY +=  __CPROVER_file_local_hash_table_c_s_emplace_item
 REMOVE_FUNCTION_BODY +=  __CPROVER_file_local_hash_table_c_s_expand_table
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_hash_table_c_s_remove_entry
 REMOVE_FUNCTION_BODY +=  nondet-compare
-
-###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_priority_queue_init_static/aws_priority_queue_init_static_harness.c
+++ b/verification/cbmc/proofs/aws_priority_queue_init_static/aws_priority_queue_init_static_harness.c
@@ -18,6 +18,7 @@ void aws_priority_queue_init_static_harness() {
     size_t item_size;
     size_t initial_item_allocation;
     size_t len;
+    uint8_t *raw_array;
 
     /* assumptions */
     __CPROVER_assume(initial_item_allocation > 0 && initial_item_allocation <= MAX_INITIAL_ITEM_ALLOCATION);
@@ -25,7 +26,7 @@ void aws_priority_queue_init_static_harness() {
     __CPROVER_assume(!aws_mul_size_checked(initial_item_allocation, item_size, &len));
 
     /* perform operation under verification */
-    uint8_t *raw_array = bounded_malloc(len);
+    ASSUME_VALID_MEMORY_COUNT(raw_array, len);
     aws_priority_queue_init_static(&queue, raw_array, initial_item_allocation, item_size, nondet_compare);
 
     /* assertions */

--- a/verification/cbmc/proofs/aws_string_bytes/aws_string_bytes_harness.c
+++ b/verification/cbmc/proofs/aws_string_bytes/aws_string_bytes_harness.c
@@ -9,6 +9,7 @@
 
 void aws_string_bytes_harness() {
     struct aws_string *str = ensure_string_is_allocated_nondet_length();
+    __CPROVER_assume(aws_string_is_valid(str));
     assert(aws_string_bytes(str) == str->bytes);
     assert(aws_string_is_valid(str));
 }

--- a/verification/cbmc/proofs/aws_string_compare/aws_string_compare_harness.c
+++ b/verification/cbmc/proofs/aws_string_compare/aws_string_compare_harness.c
@@ -9,9 +9,11 @@
 #include <proof_helpers/utils.h>
 
 void aws_string_compare_harness() {
-    struct aws_string *str_a = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
+    struct aws_string *str_a = nondet_bool() ? nondet_allocate_string_bounded_length(MAX_STRING_LEN) : NULL;
     struct aws_string *str_b =
-        nondet_bool() ? (nondet_bool() ? str_a : NULL) : ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+        nondet_bool() ? (nondet_bool() ? str_a : NULL) : nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(IMPLIES(str_a != NULL, aws_string_is_valid(str_a)));
+    __CPROVER_assume(IMPLIES(str_b != NULL, aws_string_is_valid(str_b)));
     bool nondet_parameter = nondet_bool();
     if (aws_string_compare(str_a, nondet_parameter ? str_b : str_a) == AWS_OP_SUCCESS) {
         if (nondet_parameter && str_a && str_b) {

--- a/verification/cbmc/proofs/aws_string_destroy/aws_string_destroy_harness.c
+++ b/verification/cbmc/proofs/aws_string_destroy/aws_string_destroy_harness.c
@@ -8,6 +8,7 @@
 #include <proof_helpers/proof_allocators.h>
 
 void aws_string_destroy_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_nondet_length() : NULL;
+    struct aws_string *str = ensure_string_is_allocated_nondet_length();
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
     aws_string_destroy(str);
 }

--- a/verification/cbmc/proofs/aws_string_eq/aws_string_eq_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq/aws_string_eq_harness.c
@@ -9,8 +9,10 @@
 #include <proof_helpers/utils.h>
 
 void aws_string_eq_harness() {
-    struct aws_string *str_a = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
-    struct aws_string *str_b = nondet_bool() ? str_a : ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str_a = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str_b = nondet_bool() ? str_a : nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(IMPLIES(str_a != NULL, aws_string_is_valid(str_a)));
+    __CPROVER_assume(IMPLIES(str_b != NULL, aws_string_is_valid(str_b)));
     if (aws_string_eq(str_a, str_b) && str_a && str_b) {
         assert(str_a->len == str_b->len);
         assert_bytes_match(str_a->bytes, str_b->bytes, str_a->len);

--- a/verification/cbmc/proofs/aws_string_eq_byte_buf/aws_string_eq_byte_buf_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_byte_buf/aws_string_eq_byte_buf_harness.c
@@ -10,9 +10,10 @@
 #include <stddef.h>
 
 void aws_string_eq_byte_buf_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
     struct aws_byte_buf buf;
 
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_STRING_LEN));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));

--- a/verification/cbmc/proofs/aws_string_eq_byte_buf_ignore_case/aws_string_eq_byte_buf_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_byte_buf_ignore_case/aws_string_eq_byte_buf_ignore_case_harness.c
@@ -10,9 +10,10 @@
 #include <stddef.h>
 
 void aws_string_eq_byte_buf_ignore_case_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
     struct aws_byte_buf buf;
 
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
     __CPROVER_assume(aws_byte_buf_is_bounded(&buf, MAX_STRING_LEN));
     ensure_byte_buf_has_allocated_buffer_member(&buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&buf));

--- a/verification/cbmc/proofs/aws_string_eq_byte_cursor/aws_string_eq_byte_cursor_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_byte_cursor/aws_string_eq_byte_cursor_harness.c
@@ -9,9 +9,10 @@
 #include <proof_helpers/utils.h>
 
 void aws_string_eq_byte_cursor_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
     struct aws_byte_cursor cursor;
 
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
     ensure_byte_cursor_has_allocated_buffer_member(&cursor);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cursor));
 

--- a/verification/cbmc/proofs/aws_string_eq_byte_cursor_ignore_case/aws_string_eq_byte_cursor_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_byte_cursor_ignore_case/aws_string_eq_byte_cursor_ignore_case_harness.c
@@ -8,9 +8,10 @@
 #include <proof_helpers/proof_allocators.h>
 
 void aws_string_eq_byte_cursor_ignore_case_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
     struct aws_byte_cursor cursor;
 
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
     ensure_byte_cursor_has_allocated_buffer_member(&cursor);
     __CPROVER_assume(aws_byte_cursor_is_valid(&cursor));
 

--- a/verification/cbmc/proofs/aws_string_eq_c_str/aws_string_eq_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_c_str/aws_string_eq_c_str_harness.c
@@ -9,8 +9,9 @@
 #include <proof_helpers/utils.h>
 
 void aws_string_eq_c_str_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
-    const char *c_str = nondet_bool() ? ensure_c_str_is_allocated(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
+    const char *c_str = ensure_c_str_is_allocated(MAX_STRING_LEN);
     if (aws_string_eq_c_str(str, c_str) && str && c_str) {
         assert(aws_string_is_valid(str));
         assert(aws_c_string_is_valid(c_str));

--- a/verification/cbmc/proofs/aws_string_eq_c_str_ignore_case/aws_string_eq_c_str_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_c_str_ignore_case/aws_string_eq_c_str_ignore_case_harness.c
@@ -9,8 +9,9 @@
 #include <proof_helpers/utils.h>
 
 void aws_string_eq_c_str_ignore_case_harness() {
-    struct aws_string *str = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
-    const char *c_str = nondet_bool() ? ensure_c_str_is_allocated(MAX_STRING_LEN) : NULL;
+    struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(IMPLIES(str != NULL, aws_string_is_valid(str)));
+    const char *c_str = ensure_c_str_is_allocated(MAX_STRING_LEN);
     if (aws_string_eq_c_str_ignore_case(str, c_str) && str && c_str) {
         assert(aws_string_is_valid(str));
         assert(aws_c_string_is_valid(c_str));

--- a/verification/cbmc/proofs/aws_string_eq_ignore_case/aws_string_eq_ignore_case_harness.c
+++ b/verification/cbmc/proofs/aws_string_eq_ignore_case/aws_string_eq_ignore_case_harness.c
@@ -9,9 +9,10 @@
 #include <proof_helpers/utils.h>
 
 void aws_string_eq_ignore_case_harness() {
-    struct aws_string *str_a = nondet_bool() ? ensure_string_is_allocated_bounded_length(MAX_STRING_LEN) : NULL;
-    struct aws_string *str_b =
-        nondet_bool() ? (nondet_bool() ? str_a : NULL) : ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str_a = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    struct aws_string *str_b = nondet_bool() ? str_a : nondet_allocate_string_bounded_length(MAX_STRING_LEN);
+    __CPROVER_assume(IMPLIES(str_a != NULL, aws_string_is_valid(str_a)));
+    __CPROVER_assume(IMPLIES(str_b != NULL && str_a != str_b, aws_string_is_valid(str_b)));
     if (aws_string_eq_ignore_case(str_a, str_b) && str_a && str_b) {
         assert(aws_string_is_valid(str_a));
         assert(aws_string_is_valid(str_b));

--- a/verification/cbmc/proofs/aws_string_new_from_array/aws_string_new_from_array_harness.c
+++ b/verification/cbmc/proofs/aws_string_new_from_array/aws_string_new_from_array_harness.c
@@ -11,11 +11,13 @@
 void aws_string_new_from_array_harness() {
     /* parameters */
     size_t alloc_size;
-    uint8_t *array = bounded_malloc(alloc_size);
-    struct aws_allocator *allocator = can_fail_allocator();
+    uint8_t *array;
+    struct aws_allocator *allocator;
     size_t reported_size;
 
     /* precondition */
+    ASSUME_VALID_MEMORY_COUNT(array, alloc_size);
+    ASSUME_CAN_FAIL_ALLOCATOR(allocator);
     __CPROVER_assume(reported_size <= alloc_size);
 
     /* operation under verification */

--- a/verification/cbmc/proofs/aws_string_new_from_c_str/aws_string_new_from_c_str_harness.c
+++ b/verification/cbmc/proofs/aws_string_new_from_c_str/aws_string_new_from_c_str_harness.c
@@ -11,7 +11,11 @@
 void aws_string_new_from_c_str_harness() {
     /* parameters */
     const char *c_str = ensure_c_str_is_allocated(MAX_STRING_LEN);
-    struct aws_allocator *allocator = can_fail_allocator();
+    struct aws_allocator *allocator;
+
+    /* assumptions */
+    __CPROVER_assume(c_str != NULL);
+    ASSUME_CAN_FAIL_ALLOCATOR(allocator);
 
     /* operation under verification */
     struct aws_string *str = aws_string_new_from_c_str(allocator, c_str);

--- a/verification/cbmc/proofs/aws_string_new_from_string/aws_string_new_from_string_harness.c
+++ b/verification/cbmc/proofs/aws_string_new_from_string/aws_string_new_from_string_harness.c
@@ -11,6 +11,7 @@
 void aws_string_new_from_string_harness() {
     /* parameters */
     struct aws_string *source = ensure_string_is_allocated_nondet_length();
+    __CPROVER_assume(aws_string_is_valid(source));
     struct aws_allocator *allocator = (source->allocator) ? source->allocator : can_fail_allocator();
 
     /* operation under verification */

--- a/verification/cbmc/sources/proof_allocators.c
+++ b/verification/cbmc/sources/proof_allocators.c
@@ -55,11 +55,13 @@ void *bounded_calloc(size_t num, size_t size) {
     size_t required_bytes;
     __CPROVER_assume(aws_mul_size_checked(num, size, &required_bytes) == AWS_OP_SUCCESS);
     __CPROVER_assume(required_bytes <= MAX_MALLOC);
+    __CPROVER_assume(size != 0);
     return calloc(num, size);
 }
 
 void *bounded_malloc(size_t size) {
     __CPROVER_assume(size <= MAX_MALLOC);
+    __CPROVER_assume(size != 0);
     return malloc(size);
 }
 
@@ -95,7 +97,7 @@ void *can_fail_realloc(void *ptr, size_t newsize) {
         }
         return nondet_voidp();
     }
-    return nondet_bool() ? NULL : realloc(ptr, newsize);
+    return realloc(ptr, newsize);
 }
 
 /************************************************************************************************************
@@ -218,6 +220,7 @@ int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize,
     }
 
     void *newptr = can_fail_realloc(*ptr, newsize);
+
     if (!newptr) {
         return aws_raise_error(AWS_ERROR_OOM);
     }

--- a/verification/cbmc/stubs/s_remove_entry_override.c
+++ b/verification/cbmc/stubs/s_remove_entry_override.c
@@ -1,0 +1,32 @@
+#include <aws/common/hash_table.h>
+#include <aws/common/math.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/common/string.h>
+
+#include <limits.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Clears an entry. Does _not_ invoke destructor callbacks.
+ * Returns the last slot touched (note that if we wrap, we'll report an index
+ * lower than the original entry's index)
+ */
+size_t __CPROVER_file_local_hash_table_c_s_remove_entry(
+    struct hash_table_state *state,
+    struct hash_table_entry *entry) {
+    AWS_PRECONDITION(hash_table_state_is_valid(state));
+    AWS_PRECONDITION(state->entry_count > 0);
+    AWS_PRECONDITION(
+        entry >= &state->slots[0] && entry < &state->slots[state->size],
+        "Input hash_table_entry [entry] pointer must point in the available slots.");
+    state->entry_count--;
+
+    /* This stub does not update any slots. */
+
+    size_t index;
+    __CPROVER_assume(index <= state->size);
+
+    AWS_RETURN_WITH_POSTCONDITION(index, hash_table_state_is_valid(state) && index <= state->size);
+}


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*

N/A.

*Description of changes:*

- Modify CBMC proofs to make assumptions about malloc explicit;
- Upgrade the template version used in CBMC proofs (e.g., new version includes "malloc may fail" flags);
- Revert changes from PR https://github.com/awslabs/aws-c-common/pull/600;
- Adds stub for `s_remove_entry`in `hash_table` proofs;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
