### PR TITLE
Fix thread.c for FreeBSD

### DIFF
--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -22,6 +22,7 @@
 
 #if defined(__FreeBSD__) || defined(__NETBSD__)
 #    include <pthread_np.h>
+typedef cpuset_t cpu_set_t;
 #endif
 
 static struct aws_thread_options s_default_options = {


### PR DESCRIPTION
This API is oh-so-subtly different on BSD (named `cpuset_t` instead of Linux's `cpu_set_t`). This hack does the trick for now

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
