### PR TITLE
Diagnostics fixes/improvements

### DIFF
--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -75,9 +75,13 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #    endif     /*  defined(__GNUC__) || defined(__clang__) */
 #endif         /*  defined(_MSC_VER) */
 
-#if defined(__has_feature) && __has_feature(address_sanitizer)
-#    define AWS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
-#else
+#if defined(__has_feature)
+#    if __has_feature(address_sanitizer)
+#        define AWS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
+#    endif
+#endif
+
+#if !defined(AWS_SUPPRESS_ASAN)
 #    define AWS_SUPPRESS_ASAN
 #endif
 

--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -75,6 +75,12 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #    endif     /*  defined(__GNUC__) || defined(__clang__) */
 #endif         /*  defined(_MSC_VER) */
 
+#if defined(__has_feature) && __has_feature(address_sanitizer)
+#    define AWS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
+#else
+#define AWS_SUPPRESS_ASAN
+#endif
+
 /* If this is C++, restrict isn't supported. If this is not at least C99 on gcc and clang, it isn't supported.
  * If visual C++ building in C mode, the restrict definition is __restrict.
  * This just figures all of that out based on who's including this header file. */

--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -78,7 +78,7 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #if defined(__has_feature) && __has_feature(address_sanitizer)
 #    define AWS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
 #else
-#define AWS_SUPPRESS_ASAN
+#    define AWS_SUPPRESS_ASAN
 #endif
 
 /* If this is C++, restrict isn't supported. If this is not at least C99 on gcc and clang, it isn't supported.

--- a/include/aws/common/private/lookup3.inl
+++ b/include/aws/common/private/lookup3.inl
@@ -1,5 +1,8 @@
 #ifndef AWS_COMMON_PRIVATE_LOOKUP3_INL
 #define AWS_COMMON_PRIVATE_LOOKUP3_INL
+
+#include <aws/common/macros.h>
+
 /* clang-format off */
 
 /*
@@ -498,6 +501,7 @@ static void hashlittle2(
   size_t      length,    /* length of the key */
   uint32_t   *pc,        /* IN: primary initval, OUT: primary hash */
   uint32_t   *pb)        /* IN: secondary initval, OUT: secondary hash */
+  AWS_SUPPRESS_ASAN      /* AddressSanitizer hates this implementation, even though it's innocuous */
 {
   uint32_t a,b,c;                                          /* internal state */
   union { const void *ptr; size_t i; } u;     /* needed for Mac Powerbook G4 */

--- a/include/aws/common/system_info.h
+++ b/include/aws/common/system_info.h
@@ -98,7 +98,7 @@ void aws_backtrace_print(FILE *fp, void *call_site_data);
 
 /* Log the callstack from the current stack to the currently configured aws_logger */
 AWS_COMMON_API
-void aws_backtrace_log(void);
+void aws_backtrace_log(int log_level);
 
 AWS_EXTERN_C_END
 

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -381,43 +381,7 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
     }
 
     fprintf(fp, "################################################################################\n");
-    fprintf(fp, "Resolved stacktrace:\n");
-    fprintf(fp, "################################################################################\n");
-    /* symbols look like: <exe-or-shared-lib>(<function>+<addr>) [0x<addr>]
-     *                or: <exe-or-shared-lib> [0x<addr>]
-     *                or: [0x<addr>]
-     * start at 1 to skip the current frame (this function) */
-    for (size_t frame_idx = 1; frame_idx < stack_depth; ++frame_idx) {
-        struct aws_stack_frame_info frame;
-        AWS_ZERO_STRUCT(frame);
-        const char *symbol = symbols[frame_idx];
-        if (s_parse_symbol(symbol, stack_frames[frame_idx], &frame)) {
-            goto parse_failed;
-        }
-
-        /* TODO: Emulate libunwind */
-        char cmd[sizeof(struct aws_stack_frame_info)] = {0};
-        s_resolve_cmd(cmd, sizeof(cmd), &frame);
-        FILE *out = popen(cmd, "r");
-        if (!out) {
-            goto parse_failed;
-        }
-        char output[1024];
-        if (fgets(output, sizeof(output), out)) {
-            /* if addr2line or atos don't know what to do with an address, they just echo it */
-            /* if there are spaces in the output, then they resolved something */
-            if (strstr(output, " ")) {
-                symbol = output;
-            }
-        }
-        pclose(out);
-
-    parse_failed:
-        fprintf(fp, "%s%s", symbol, (symbol == symbols[frame_idx]) ? "\n" : "");
-    }
-
-    fprintf(fp, "################################################################################\n");
-    fprintf(fp, "Raw stacktrace:\n");
+    fprintf(fp, "Stack trace:\n");
     fprintf(fp, "################################################################################\n");
     for (size_t frame_idx = 1; frame_idx < stack_depth; ++frame_idx) {
         const char *symbol = symbols[frame_idx];
@@ -453,16 +417,17 @@ char **aws_backtrace_addr2line(void *const *stack_frames, size_t stack_depth) {
 }
 #endif /* AWS_HAVE_EXECINFO */
 
-void aws_backtrace_log() {
-    void *stack_frames[1024];
-    size_t num_frames = aws_backtrace(stack_frames, 1024);
+void aws_backtrace_log(int log_level) {
+    void *stack_frames[AWS_BACKTRACE_DEPTH];
+    size_t num_frames = aws_backtrace(stack_frames, AWS_BACKTRACE_DEPTH);
     if (!num_frames) {
+        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "Unable to capture backtrace");
         return;
     }
-    char **symbols = aws_backtrace_addr2line(stack_frames, num_frames);
+    char **symbols = aws_backtrace_symbols(stack_frames, num_frames);
     for (size_t line = 0; line < num_frames; ++line) {
         const char *symbol = symbols[line];
-        AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "%s", symbol);
+        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "%s", symbol);
     }
     free(symbols);
 }

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -392,6 +392,21 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
     free(symbols);
 }
 
