### PR TITLE
Use aligned allocs for > PAGE_SIZE allocations, avoid unaligned memcpy/memset on large buffers

### DIFF
--- a/source/allocator.c
+++ b/source/allocator.c
@@ -65,7 +65,7 @@ static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_
 #if !defined(_WIN32)
     return realloc(ptr, newsize);
 #else
-    return _aligned_realloc(ptr, newsize, sizeof(void *) * (size > PAGE_SIZE ? 8 : 1));
+    return _aligned_realloc(ptr, newsize, sizeof(void *) * (newsize > PAGE_SIZE ? 8 : 1));
 #endif
 }
 

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -55,7 +55,7 @@ static void s_default_free(struct aws_allocator *allocator, void *ptr) {
 #if !defined(_WIN32)
     free(ptr);
 #else
-    _aligned_free(ptr)
+    _aligned_free(ptr);
 #endif
 }
 

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -39,7 +39,9 @@ static void *s_default_malloc(struct aws_allocator *allocator, size_t size) {
 #if !defined(_WIN32)
     if (size > PAGE_SIZE) {
         void *result = NULL;
-        posix_memalign(&result, sizeof(void *) * 8, size);
+        if (posix_memalign(&result, sizeof(void *) * 8, size)) {
+            return NULL;
+        }
         return result;
     }
     return malloc(size);

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -59,7 +59,7 @@ static void s_default_free(struct aws_allocator *allocator, void *ptr) {
 static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
     (void)allocator;
     (void)oldsize;
-    const size_t alignment = sizeof(void *) * (size > PAGE_SIZE ? 8 : 1);
+    const size_t alignment = sizeof(void *) * (newsize > PAGE_SIZE ? 8 : 1);
 #if !defined(_WIN32)
     if (newsize == 0) {
         free(ptr);

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -59,7 +59,6 @@ static void s_default_free(struct aws_allocator *allocator, void *ptr) {
 static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
     (void)allocator;
     (void)oldsize;
-    const size_t alignment = sizeof(void *) * (newsize > PAGE_SIZE ? 8 : 1);
 #if !defined(_WIN32)
     if (newsize == 0) {
         free(ptr);
@@ -75,6 +74,7 @@ static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_
     memcpy(new_mem, ptr, oldsize);
     s_default_free(allocator, ptr);
 #else
+    const size_t alignment = sizeof(void *) * (newsize > PAGE_SIZE ? 8 : 1);
     return _aligned_realloc(ptr, newsize, alignment);
 #endif
 }

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -73,6 +73,7 @@ static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_
     void *new_mem = s_default_malloc(allocator, newsize);
     memcpy(new_mem, ptr, oldsize);
     s_default_free(allocator, ptr);
+    return new_mem;
 #else
     const size_t alignment = sizeof(void *) * (newsize > PAGE_SIZE ? 8 : 1);
     return _aligned_realloc(ptr, newsize, alignment);

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -61,7 +61,19 @@ static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_
     (void)oldsize;
     const size_t alignment = sizeof(void *) * (size > PAGE_SIZE ? 8 : 1);
 #if !defined(_WIN32)
-    return realloc(ptr, newsize);
+    if (newsize == 0) {
+        free(ptr);
+        return NULL;
+    }
+
+    if (newsize <= oldsize) {
+        return ptr;
+    }
+
+    /* newsize is > oldsize, need more memory */
+    void *new_mem = s_default_malloc(allocator, newsize);
+    memcpy(new_mem, ptr, oldsize);
+    s_default_free(allocator, ptr);
 #else
     return _aligned_realloc(ptr, newsize, alignment);
 #endif

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -38,12 +38,12 @@ static void *s_default_malloc(struct aws_allocator *allocator, size_t size) {
     (void)allocator;
     /* larger allocations should be aligned so that AVX and friends can run
      * the aligned versions of memcpy and memset and friends on big buffers */
-    size_t alignment = sizeof(void*) * (size > PAGE_SIZE ? 8 : 1)
+    const size_t alignment = sizeof(void *) * (size > PAGE_SIZE ? 8 : 1);
 #if !defined(_WIN32)
     void *result = NULL;
-    return (posix_memalign(&result, sizeof(void *) * 8, size)) ? NULL : result;
+    return (posix_memalign(&result, alignment)) ? NULL : result;
 #else
-    return _aligned_malloc(size, sizeof(void *) * (size > PAGE_SIZE ? 8 : 1));
+    return _aligned_malloc(size, alignment));
 #endif
 }
 
@@ -59,10 +59,11 @@ static void s_default_free(struct aws_allocator *allocator, void *ptr) {
 static void *s_default_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
     (void)allocator;
     (void)oldsize;
+    const size_t alignment = sizeof(void *) * (size > PAGE_SIZE ? 8 : 1);
 #if !defined(_WIN32)
     return realloc(ptr, newsize);
 #else
-    return _aligned_realloc(ptr, newsize, sizeof(void *) * (newsize > PAGE_SIZE ? 8 : 1));
+    return _aligned_realloc(ptr, newsize, alignment);
 #endif
 }
 

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -41,7 +41,7 @@ static void *s_default_malloc(struct aws_allocator *allocator, size_t size) {
     const size_t alignment = sizeof(void *) * (size > PAGE_SIZE ? 8 : 1);
 #if !defined(_WIN32)
     void *result = NULL;
-    return (posix_memalign(&result, alignment)) ? NULL : result;
+    return (posix_memalign(&result, alignment, size)) ? NULL : result;
 #else
     return _aligned_malloc(size, alignment));
 #endif

--- a/source/allocator.c
+++ b/source/allocator.c
@@ -43,7 +43,7 @@ static void *s_default_malloc(struct aws_allocator *allocator, size_t size) {
     void *result = NULL;
     return (posix_memalign(&result, alignment, size)) ? NULL : result;
 #else
-    return _aligned_malloc(size, alignment));
+    return _aligned_malloc(size, alignment);
 #endif
 }
 

--- a/source/memtrace.c
+++ b/source/memtrace.c
@@ -224,7 +224,7 @@ static int s_collect_stack_trace(void *context, struct aws_hash_element *item) {
         struct aws_byte_cursor cursor = aws_byte_cursor_from_c_str(caller);
         aws_byte_buf_append(&stacktrace, &cursor);
     }
-    free(symbols);
+    aws_mem_release(aws_default_allocator(), symbols);
     /* record the resultant buffer as a string */
     stack_info->trace = aws_string_new_from_array(aws_default_allocator(), stacktrace.buffer, stacktrace.len);
     AWS_FATAL_ASSERT(stack_info->trace);

--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -223,7 +223,7 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
         fprintf(fp, "%s\n", symbol);
     }
     fflush(fp);
-    free(symbols);
+    aws_mem_release(aws_default_allocator(), symbols);
 }
 
 void aws_backtrace_log() {
@@ -239,5 +239,5 @@ void aws_backtrace_log() {
         const char *symbol = symbols[line];
         AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "%s", symbol);
     }
-    free(symbols);
+    aws_mem_release(aws_default_allocator(), symbols);
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
