### PR TITLE
Crude build os detection function

### DIFF
--- a/include/aws/common/system_info.h
+++ b/include/aws/common/system_info.h
@@ -8,7 +8,17 @@
 
 #include <aws/common/common.h>
 
+enum aws_platform_os {
+    AWS_OS_WINDOWS,
+    AWS_OS_MAC,
+    AWS_OS_UNIX,
+};
+
 AWS_EXTERN_C_BEGIN
+
+/* Returns the OS this was built under */
+AWS_COMMON_API
+enum aws_platform_os aws_get_platform_build_os(void);
 
 /* Returns the number of online processors available for usage. */
 AWS_COMMON_API

--- a/include/aws/common/system_info.h
+++ b/include/aws/common/system_info.h
@@ -9,9 +9,9 @@
 #include <aws/common/common.h>
 
 enum aws_platform_os {
-    AWS_OS_WINDOWS,
-    AWS_OS_MAC,
-    AWS_OS_UNIX,
+    AWS_PLATFORM_OS_WINDOWS,
+    AWS_PLATFORM_OS_MAC,
+    AWS_PLATFORM_OS_UNIX,
 };
 
 AWS_EXTERN_C_BEGIN

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -7,6 +7,7 @@
 
 #include <aws/common/byte_buf.h>
 #include <aws/common/logging.h>
+#include <aws/common/platform.h>
 
 #if defined(__FreeBSD__) || defined(__NetBSD__)
 #    define __BSD_VISIBLE 1
@@ -397,12 +398,12 @@ void aws_backtrace_log() {
     free(symbols);
 }
 
-#if defined(__APPLE__)
+#if defined(AWS_OS_APPLE)
 enum aws_platform_os aws_get_platform_build_os(void) {
-    return AWS_OS_MAC;
+    return AWS_PLATFORM_OS_MAC;
 }
 #else
 enum aws_platform_os aws_get_platform_build_os(void) {
-    return AWS_OS_UNIX;
+    return AWS_PLATFORM_OS_UNIX;
 }
-#endif /* __APPLE__ */
+#endif /* AWS_OS_APPLE */

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -396,3 +396,13 @@ void aws_backtrace_log() {
     }
     free(symbols);
 }
+
+#if defined(__APPLE__)
+enum aws_platform_os aws_get_platform_build_os(void) {
+    return AWS_OS_MAC;
+}
+#else
+enum aws_platform_os aws_get_platform_build_os(void) {
+    return AWS_OS_UNIX;
+}
+#endif /* __APPLE__ */

--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -12,7 +12,7 @@
 #include <windows.h>
 
 enum aws_platform_os aws_get_platform_build_os(void) {
-    return AWS_OS_WINDOWS;
+    return AWS_PLATFORM_OS_WINDOWS;
 }
 
 size_t aws_system_info_processor_count(void) {

--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -11,6 +11,10 @@
 
 #include <windows.h>
 
+enum aws_platform_os aws_get_platform_build_os(void) {
+    return AWS_OS_WINDOWS;
+}
+
 size_t aws_system_info_processor_count(void) {
     SYSTEM_INFO info;
     GetSystemInfo(&info);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -283,6 +283,7 @@ endif()
 
 add_test_case(test_cpu_count_at_least_works_superficially)
 add_test_case(test_stack_trace_decoding)
+add_test_case(test_platform_build_os)
 
 add_test_case(test_realloc_fallback)
 add_test_case(test_realloc_fallback_oom)

--- a/tests/system_info_tests.c
+++ b/tests/system_info_tests.c
@@ -98,12 +98,12 @@ static int s_test_platform_build_os_fn(struct aws_allocator *allocator, void *ct
 
     enum aws_platform_os build_os = aws_get_platform_build_os();
 
-#if defined(__APPLE__)
-    ASSERT_INT_EQUALS(build_os, AWS_OS_MAC);
+#if defined(AWS_OS_APPLE)
+    ASSERT_INT_EQUALS(build_os, AWS_PLATFORM_OS_MAC);
 #elif defined(_WIN32)
-    ASSERT_INT_EQUALS(build_os, AWS_OS_WINDOWS);
+    ASSERT_INT_EQUALS(build_os, AWS_PLATFORM_OS_WINDOWS);
 #else
-    ASSERT_INT_EQUALS(build_os, AWS_OS_UNIX);
+    ASSERT_INT_EQUALS(build_os, AWS_PLATFORM_OS_UNIX);
 #endif
 
     return 0;

--- a/tests/system_info_tests.c
+++ b/tests/system_info_tests.c
@@ -91,3 +91,22 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
 }
 
 AWS_TEST_CASE(test_stack_trace_decoding, s_test_stack_trace_decoding);
+
+static int s_test_platform_build_os_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    enum aws_platform_os build_os = aws_get_platform_build_os();
+
+#if defined(__APPLE__)
+    ASSERT_INT_EQUALS(build_os, AWS_OS_MAC);
+#elif defined(_WIN32)
+    ASSERT_INT_EQUALS(build_os, AWS_OS_WINDOWS);
+#else
+    ASSERT_INT_EQUALS(build_os, AWS_OS_UNIX);
+#endif
+
+    return 0;
+}
+
+AWS_TEST_CASE(test_platform_build_os, s_test_platform_build_os_fn)


### PR DESCRIPTION
potentially improve granularity, flavors, etc... later
Critical to get dotnet crt loading properly on macs when targeting net35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
