### PR TITLE
Don't re-export libs, fix build with cmake 3.19

### DIFF
--- a/cmake/AwsSharedLibSetup.cmake
+++ b/cmake/AwsSharedLibSetup.cmake
@@ -32,7 +32,6 @@ function(aws_prepare_shared_lib_exports target)
                 DESTINATION ${RUNTIME_DIRECTORY}
                 COMPONENT Runtime)
         install(TARGETS ${target}
-                EXPORT ${target}-targets
                 LIBRARY
                 DESTINATION ${LIBRARY_DIRECTORY}
                 NAMELINK_ONLY


### PR DESCRIPTION
*Issue #, if available:*
closes #734

*Description of changes:*
Attempting to build with cmake 3.19 will result in this error:
```
CMake Error: install(EXPORT "aws-c-common-targets" ...) includes target "aws-c-common" more than once in the export set.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