+void aws_backtrace_log(int log_level) {
+    void *stack_frames[AWS_BACKTRACE_DEPTH];
+    size_t num_frames = aws_backtrace(stack_frames, AWS_BACKTRACE_DEPTH);
+    if (!num_frames) {
+        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "Unable to capture backtrace");
+        return;
+    }
+    char **symbols = aws_backtrace_symbols(stack_frames, num_frames);
+    for (size_t line = 0; line < num_frames; ++line) {
+        const char *symbol = symbols[line];
+        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "%s", symbol);
+    }
+    free(symbols);
+}
+
 #else
 void aws_backtrace_print(FILE *fp, void *call_site_data) {
     (void)call_site_data;
@@ -415,22 +430,11 @@ char **aws_backtrace_addr2line(void *const *stack_frames, size_t stack_depth) {
     (void)stack_depth;
     return NULL;
 }
-#endif /* AWS_HAVE_EXECINFO */
 
 void aws_backtrace_log(int log_level) {
-    void *stack_frames[AWS_BACKTRACE_DEPTH];
-    size_t num_frames = aws_backtrace(stack_frames, AWS_BACKTRACE_DEPTH);
-    if (!num_frames) {
-        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "Unable to capture backtrace");
-        return;
-    }
-    char **symbols = aws_backtrace_symbols(stack_frames, num_frames);
-    for (size_t line = 0; line < num_frames; ++line) {
-        const char *symbol = symbols[line];
-        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "%s", symbol);
-    }
-    free(symbols);
+    AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "aws_backtrace_log: no execinfo compatible backtrace API available");
 }
+#endif /* AWS_HAVE_EXECINFO */
 
 #if defined(AWS_OS_APPLE)
 enum aws_platform_os aws_get_platform_build_os(void) {

--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -257,7 +257,7 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
     aws_mem_release(aws_default_allocator(), symbols);
 }
 
