### PR TITLE
Fixing Thread Affinity CMake

### DIFF
--- a/cmake/AwsThreadAffinity.cmake
+++ b/cmake/AwsThreadAffinity.cmake
@@ -14,13 +14,17 @@ function(aws_set_thread_affinity_method target)
         return()
     endif()
 
-    set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES pthread)
 
     set(headers "pthread.h")
     # BSDs put nonportable pthread declarations in a separate header.
     if(CMAKE_SYSTEM_NAME MATCHES BSD)
         set(headers "${headers};pthread_np.h")
     endif()
+
+    # Reset variable so that check_symbol_exists doesn't early out.
+    unset(USE_PTHREAD_ATTR_SETAFFINITY CACHE)
 
     # Using pthread attrs is the preferred method, but is glibc-specific.
     check_symbol_exists(pthread_attr_setaffinity_np "${headers}" USE_PTHREAD_ATTR_SETAFFINITY)
@@ -29,6 +33,9 @@ function(aws_set_thread_affinity_method target)
             -DAWS_AFFINITY_METHOD=AWS_AFFINITY_METHOD_PTHREAD_ATTR)
         return()
     endif()
+
+    # Reset varaible so that check_symbol_exists doesn't early out.
+    unset(USE_PTHREAD_SETAFFINITY CACHE)
 
     # This method is still nonportable, but is supported by musl and BSDs.
     check_symbol_exists(pthread_setaffinity_np "${headers}" USE_PTHREAD_SETAFFINITY)

--- a/cmake/AwsThreadAffinity.cmake
+++ b/cmake/AwsThreadAffinity.cmake
@@ -34,7 +34,7 @@ function(aws_set_thread_affinity_method target)
         return()
     endif()
 
-    # Reset varaible so that check_symbol_exists doesn't early out.
+    # Reset variable so that check_symbol_exists doesn't early out.
     unset(USE_PTHREAD_SETAFFINITY CACHE)
 
     # This method is still nonportable, but is supported by musl and BSDs.

--- a/cmake/AwsThreadAffinity.cmake
+++ b/cmake/AwsThreadAffinity.cmake
@@ -23,9 +23,6 @@ function(aws_set_thread_affinity_method target)
         set(headers "${headers};pthread_np.h")
     endif()
 
-    # Reset variable so that check_symbol_exists doesn't early out.
-    unset(USE_PTHREAD_ATTR_SETAFFINITY CACHE)
-
     # Using pthread attrs is the preferred method, but is glibc-specific.
     check_symbol_exists(pthread_attr_setaffinity_np "${headers}" USE_PTHREAD_ATTR_SETAFFINITY)
     if (USE_PTHREAD_ATTR_SETAFFINITY)
@@ -33,9 +30,6 @@ function(aws_set_thread_affinity_method target)
             -DAWS_AFFINITY_METHOD=AWS_AFFINITY_METHOD_PTHREAD_ATTR)
         return()
     endif()
-
-    # Reset variable so that check_symbol_exists doesn't early out.
-    unset(USE_PTHREAD_SETAFFINITY CACHE)
 
     # This method is still nonportable, but is supported by musl and BSDs.
     check_symbol_exists(pthread_setaffinity_np "${headers}" USE_PTHREAD_SETAFFINITY)


### PR DESCRIPTION
*Description of changes:*
Thread Affinity check needs pthread library.

Note: we could probably use set for both, but list seemed more correct/consistent. (Changing the "set" to "list" for CMAKE_REQUIRED_DEFINITIONS is not strictly necessary for fixing the bug.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
