### PR TITLE
Prevent log-subject ordering errors

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -253,8 +253,8 @@ static struct aws_log_subject_info s_common_log_subject_infos[] = {
         "task-scheduler",
         "Subject for task scheduler or task specific logging."),
     DEFINE_LOG_SUBJECT_INFO(AWS_LS_COMMON_THREAD, "thread", "Subject for logging thread related functions."),
-    DEFINE_LOG_SUBJECT_INFO(AWS_LS_COMMON_XML_PARSER, "xml-parser", "Subject for xml parser specific logging."),
     DEFINE_LOG_SUBJECT_INFO(AWS_LS_COMMON_MEMTRACE, "memtrace", "Output from the aws_mem_trace_dump function"),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_COMMON_XML_PARSER, "xml-parser", "Subject for xml parser specific logging."),
 };
 
 static struct aws_log_subject_info_list s_common_log_subject_list = {

--- a/source/logging.c
+++ b/source/logging.c
@@ -381,6 +381,17 @@ void aws_register_log_subject_info_list(struct aws_log_subject_info_list *log_su
     const uint32_t min_range = log_subject_list->subject_list[0].subject_id;
     const uint32_t slot_index = min_range >> AWS_LOG_SUBJECT_STRIDE_BITS;
 
+#if DEBUG_BUILD
+    for (uint32_t i = 0; i < log_subject_list->count; ++i) {
+        const struct aws_log_subject_info *info = &log_subject_list->subject_list[i];
+        uint32_t expected_id = min_range + i;
+        if (expected_id != info->subject_id) {
+            fprintf(stderr, "\"%s\" is at wrong index in aws_log_subject_info[]\n", info->subject_name);
+            AWS_FATAL_ASSERT(0);
+        }
+    }
+#endif /* DEBUG_BUILD */
+
     if (slot_index >= AWS_PACKAGE_SLOTS) {
         /* This is an NDEBUG build apparently. Kill the process rather than
          * corrupting heap. */


### PR DESCRIPTION
aws-c-common's log subjects were out of order, so memtracer logged as "xml-parser".

Fix this, and prevent order from ever getting screwed up anywhere ever again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
