### PR TITLE
Do not use addr2line by default, backtrace_symbols will do the job

### DIFF
--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -53,6 +53,7 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #    define AWS_LIKELY(x) x
 #    define AWS_UNLIKELY(x) x
 #    define AWS_FORCE_INLINE __forceinline
+#    define AWS_NO_INLINE __declspec(noinline)
 #    define AWS_VARIABLE_LENGTH_ARRAY(type, name, length) type *name = _alloca(sizeof(type) * (length))
 #    define AWS_DECLSPEC_NORETURN __declspec(noreturn)
 #    define AWS_ATTRIBUTE_NORETURN
@@ -63,6 +64,7 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #        define AWS_LIKELY(x) __builtin_expect(!!(x), 1)
 #        define AWS_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #        define AWS_FORCE_INLINE __attribute__((always_inline))
+#        define AWS_NO_INLINE __attribute__((noinline))
 #        define AWS_DECLSPEC_NORETURN
 #        define AWS_ATTRIBUTE_NORETURN __attribute__((noreturn))
 #        if defined(__cplusplus)

--- a/source/memtrace.c
+++ b/source/memtrace.c
@@ -212,7 +212,7 @@ static int s_collect_stack_trace(void *context, struct aws_hash_element *item) {
     char buf[4096] = {0};
     struct aws_byte_buf stacktrace = aws_byte_buf_from_empty_array(buf, AWS_ARRAY_SIZE(buf));
     struct aws_byte_cursor newline = aws_byte_cursor_from_c_str("\n");
-    char **symbols = aws_backtrace_addr2line(stack_frames, stack->depth);
+    char **symbols = aws_backtrace_symbols(stack_frames, stack->depth);
     for (size_t idx = 0; idx < stack->depth; ++idx) {
         if (idx > 0) {
             aws_byte_buf_append(&stacktrace, &newline);

--- a/tests/memtrace_test.c
+++ b/tests/memtrace_test.c
@@ -63,19 +63,29 @@ static int s_test_memtrace_count(struct aws_allocator *allocator, void *ctx) {
 }
 AWS_TEST_CASE(test_memtrace_count, s_test_memtrace_count)
 
-static void *s_alloc_1(struct aws_allocator *allocator, size_t size) {
+#if defined(__GNUC__) || defined(__clang__)
+#    define AWS_PREVENT_OPTIMIZATION __asm__ __volatile__("" ::: "memory")
+#else
+#    define AWS_PREVENT_OPTIMIZATION
+#endif
+
+AWS_NO_INLINE void *s_alloc_1(struct aws_allocator *allocator, size_t size) {
+    AWS_PREVENT_OPTIMIZATION;
     return aws_mem_acquire(allocator, size);
 }
 
-static void *s_alloc_2(struct aws_allocator *allocator, size_t size) {
+AWS_NO_INLINE void *s_alloc_2(struct aws_allocator *allocator, size_t size) {
+    AWS_PREVENT_OPTIMIZATION;
     return aws_mem_acquire(allocator, size);
 }
 
-static void *s_alloc_3(struct aws_allocator *allocator, size_t size) {
+AWS_NO_INLINE void *s_alloc_3(struct aws_allocator *allocator, size_t size) {
+    AWS_PREVENT_OPTIMIZATION;
     return aws_mem_acquire(allocator, size);
 }
 
-static void *s_alloc_4(struct aws_allocator *allocator, size_t size) {
+AWS_NO_INLINE void *s_alloc_4(struct aws_allocator *allocator, size_t size) {
+    AWS_PREVENT_OPTIMIZATION;
     return aws_mem_acquire(allocator, size);
 }
 
@@ -132,11 +142,20 @@ static int s_test_memtrace_stacks(struct aws_allocator *allocator, void *ctx) {
     /* if this is not a debug build, there may not be symbols, so the test cannot
      * verify if a best effort was made */
 #if defined(DEBUG_BUILD)
-    ASSERT_TRUE(strstr((const char *)test_logger->log_buffer.buffer, "s_alloc_1"));
-    ASSERT_TRUE(strstr((const char *)test_logger->log_buffer.buffer, "s_alloc_2"));
-    ASSERT_TRUE(strstr((const char *)test_logger->log_buffer.buffer, "s_alloc_3"));
-    ASSERT_TRUE(strstr((const char *)test_logger->log_buffer.buffer, "s_alloc_4"));
-    ASSERT_TRUE(strstr((const char *)test_logger->log_buffer.buffer, __FUNCTION__));
+    /* fprintf(stderr, "%s\n", test_logger->log_buffer.buffer); */
+    char s_alloc_1_addr[32];
+    char s_alloc_2_addr[32];
+    char s_alloc_3_addr[32];
+    char s_alloc_4_addr[32];
+    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%lx", (uintptr_t)(void *)s_alloc_1);
+    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%lx", (uintptr_t)(void *)s_alloc_2);
+    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%lx", (uintptr_t)(void *)s_alloc_3);
+    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%lx", (uintptr_t)(void *)s_alloc_4);
+    const char *log_buffer = (const char *)test_logger->log_buffer.buffer;
+    ASSERT_TRUE(strstr(log_buffer, "s_alloc_1") || strstr(log_buffer, s_alloc_1_addr));
+    ASSERT_TRUE(strstr(log_buffer, "s_alloc_2") || strstr(log_buffer, s_alloc_2_addr));
+    ASSERT_TRUE(strstr(log_buffer, "s_alloc_3") || strstr(log_buffer, s_alloc_3_addr));
+    ASSERT_TRUE(strstr(log_buffer, "s_alloc_4") || strstr(log_buffer, s_alloc_4_addr));
 #endif
 
     /* reset log */

--- a/tests/memtrace_test.c
+++ b/tests/memtrace_test.c
@@ -147,10 +147,10 @@ static int s_test_memtrace_stacks(struct aws_allocator *allocator, void *ctx) {
     char s_alloc_2_addr[32];
     char s_alloc_3_addr[32];
     char s_alloc_4_addr[32];
-    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%lx", (uintptr_t)(void *)s_alloc_1);
-    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%lx", (uintptr_t)(void *)s_alloc_2);
-    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%lx", (uintptr_t)(void *)s_alloc_3);
-    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%lx", (uintptr_t)(void *)s_alloc_4);
+    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%lx", (uint64_t)(void *)s_alloc_1);
+    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%lx", (uint64_t)(void *)s_alloc_2);
+    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%lx", (uint64_t)(void *)s_alloc_3);
+    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%lx", (uint64_t)(void *)s_alloc_4);
     const char *log_buffer = (const char *)test_logger->log_buffer.buffer;
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_1") || strstr(log_buffer, s_alloc_1_addr));
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_2") || strstr(log_buffer, s_alloc_2_addr));

--- a/tests/memtrace_test.c
+++ b/tests/memtrace_test.c
@@ -147,10 +147,10 @@ static int s_test_memtrace_stacks(struct aws_allocator *allocator, void *ctx) {
     char s_alloc_2_addr[32];
     char s_alloc_3_addr[32];
     char s_alloc_4_addr[32];
-    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%lx", (uint64_t)(void *)s_alloc_1);
-    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%lx", (uint64_t)(void *)s_alloc_2);
-    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%lx", (uint64_t)(void *)s_alloc_3);
-    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%lx", (uint64_t)(void *)s_alloc_4);
+    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%llx", (uint64_t)(void *)s_alloc_1);
+    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%llx", (uint64_t)(void *)s_alloc_2);
+    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%llx", (uint64_t)(void *)s_alloc_3);
+    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%llx", (uint64_t)(void *)s_alloc_4);
     const char *log_buffer = (const char *)test_logger->log_buffer.buffer;
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_1") || strstr(log_buffer, s_alloc_1_addr));
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_2") || strstr(log_buffer, s_alloc_2_addr));

--- a/tests/memtrace_test.c
+++ b/tests/memtrace_test.c
@@ -147,10 +147,10 @@ static int s_test_memtrace_stacks(struct aws_allocator *allocator, void *ctx) {
     char s_alloc_2_addr[32];
     char s_alloc_3_addr[32];
     char s_alloc_4_addr[32];
-    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%llx", (uint64_t)(void *)s_alloc_1);
-    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%llx", (uint64_t)(void *)s_alloc_2);
-    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%llx", (uint64_t)(void *)s_alloc_3);
-    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%llx", (uint64_t)(void *)s_alloc_4);
+    snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%tx", (uintptr_t)(void *)s_alloc_1);
+    snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%tx", (uintptr_t)(void *)s_alloc_2);
+    snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%tx", (uintptr_t)(void *)s_alloc_3);
+    snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%tx", (uintptr_t)(void *)s_alloc_4);
     const char *log_buffer = (const char *)test_logger->log_buffer.buffer;
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_1") || strstr(log_buffer, s_alloc_1_addr));
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_2") || strstr(log_buffer, s_alloc_2_addr));


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
