### PR TITLE
Fixing Clang Tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*,-readability-magic-numbers,-readability-non-const-parameter,-readability-avoid-const-params-in-decls,-readability-else-after-return,-readability-isolate-declaration,-readability-uppercase-literal-suffix'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*,-readability-magic-numbers,-readability-non-const-parameter,-readability-avoid-const-params-in-decls,-readability-else-after-return,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-bugprone-sizeof-expression'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*\.[h|inl]$'
 FormatStyle: 'file'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,8 +6,6 @@ jobs:
   clang-tidy-ubuntu-16-04:
 
     runs-on: ubuntu-16.04
-    - ubuntu-18.04
-    - ubuntu-20.04
 
     steps:
     - name: Checkout Sources

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,12 +3,39 @@ name: Lint
 on: [push]
 
 jobs:
-  clang-tidy:
+  clang-tidy-ubuntu-16-04:
 
-    runs-on:
-    - ubuntu-16.04
+    runs-on: ubuntu-16.04
     - ubuntu-18.04
     - ubuntu-20.04
+
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v1
+
+    - name: clang-tidy lint
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('https://d19elf31gohf1l.cloudfront.net/LATEST/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder clang-tidy --project=aws-c-common
+
+  clang-tidy-ubuntu-18-04:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout Sources
+      uses: actions/checkout@v1
+
+    - name: clang-tidy lint
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('https://d19elf31gohf1l.cloudfront.net/LATEST/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder clang-tidy --project=aws-c-common
+
+  clang-tidy-ubuntu-20-04:
+
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout Sources

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        host: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        host: [ubuntu-20.04]
 
     runs-on: ${{ matrix.host }}
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [push]
 
 jobs:
-  clang-tidy-ubuntu-16-04:
+  clang-tidy-ubuntu-16.04:
 
     runs-on: ubuntu-16.04
 
@@ -17,7 +17,7 @@ jobs:
         chmod a+x builder
         ./builder clang-tidy --project=aws-c-common
 
-  clang-tidy-ubuntu-18-04:
+  clang-tidy-ubuntu-18.04:
 
     runs-on: ubuntu-18.04
 
@@ -31,7 +31,7 @@ jobs:
         chmod a+x builder
         ./builder clang-tidy --project=aws-c-common
 
-  clang-tidy-ubuntu-20-04:
+  clang-tidy-ubuntu-20.04:
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,37 +3,13 @@ name: Lint
 on: [push]
 
 jobs:
-  clang-tidy-ubuntu-16.04:
+  clang-tidy:
 
-    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        host: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
 
-    steps:
-    - name: Checkout Sources
-      uses: actions/checkout@v1
-
-    - name: clang-tidy lint
-      run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('https://d19elf31gohf1l.cloudfront.net/LATEST/builder.pyz?run=${{ env.RUN }}', 'builder')"
-        chmod a+x builder
-        ./builder clang-tidy --project=aws-c-common
-
-  clang-tidy-ubuntu-18.04:
-
-    runs-on: ubuntu-18.04
-
-    steps:
-    - name: Checkout Sources
-      uses: actions/checkout@v1
-
-    - name: clang-tidy lint
-      run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('https://d19elf31gohf1l.cloudfront.net/LATEST/builder.pyz?run=${{ env.RUN }}', 'builder')"
-        chmod a+x builder
-        ./builder clang-tidy --project=aws-c-common
-
-  clang-tidy-ubuntu-20.04:
-
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.host }}
 
     steps:
     - name: Checkout Sources

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -5,7 +5,10 @@ on: [push]
 jobs:
   clang-tidy:
 
-    runs-on: ubuntu-latest
+    runs-on:
+    - ubuntu-16.04
+    - ubuntu-18.04
+    - ubuntu-20.04
 
     steps:
     - name: Checkout Sources

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -1611,15 +1611,10 @@ bool aws_isxdigit(uint8_t ch) {
 bool aws_isspace(uint8_t ch) {
     switch (ch) {
         case 0x20: /* ' ' - space */
-            return true;
         case 0x09: /* '\t' - horizontal tab */
-            return true;
         case 0x0A: /* '\n' - line feed */
-            return true;
         case 0x0B: /* '\v' - vertical tab */
-            return true;
         case 0x0C: /* '\f' - form feed */
-            return true;
         case 0x0D: /* '\r' - carriage return */
             return true;
         default:

--- a/source/command_line_parser.c
+++ b/source/command_line_parser.c
@@ -85,7 +85,7 @@ int aws_cli_getopt_long(
     if (option) {
         bool has_arg = false;
 
-        char *opt_value = memchr(optstring, option->val, strlen(optstring));
+        char *opt_value = memchr(optstring, option->val, strlen(optstring) + 1);
         if (!opt_value) {
             return '?';
         }

--- a/source/date_time.c
+++ b/source/date_time.c
@@ -22,8 +22,8 @@ static const char *ISO_8601_LONG_BASIC_DATE_FORMAT_STR = "%Y%m%dT%H%M%SZ";
 static const char *ISO_8601_SHORT_BASIC_DATE_FORMAT_STR = "%Y%m%d";
 
 #define STR_TRIPLET_TO_INDEX(str)                                                                                      \
-    (((uint32_t)(uint8_t)tolower((str)[0]) << 0) | ((uint32_t)(uint8_t)tolower((str)[1]) << 8) |                       \
-     ((uint32_t)(uint8_t)tolower((str)[2]) << 16))
+    (((uint32_t)(uint8_t)tolower((uint8_t)((str)[0]) << 0)) | ((uint32_t)(uint8_t)tolower((uint8_t)((str)[1]) << 8)) | \
+     ((uint32_t)(uint8_t)tolower((uint8_t)((str)[2]) << 16)))
 
 static uint32_t s_jan = 0;
 static uint32_t s_feb = 0;
@@ -140,7 +140,7 @@ static bool is_utc_time_zone(const char *str) {
         }
 
         if (len == 2) {
-            return tolower(str[0]) == 'u' && tolower(str[1]) == 't';
+            return tolower((uint8_t)str[0]) == 'u' && tolower((uint8_t)str[1]) == 't';
         }
 
         if (len < 3) {


### PR DESCRIPTION
*Description of changes:*
* Changing clang tidy github script to check 20.04 explicitly.
* Applying fixes from ThreadJoin branch for clang-tidy on newer version of Ubuntu.
* Adding check to clang-tidy also found in ThreadJoin branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