-void aws_backtrace_log() {
+void aws_backtrace_log(int log_level) {
     if (!s_init_dbghelp()) {
         AWS_LOGF_ERROR(AWS_LS_COMMON_GENERAL, "Unable to initialize dbghelp.dll for backtrace");
         return;
@@ -268,7 +268,7 @@ void aws_backtrace_log() {
     char **symbols = aws_backtrace_symbols(stack, num_frames);
     for (size_t line = 0; line < num_frames; ++line) {
         const char *symbol = symbols[line];
-        AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "%s", symbol);
+        AWS_LOGF(log_level, AWS_LS_COMMON_GENERAL, "%s", symbol);
     }
     aws_mem_release(aws_default_allocator(), symbols);
 }

--- a/tests/system_info_tests.c
+++ b/tests/system_info_tests.c
@@ -37,8 +37,8 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
     test_logger_init(&test_log, allocator, AWS_LL_TRACE, 0);
     aws_logger_set(&test_log);
 
-    int line = 0;                           /* captured on line of aws_backtrace_log call to match call site */
-    (void)line;                             /* may not be used if debug info is unavailable */
+    int line = 0; /* captured on line of aws_backtrace_log call to match call site */
+    (void)line;   /* may not be used if debug info is unavailable */
     aws_backtrace_log(AWS_LL_TRACE), (line = __LINE__); /* NOLINT */
 
     struct test_logger_impl *log = test_log.p_impl;
@@ -70,9 +70,9 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
      * verify if a best effort was made */
     if (strstr((const char *)buffer->buffer, file)) {
         /* check for the call site of aws_backtrace_print. Note that line numbers are off by one
-        * in both directions depending on compiler, so we check a range around the call site __LINE__
-        * The line number can also be ? on old compilers
-        */
+         * in both directions depending on compiler, so we check a range around the call site __LINE__
+         * The line number can also be ? on old compilers
+         */
         char fileline[4096];
         uint32_t found_file_line = 0;
         for (int lineno = line - 1; lineno <= line + 1; ++lineno) {

--- a/tests/system_info_tests.c
+++ b/tests/system_info_tests.c
@@ -61,11 +61,10 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
     aws_byte_buf_append_dynamic(buffer, &null_term);
     fprintf(stderr, "%s", (const char *)buffer->buffer);
     const char *func = __func__;
-    if (func[0] == 's') {
+    if (func[0] == 's' && func[1] == '_') {
         func += 2; /* skip over s_ */
     }
     ASSERT_NOT_NULL(strstr((const char *)buffer->buffer, func));
-#    if !defined(__APPLE__) /* apple doesn't always find file info */
     /* if this is not a debug build, there may not be symbols, so the test cannot
      * verify if a best effort was made */
     if (strstr((const char *)buffer->buffer, file)) {
@@ -77,7 +76,7 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
         uint32_t found_file_line = 0;
         for (int lineno = line - 1; lineno <= line + 1; ++lineno) {
             snprintf(fileline, sizeof(fileline), "%s:%d", file, lineno);
-            found_file_line |= strstr((const char *)buffer->buffer, fileline) != NULL;
+            found_file_line = strstr((const char *)buffer->buffer, fileline) != NULL;
             if (found_file_line) {
                 break;
             }
@@ -89,7 +88,6 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
 
         ASSERT_TRUE(found_file_line);
     }
-#    endif /* __APPLE__ */
 #endif
 
     aws_logger_clean_up(&test_log);

--- a/tests/system_info_tests.c
+++ b/tests/system_info_tests.c
@@ -39,7 +39,7 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
 
     int line = 0;                           /* captured on line of aws_backtrace_log call to match call site */
     (void)line;                             /* may not be used if debug info is unavailable */
-    aws_backtrace_log(), (line = __LINE__); /* NOLINT */
+    aws_backtrace_log(AWS_LL_TRACE), (line = __LINE__); /* NOLINT */
 
     struct test_logger_impl *log = test_log.p_impl;
     ASSERT_NOT_NULL(log);
@@ -59,30 +59,36 @@ static int s_test_stack_trace_decoding(struct aws_allocator *allocator, void *ct
 
     struct aws_byte_cursor null_term = aws_byte_cursor_from_array("", 1);
     aws_byte_buf_append_dynamic(buffer, &null_term);
-    ASSERT_NOT_NULL(strstr((const char *)buffer->buffer, __func__));
+    fprintf(stderr, "%s", (const char *)buffer->buffer);
+    const char *func = __func__;
+    if (func[0] == 's') {
+        func += 2; /* skip over s_ */
+    }
+    ASSERT_NOT_NULL(strstr((const char *)buffer->buffer, func));
 #    if !defined(__APPLE__) /* apple doesn't always find file info */
     /* if this is not a debug build, there may not be symbols, so the test cannot
      * verify if a best effort was made */
-    ASSERT_NOT_NULL(strstr((const char *)buffer->buffer, file));
-    /* check for the call site of aws_backtrace_print. Note that line numbers are off by one
-     * in both directions depending on compiler, so we check a range around the call site __LINE__
-     * The line number can also be ? on old compilers
-     */
-    char fileline[4096];
-    uint32_t found_file_line = 0;
-    for (int lineno = line - 1; lineno <= line + 1; ++lineno) {
-        snprintf(fileline, sizeof(fileline), "%s:%d", file, lineno);
-        found_file_line |= strstr((const char *)buffer->buffer, fileline) != NULL;
-        if (found_file_line) {
-            break;
+    if (strstr((const char *)buffer->buffer, file)) {
+        /* check for the call site of aws_backtrace_print. Note that line numbers are off by one
+        * in both directions depending on compiler, so we check a range around the call site __LINE__
+        * The line number can also be ? on old compilers
+        */
+        char fileline[4096];
+        uint32_t found_file_line = 0;
+        for (int lineno = line - 1; lineno <= line + 1; ++lineno) {
+            snprintf(fileline, sizeof(fileline), "%s:%d", file, lineno);
+            found_file_line |= strstr((const char *)buffer->buffer, fileline) != NULL;
+            if (found_file_line) {
+                break;
+            }
         }
-    }
-    if (!found_file_line) {
-        snprintf(fileline, sizeof(fileline), "%s:?", file);
-        found_file_line = strstr((const char *)buffer->buffer, fileline) != NULL;
-    }
+        if (!found_file_line) {
+            snprintf(fileline, sizeof(fileline), "%s:?", file);
+            found_file_line = strstr((const char *)buffer->buffer, fileline) != NULL;
+        }
 
-    ASSERT_TRUE(found_file_line);
+        ASSERT_TRUE(found_file_line);
+    }
 #    endif /* __APPLE__ */
 #endif
 


### PR DESCRIPTION
* aws_backtrace_log now takes a log level instead of forcing TRACE
* aws_backtrace_print no longer forces the use of addr2line or atos which produces crap output most of the time
* test_stack_trace_decoding is now more permissive for linkers that do weird things to symbols/debug info

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
