### PR TITLE
fix shared libs

### DIFF
--- a/include/aws/common/private/thread_shared.h
+++ b/include/aws/common/private/thread_shared.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/common/common.h>
+#include <aws/common/thread.h>
 
 struct aws_linked_list;
 struct aws_linked_list_node;


### PR DESCRIPTION
`aws_thread_set_managed_join_timeout_ns()` and `aws_thread_join_all_managed()` are declared in `thread.h` and implemented in `thread_shared.c`. But since `thread_shared.c` did not include `thread.h`, it was not seen as the implementation by the linker.

😡😡😡😡😡😡😡😡😡😡😡😡😡😡😡

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
