### PR TITLE
aws_byte_buf_append_n

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -345,6 +345,13 @@ AWS_COMMON_API
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from);
 
 /**
+ * Writes 'count' copies of a character to 'to'. If to is too small, AWS_ERROR_DEST_COPY_TOO_SMALL will be
+ * returned. dest->len will contain the amount of data actually copied to dest.
+ */
+AWS_COMMON_API
+int aws_byte_buf_append_n(struct aws_byte_buf *to, uint8_t value, size_t count);
+
+/**
  * Copies from to to while converting bytes via the passed in lookup table.
  * If to is too small, AWS_ERROR_DEST_COPY_TOO_SMALL will be
  * returned. to->len will contain its original size plus the amount of data actually copied to to.

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -345,8 +345,8 @@ AWS_COMMON_API
 int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *from);
 
 /**
- * Writes 'count' copies of a character to 'to'. If to is too small, AWS_ERROR_DEST_COPY_TOO_SMALL will be
- * returned. dest->len will contain the amount of data actually copied to dest.
+ * Writes 'count' copies of a character to 'to'. If 'to' is too small, AWS_ERROR_DEST_COPY_TOO_SMALL will be
+ * returned. to->len will be updated with the amount of data actually copied to 'to'.
  */
 AWS_COMMON_API
 int aws_byte_buf_append_n(struct aws_byte_buf *to, uint8_t value, size_t count);

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -581,6 +581,23 @@ int aws_byte_buf_append(struct aws_byte_buf *to, const struct aws_byte_cursor *f
     return AWS_OP_SUCCESS;
 }
 
+int aws_byte_buf_append_n(struct aws_byte_buf *to, uint8_t value, size_t count) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(to));
+
+    if (to->capacity - to->len < count) {
+        AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+        return aws_raise_error(AWS_ERROR_DEST_COPY_TOO_SMALL);
+    }
+
+    if (count > 0) {
+        memset(to->buffer + to->len, value, count);
+        to->len += count;
+    }
+
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(to));
+    return AWS_OP_SUCCESS;
+}
+
 int aws_byte_buf_append_with_lookup(
     struct aws_byte_buf *AWS_RESTRICT to,
     const struct aws_byte_cursor *AWS_RESTRICT from,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,8 @@ add_test_case(test_isalpha)
 add_test_case(test_isdigit)
 add_test_case(test_isxdigit)
 add_test_case(test_isspace)
+add_test_case(test_buffer_append_n)
+add_test_case(test_buffer_append_n_dest_too_small)
 
 add_test_case(byte_swap_test)
 


### PR DESCRIPTION
* new byte_buf api to append N copies of a byte 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
