### PR TITLE
Disabled MSVC 2015's non-constant aggregate initializer warning

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -30,6 +30,9 @@ function(aws_set_common_properties target)
         # Since we want to be compatible with user builds using /volatile:iso, use it for the tests.
         list(APPEND AWS_C_FLAGS /volatile:iso)
 
+        # disable non-constant initializer warning, it's not non-standard, just for Microsoft
+        list(APPEND AWS_C_FLAGS /wd4204)
+
         if (AWS_SUPPORT_WIN7)
             # Use only APIs available in Win7 and later
             message(STATUS "Windows 7 support requested, forcing WINVER and _WIN32_WINNT to 0x0601")


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
