### PR TITLE
Add a success/fail return value to aws_thread_managed_join_all

### DIFF
--- a/include/aws/common/thread.h
+++ b/include/aws/common/thread.h
@@ -154,7 +154,7 @@ int aws_thread_join(struct aws_thread *thread);
  * By default the wait is unbounded, but that default can be overridden via aws_thread_set_managed_join_timeout_ns()
  */
 AWS_COMMON_API
-void aws_thread_join_all_managed(void);
+int aws_thread_join_all_managed(void);
 
 /**
  * Overrides how long, in nanoseconds, that aws_thread_join_all_managed will wait for threads to complete.


### PR DESCRIPTION



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
