### PR TITLE
Disable warning on test

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -15,7 +15,7 @@ option(AWS_SUPPORT_WIN7 "Restricts WINAPI calls to Win7 and older (This will hav
 #  NO_WEXTRA: Disable -Wextra
 #  NO_PEDANTIC: Disable -pedantic
 function(aws_set_common_properties target)
-    set(options NO_WGNU NO_WEXTRA NO_PEDANTIC NO_LTO)
+    set(options NO_WGNU NO_WEXTRA NO_PEDANTIC NO_LTO NO_STRINGOP_OVERFLOW)
     cmake_parse_arguments(SET_PROPERTIES "${options}" "" "" ${ARGN})
 
     if(MSVC)
@@ -71,6 +71,10 @@ function(aws_set_common_properties target)
 
         if (LEGACY_COMPILER_SUPPORT)
             list(APPEND AWS_C_FLAGS -Wno-strict-aliasing)
+        endif()
+
+        if (SET_PROPERTIES_NO_STRINGOP_OVERFLOW)
+            list(APPEND AWS_C_FLAGS -Wno-error=stringop-overflow)
         endif()
 
        # -moutline-atomics generates code for both older load/store exclusive atomics and also

--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -15,7 +15,7 @@ option(AWS_SUPPORT_WIN7 "Restricts WINAPI calls to Win7 and older (This will hav
 #  NO_WEXTRA: Disable -Wextra
 #  NO_PEDANTIC: Disable -pedantic
 function(aws_set_common_properties target)
-    set(options NO_WGNU NO_WEXTRA NO_PEDANTIC NO_LTO NO_STRINGOP_OVERFLOW)
+    set(options NO_WGNU NO_WEXTRA NO_PEDANTIC NO_LTO)
     cmake_parse_arguments(SET_PROPERTIES "${options}" "" "" ${ARGN})
 
     if(MSVC)
@@ -71,10 +71,6 @@ function(aws_set_common_properties target)
 
         if (LEGACY_COMPILER_SUPPORT)
             list(APPEND AWS_C_FLAGS -Wno-strict-aliasing)
-        endif()
-
-        if (SET_PROPERTIES_NO_STRINGOP_OVERFLOW)
-            list(APPEND AWS_C_FLAGS -Wno-error=stringop-overflow)
         endif()
 
        # -moutline-atomics generates code for both older load/store exclusive atomics and also

--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -82,7 +82,7 @@ if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
 endif()
 
 if (NOT MSVC)
-    set(CMAKE_REQUIRED_FLAGS "-Wno-error=stringop-overflow")
+    set(CMAKE_REQUIRED_FLAGS "-Werror -Wno-error=stringop-overflow")
     check_c_source_compiles("
     int main() {
         return 0;

--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -80,3 +80,12 @@ if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
         return 0;
     }" AWS_HAVE_EXECINFO)
 endif()
+
+if (NOT MSVC)
+    set(CMAKE_REQUIRED_FLAGS "-Wno-error=stringop-overflow")
+    check_c_source_compiles("
+    int main() {
+        return 0;
+    }" AWS_SHOULD_DISABLE_STRINGOP_OVERFLOW)
+    unset(CMAKE_REQUIRED_FLAGS)
+endif()

--- a/cmake/AwsTestHarness.cmake
+++ b/cmake/AwsTestHarness.cmake
@@ -33,7 +33,8 @@ function(generate_test_driver driver_exe_name)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/.clang-tidy" "Checks: '-*,misc-static-assert'")
 
     add_executable(${driver_exe_name} ${CMAKE_CURRENT_BINARY_DIR}/test_runner.c ${TESTS})
-    aws_set_common_properties(${driver_exe_name} NO_WEXTRA NO_PEDANTIC)
+    aws_set_common_properties(${driver_exe_name} NO_WEXTRA NO_PEDANTIC NO_STRINGOP_OVERFLOW)
+
     aws_add_sanitizers(${driver_exe_name} ${${PROJECT_NAME}_SANITIZERS})
 
     target_link_libraries(${driver_exe_name} PRIVATE ${PROJECT_NAME})

--- a/cmake/AwsTestHarness.cmake
+++ b/cmake/AwsTestHarness.cmake
@@ -33,7 +33,11 @@ function(generate_test_driver driver_exe_name)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/.clang-tidy" "Checks: '-*,misc-static-assert'")
 
     add_executable(${driver_exe_name} ${CMAKE_CURRENT_BINARY_DIR}/test_runner.c ${TESTS})
-    aws_set_common_properties(${driver_exe_name} NO_WEXTRA NO_PEDANTIC NO_STRINGOP_OVERFLOW)
+    aws_set_common_properties(${driver_exe_name} NO_WEXTRA NO_PEDANTIC)
+
+    if (NOT MSVC AND AWS_SHOULD_DISABLE_STRINGOP_OVERFLOW)
+        SET_SOURCE_FILES_PROPERTIES(test_runner.c PROPERTIES COMPILE_FLAGS -Wno-error=stringop-overflow)
+    endif()
 
     aws_add_sanitizers(${driver_exe_name} ${${PROJECT_NAME}_SANITIZERS})
 


### PR DESCRIPTION
* The stringop-overflow warning is showing up if an older version of cmake is used against a more modern version of gcc, resulting in a build error in code that we don't have control over.  Disable the stringop-overflow warning if it's known by the compiler and only for the generated file test_runner.c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
