### PR TITLE
Updates readable and writable macros

### DIFF
--- a/include/aws/common/assert.h
+++ b/include/aws/common/assert.h
@@ -86,8 +86,8 @@ AWS_EXTERN_C_END
 #    define AWS_POSTCONDITION1(cond) __CPROVER_assert((cond), #    cond " check failed")
 #    define AWS_FATAL_POSTCONDITION2(cond, explanation) __CPROVER_assert((cond), (explanation))
 #    define AWS_FATAL_POSTCONDITION1(cond) __CPROVER_assert((cond), #    cond " check failed")
-#    define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (__CPROVER_r_ok((base), (len))))
-#    define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (__CPROVER_r_ok((base), (len))))
+#    define AWS_MEM_IS_READABLE_CHECK(base, len) (((len) == 0) || (__CPROVER_r_ok((base), (len))))
+#    define AWS_MEM_IS_WRITABLE_CHECK(base, len) (((len) == 0) || (__CPROVER_r_ok((base), (len))))
 #else
 #    define AWS_PRECONDITION2(cond, expl) AWS_ASSERT(cond)
 #    define AWS_PRECONDITION1(cond) AWS_ASSERT(cond)
@@ -98,11 +98,21 @@ AWS_EXTERN_C_END
 #    define AWS_FATAL_POSTCONDITION2(cond, expl) AWS_FATAL_ASSERT(cond)
 #    define AWS_FATAL_POSTCONDITION1(cond) AWS_FATAL_ASSERT(cond)
 /**
+ * These macros should not be used in is_valid functions.
+ * All validate functions are also used in assumptions for CBMC proofs,
+ * which should not contain __CPROVER_*_ok primitives. The use of these primitives
+ * in assumptions may lead to spurious results.
  * The C runtime does not give a way to check these properties,
  * but we can at least check that the pointer is valid. */
-#    define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
-#    define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
+#    define AWS_MEM_IS_READABLE_CHECK(base, len) (((len) == 0) || (base))
+#    define AWS_MEM_IS_WRITABLE_CHECK(base, len) (((len) == 0) || (base))
 #endif /* CBMC */
+
+/**
+ * These macros can safely be used in validate functions.
+ */
+#define AWS_MEM_IS_READABLE(base, len) (((len) == 0) || (base))
+#define AWS_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base))
 
 /* Logical consequence. */
 #define AWS_IMPLIES(a, b) (!(a) || (b))


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
The current implementation of these macros (using `__CPROVER_*_ok`) should not be used in `*_is_valid` functions.
All validity functions are also used in assumptions for CBMC proofs, which should not contain `__CPROVER_*_ok` primitives. The use of these primitives in assumptions may lead to spurious results.
They can safely be used in assertions or if-statement conditions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
