### PR TITLE
Marking aws-c-common/source/posix/system_info.c as a non parameters function

### DIFF
--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -193,7 +193,7 @@ char *s_whitelist_chars(char *path) {
 #        include <dlfcn.h>
 #        include <mach-o/dyld.h>
 static char s_exe_path[PATH_MAX];
-static const char *s_get_executable_path() {
+static const char *s_get_executable_path(void) {
     static const char *s_exe = NULL;
     if (AWS_LIKELY(s_exe)) {
         return s_exe;


### PR DESCRIPTION
*Issue #, if available:*
No issue available, this fails C++ SDK built with -Wstrict-prototypes

*Description of changes:*
Making zero-parameters explicit for const char *s_get_executable_path() function.

```
const char *s_get_executable_path()  >>> const char *s_get_executable_path(void)
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
