### PR TITLE
Mark s_get_executable_path as static, fixes #729

### DIFF
--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -193,7 +193,7 @@ char *s_whitelist_chars(char *path) {
 #        include <dlfcn.h>
 #        include <mach-o/dyld.h>
 static char s_exe_path[PATH_MAX];
-const char *s_get_executable_path() {
+const static char *s_get_executable_path() {
     static const char *s_exe = NULL;
     if (AWS_LIKELY(s_exe)) {
         return s_exe;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
