### PR TITLE
Avoid null-pointer arithmetic

### DIFF
--- a/include/aws/common/ring_buffer.inl
+++ b/include/aws/common/ring_buffer.inl
@@ -14,7 +14,7 @@ AWS_EXTERN_C_BEGIN
 AWS_STATIC_IMPL bool aws_ring_buffer_check_atomic_ptr(
     const struct aws_ring_buffer *ring_buf,
     const uint8_t *atomic_ptr) {
-    return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
+    return ((atomic_ptr != NULL) && (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end));
 }
 
 /**

--- a/include/aws/common/ring_buffer.inl
+++ b/include/aws/common/ring_buffer.inl
@@ -8,24 +8,13 @@
 #include <aws/common/ring_buffer.h>
 
 AWS_EXTERN_C_BEGIN
-
-static bool s_check_null_ring_buffer(const struct aws_ring_buffer *ring_buf) {
-    return !ring_buf->allocation && !ring_buf->allocation_end;
-}
-
 /*
  * Checks whether atomic_ptr correctly points to a memory location within the bounds of the aws_ring_buffer
  */
 AWS_STATIC_IMPL bool aws_ring_buffer_check_atomic_ptr(
     const struct aws_ring_buffer *ring_buf,
     const uint8_t *atomic_ptr) {
-    if (!atomic_ptr) {
-        return s_check_null_ring_buffer(ring_buf);
-    }
-    if (ring_buf->allocation && ring_buf->allocation_end) {
-        return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
-    }
-    return false;
+    return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
 }
 
 /**
@@ -48,11 +37,8 @@ AWS_STATIC_IMPL bool aws_ring_buffer_is_valid(const struct aws_ring_buffer *ring
     bool tail_in_range = aws_ring_buffer_check_atomic_ptr(ring_buf, tail);
     /* if head points-to the first element of the buffer then tail must too */
     bool valid_head_tail = (head != ring_buf->allocation) || (tail == ring_buf->allocation);
-    bool valid_mem = s_check_null_ring_buffer(ring_buf);
-    if (ring_buf->allocation && ring_buf->allocation_end) {
-        valid_mem = AWS_MEM_IS_READABLE(ring_buf->allocation, ring_buf->allocation_end - ring_buf->allocation);
-    }
-    return ring_buf && valid_mem && head_in_range && tail_in_range && valid_head_tail && (ring_buf->allocator != NULL);
+    return ring_buf && (ring_buf->allocation != NULL) && head_in_range && tail_in_range && valid_head_tail &&
+           (ring_buf->allocator != NULL);
 }
 AWS_EXTERN_C_END
 #endif /* AWS_COMMON_RING_BUFFER_INL */

--- a/include/aws/common/ring_buffer.inl
+++ b/include/aws/common/ring_buffer.inl
@@ -8,13 +8,24 @@
 #include <aws/common/ring_buffer.h>
 
 AWS_EXTERN_C_BEGIN
+
+static bool s_check_null_ring_buffer(const struct aws_ring_buffer *ring_buf) {
+    return !ring_buf->allocation && !ring_buf->allocation_end;
+}
+
 /*
  * Checks whether atomic_ptr correctly points to a memory location within the bounds of the aws_ring_buffer
  */
 AWS_STATIC_IMPL bool aws_ring_buffer_check_atomic_ptr(
     const struct aws_ring_buffer *ring_buf,
     const uint8_t *atomic_ptr) {
-    return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
+    if (!atomic_ptr) {
+        return s_check_null_ring_buffer(ring_buf);
+    }
+    if (ring_buf->allocation && ring_buf->allocation_end) {
+        return (atomic_ptr >= ring_buf->allocation && atomic_ptr <= ring_buf->allocation_end);
+    }
+    return false;
 }
 
 /**
@@ -37,8 +48,11 @@ AWS_STATIC_IMPL bool aws_ring_buffer_is_valid(const struct aws_ring_buffer *ring
     bool tail_in_range = aws_ring_buffer_check_atomic_ptr(ring_buf, tail);
     /* if head points-to the first element of the buffer then tail must too */
     bool valid_head_tail = (head != ring_buf->allocation) || (tail == ring_buf->allocation);
-    return ring_buf && AWS_MEM_IS_READABLE(ring_buf->allocation, ring_buf->allocation_end - ring_buf->allocation) &&
-           head_in_range && tail_in_range && valid_head_tail && (ring_buf->allocator != NULL);
+    bool valid_mem = s_check_null_ring_buffer(ring_buf);
+    if (ring_buf->allocation && ring_buf->allocation_end) {
+        valid_mem = AWS_MEM_IS_READABLE(ring_buf->allocation, ring_buf->allocation_end - ring_buf->allocation);
+    }
+    return ring_buf && valid_mem && head_in_range && tail_in_range && valid_head_tail && (ring_buf->allocator != NULL);
 }
 AWS_EXTERN_C_END
 #endif /* AWS_COMMON_RING_BUFFER_INL */

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -857,13 +857,12 @@ int aws_byte_cursor_compare_lookup(
     AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
     AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
-    if (lhs->len == 0 || rhs->len == 0) {
-        if (lhs->len < rhs->len) {
-            return -1;
-        } else if (lhs->len > rhs->len) {
-            return 1;
-        }
+    if (lhs->len == 0 && rhs->len == 0) {
         return 0;
+    } else if (lhs->len == 0) {
+        return -1;
+    } else if (rhs->len == 0) {
+        return 1;
     }
     const uint8_t *lhs_curr = lhs->ptr;
     const uint8_t *lhs_end = lhs_curr + lhs->len;

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -496,7 +496,7 @@ uint64_t aws_hash_array_ignore_case(const void *array, const size_t len) {
     const uint64_t fnv_prime = 0x100000001b3ULL;
 
     const uint8_t *i = array;
-    const uint8_t *end = len ? i + len : i;
+    const uint8_t *end = (i == NULL) ? NULL : (i + len);
 
     uint64_t hash = fnv_offset_basis;
     while (i != end) {
@@ -1055,9 +1055,7 @@ struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cur
     } else {
         rv.ptr = cursor->ptr;
         rv.len = len;
-        if (len) {
-            cursor->ptr += len;
-        }
+        cursor->ptr = (cursor->ptr == NULL) ? NULL : cursor->ptr + len;
         cursor->len -= len;
     }
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
@@ -1098,9 +1096,7 @@ struct aws_byte_cursor aws_byte_cursor_advance_nospec(struct aws_byte_cursor *co
         /* Make sure anything acting upon the returned cursor _also_ doesn't advance past NULL */
         rv.len = len & mask;
 
-        if (len) {
-            cursor->ptr += len;
-        }
+        cursor->ptr = (cursor->ptr == NULL) ? NULL : cursor->ptr + len;
         cursor->len -= len;
     } else {
         rv.ptr = NULL;
@@ -1382,11 +1378,7 @@ bool aws_byte_buf_advance(
     AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
     AWS_PRECONDITION(aws_byte_buf_is_valid(output));
     if (buffer->capacity - buffer->len >= len) {
-        if (len) {
-            *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
-        } else {
-            *output = aws_byte_buf_from_array(NULL, len);
-        }
+        *output = aws_byte_buf_from_array((buffer->buffer == NULL) ? NULL : buffer->buffer + buffer->len, len);
         buffer->len += len;
         output->len = 0;
         AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -496,7 +496,7 @@ uint64_t aws_hash_array_ignore_case(const void *array, const size_t len) {
     const uint64_t fnv_prime = 0x100000001b3ULL;
 
     const uint8_t *i = array;
-    const uint8_t *end = i + len;
+    const uint8_t *end = len ? i + len : i;
 
     uint64_t hash = fnv_offset_basis;
     while (i != end) {
@@ -857,6 +857,14 @@ int aws_byte_cursor_compare_lookup(
     AWS_PRECONDITION(aws_byte_cursor_is_valid(lhs));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(rhs));
     AWS_PRECONDITION(AWS_MEM_IS_READABLE(lookup_table, 256));
+    if (lhs->len == 0 || rhs->len == 0) {
+        if (lhs->len < rhs->len) {
+            return -1;
+        } else if (lhs->len > rhs->len) {
+            return 1;
+        }
+        return 0;
+    }
     const uint8_t *lhs_curr = lhs->ptr;
     const uint8_t *lhs_end = lhs_curr + lhs->len;
 
@@ -1047,8 +1055,9 @@ struct aws_byte_cursor aws_byte_cursor_advance(struct aws_byte_cursor *const cur
     } else {
         rv.ptr = cursor->ptr;
         rv.len = len;
-
-        cursor->ptr += len;
+        if (len) {
+            cursor->ptr += len;
+        }
         cursor->len -= len;
     }
     AWS_POSTCONDITION(aws_byte_cursor_is_valid(cursor));
@@ -1089,7 +1098,9 @@ struct aws_byte_cursor aws_byte_cursor_advance_nospec(struct aws_byte_cursor *co
         /* Make sure anything acting upon the returned cursor _also_ doesn't advance past NULL */
         rv.len = len & mask;
 
-        cursor->ptr += len;
+        if (len) {
+            cursor->ptr += len;
+        }
         cursor->len -= len;
     } else {
         rv.ptr = NULL;
@@ -1371,7 +1382,11 @@ bool aws_byte_buf_advance(
     AWS_PRECONDITION(aws_byte_buf_is_valid(buffer));
     AWS_PRECONDITION(aws_byte_buf_is_valid(output));
     if (buffer->capacity - buffer->len >= len) {
-        *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
+        if (len) {
+            *output = aws_byte_buf_from_array(buffer->buffer + buffer->len, len);
+        } else {
+            *output = aws_byte_buf_from_array(NULL, len);
+        }
         buffer->len += len;
         output->len = 0;
         AWS_POSTCONDITION(aws_byte_buf_is_valid(buffer));

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -73,8 +73,7 @@ int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_s
 
     /* this branch is, we don't have any vended buffers. */
     if (head_cpy == tail_cpy) {
-        size_t ring_space =
-            (!ring_buf->allocation || !ring_buf->allocation_end) ? 0 : ring_buf->allocation_end - ring_buf->allocation;
+        size_t ring_space = ring_buf->allocation_end == NULL ? 0 : ring_buf->allocation_end - ring_buf->allocation;
 
         if (requested_size > ring_space) {
             AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
@@ -148,8 +147,7 @@ int aws_ring_buffer_acquire_up_to(
 
     /* this branch is, we don't have any vended buffers. */
     if (head_cpy == tail_cpy) {
-        size_t ring_space =
-            (!ring_buf->allocation || !ring_buf->allocation_end) ? 0 : ring_buf->allocation_end - ring_buf->allocation;
+        size_t ring_space = ring_buf->allocation_end == NULL ? 0 : ring_buf->allocation_end - ring_buf->allocation;
 
         size_t allocation_size = ring_space > requested_size ? requested_size : ring_space;
 

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -73,7 +73,8 @@ int aws_ring_buffer_acquire(struct aws_ring_buffer *ring_buf, size_t requested_s
 
     /* this branch is, we don't have any vended buffers. */
     if (head_cpy == tail_cpy) {
-        size_t ring_space = ring_buf->allocation_end - ring_buf->allocation;
+        size_t ring_space =
+            (!ring_buf->allocation || !ring_buf->allocation_end) ? 0 : ring_buf->allocation_end - ring_buf->allocation;
 
         if (requested_size > ring_space) {
             AWS_POSTCONDITION(aws_ring_buffer_is_valid(ring_buf));
@@ -147,7 +148,8 @@ int aws_ring_buffer_acquire_up_to(
 
     /* this branch is, we don't have any vended buffers. */
     if (head_cpy == tail_cpy) {
-        size_t ring_space = ring_buf->allocation_end - ring_buf->allocation;
+        size_t ring_space =
+            (!ring_buf->allocation || !ring_buf->allocation_end) ? 0 : ring_buf->allocation_end - ring_buf->allocation;
 
         size_t allocation_size = ring_space > requested_size ? requested_size : ring_space;
 
@@ -232,7 +234,7 @@ static inline bool s_buf_belongs_to_pool(const struct aws_ring_buffer *ring_buff
 #ifdef CBMC
     /* only continue if buf points-into ring_buffer because comparison of pointers to different objects is undefined
      * (C11 6.5.8) */
-    if (!__CPROVER_same_object(buf->buffer, ring_buffer->allocation) ||
+    if (!__CPROVER_same_object(buf->buffer, ring_buffer->allocation) || !ring_buffer->allocation_end ||
         !__CPROVER_same_object(buf->buffer, ring_buffer->allocation_end - 1)) {
         return false;
     }

--- a/source/ring_buffer.c
+++ b/source/ring_buffer.c
@@ -234,10 +234,11 @@ static inline bool s_buf_belongs_to_pool(const struct aws_ring_buffer *ring_buff
 #ifdef CBMC
     /* only continue if buf points-into ring_buffer because comparison of pointers to different objects is undefined
      * (C11 6.5.8) */
-    if (!__CPROVER_same_object(buf->buffer, ring_buffer->allocation) || !ring_buffer->allocation_end ||
-        !__CPROVER_same_object(buf->buffer, ring_buffer->allocation_end - 1)) {
-        return false;
-    }
+    return (
+        __CPROVER_same_object(buf->buffer, ring_buffer->allocation) &&
+        AWS_IMPLIES(
+            ring_buffer->allocation_end != NULL, __CPROVER_same_object(buf->buffer, ring_buffer->allocation_end - 1)));
+
 #endif
     return buf->buffer && ring_buffer->allocation && ring_buffer->allocation_end &&
            buf->buffer >= ring_buffer->allocation && buf->buffer + buf->capacity <= ring_buffer->allocation_end;

--- a/verification/cbmc/.gitignore
+++ b/verification/cbmc/.gitignore
@@ -10,3 +10,4 @@ TAGS-*
 # Written by litani on each proof run
 .litani_cache_dir
 .ninja_log
+.ninja_deps

--- a/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
@@ -36,9 +36,7 @@ void aws_byte_cursor_advance_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        if (old.ptr) {
-            assert(cursor.ptr == old.ptr + len);
-        }
+        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
         assert(cursor.len == old.len - len);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
@@ -36,7 +36,11 @@ void aws_byte_cursor_advance_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
+        if (old_cur.ptr != NULL) {
+            assert(cursor.ptr == old_cur.ptr + len);
+        } else {
+            assert(cursor.ptr == NULL);
+        }
         assert(cursor.len == old.len - len);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
@@ -37,9 +37,9 @@ void aws_byte_cursor_advance_harness() {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
         if (old_cur.ptr != NULL) {
-            assert(cur.ptr == old_cur.ptr + len);
+            assert(cursor.ptr == old_cur.ptr + len);
         } else {
-            assert(cur.ptr == NULL);
+            assert(cursor.ptr == NULL);
         }
         assert(cursor.len == old.len - len);
     }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
@@ -36,8 +36,8 @@ void aws_byte_cursor_advance_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        if (old_cur.ptr != NULL) {
-            assert(cursor.ptr == old_cur.ptr + len);
+        if (old.ptr != NULL) {
+            assert(cursor.ptr == old.ptr + len);
         } else {
             assert(cursor.ptr == NULL);
         }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
@@ -37,9 +37,9 @@ void aws_byte_cursor_advance_harness() {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
         if (old_cur.ptr != NULL) {
-            assert(cursor.ptr == old_cur.ptr + len);
+            assert(cur.ptr == old_cur.ptr + len);
         } else {
-            assert(cursor.ptr == NULL);
+            assert(cur.ptr == NULL);
         }
         assert(cursor.len == old.len - len);
     }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance/aws_byte_cursor_advance_harness.c
@@ -36,7 +36,9 @@ void aws_byte_cursor_advance_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        assert(cursor.ptr == old.ptr + len);
+        if (old.ptr) {
+            assert(cursor.ptr == old.ptr + len);
+        }
         assert(cursor.len == old.len - len);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
@@ -37,9 +37,9 @@ void aws_byte_cursor_advance_nospec_harness() {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
         if (old_cur.ptr != NULL) {
-            assert(cursor.ptr == old_cur.ptr + len);
+            assert(cur.ptr == old_cur.ptr + len);
         } else {
-            assert(cursor.ptr == NULL);
+            assert(cur.ptr == NULL);
         }
         assert(cursor.len == old.len - len);
     }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
@@ -36,7 +36,11 @@ void aws_byte_cursor_advance_nospec_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
+        if (old_cur.ptr != NULL) {
+            assert(cursor.ptr == old_cur.ptr + len);
+        } else {
+            assert(cursor.ptr == NULL);
+        }
         assert(cursor.len == old.len - len);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
@@ -37,9 +37,9 @@ void aws_byte_cursor_advance_nospec_harness() {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
         if (old_cur.ptr != NULL) {
-            assert(cur.ptr == old_cur.ptr + len);
+            assert(cursor.ptr == old_cur.ptr + len);
         } else {
-            assert(cur.ptr == NULL);
+            assert(cursor.ptr == NULL);
         }
         assert(cursor.len == old.len - len);
     }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
@@ -36,7 +36,9 @@ void aws_byte_cursor_advance_nospec_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        assert(cursor.ptr == old.ptr + len);
+        if (old.ptr) {
+            assert(cursor.ptr == old.ptr + len);
+        }
         assert(cursor.len == old.len - len);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
@@ -36,8 +36,8 @@ void aws_byte_cursor_advance_nospec_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        if (old_cur.ptr != NULL) {
-            assert(cursor.ptr == old_cur.ptr + len);
+        if (old.ptr != NULL) {
+            assert(cursor.ptr == old.ptr + len);
         } else {
             assert(cursor.ptr == NULL);
         }

--- a/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_advance_nospec/aws_byte_cursor_advance_nospec_harness.c
@@ -36,9 +36,7 @@ void aws_byte_cursor_advance_nospec_harness() {
     } else {
         assert(rv.ptr == old.ptr);
         assert(rv.len == len);
-        if (old.ptr) {
-            assert(cursor.ptr == old.ptr + len);
-        }
+        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
         assert(cursor.len == old.len - len);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -39,7 +39,11 @@ void aws_byte_cursor_read_harness() {
             assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
         }
     } else {
-        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
+        if (old_cur.ptr != NULL) {
+            assert(cursor.ptr == old_cur.ptr + len);
+        } else {
+            assert(cursor.ptr == NULL);
+        }
         assert(cur.len == old_cur.len - length);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -40,7 +40,7 @@ void aws_byte_cursor_read_harness() {
         }
     } else {
         if (old_cur.ptr != NULL) {
-            assert(cur.ptr == old_cur.ptr + len);
+            assert(cur.ptr == old_cur.ptr + length);
         } else {
             assert(cur.ptr == NULL);
         }

--- a/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -40,9 +40,9 @@ void aws_byte_cursor_read_harness() {
         }
     } else {
         if (old_cur.ptr != NULL) {
-            assert(cursor.ptr == old_cur.ptr + len);
+            assert(cur.ptr == old_cur.ptr + len);
         } else {
-            assert(cursor.ptr == NULL);
+            assert(cur.ptr == NULL);
         }
         assert(cur.len == old_cur.len - length);
     }

--- a/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -39,9 +39,7 @@ void aws_byte_cursor_read_harness() {
             assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
         }
     } else {
-        if (old_cur.ptr) {
-            assert(cur.ptr == old_cur.ptr + length);
-        }
+        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
         assert(cur.len == old_cur.len - length);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read/aws_byte_cursor_read_harness.c
@@ -39,7 +39,9 @@ void aws_byte_cursor_read_harness() {
             assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
         }
     } else {
-        assert(cur.ptr == old_cur.ptr + length);
+        if (old_cur.ptr) {
+            assert(cur.ptr == old_cur.ptr + length);
+        }
         assert(cur.len == old_cur.len - length);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -44,7 +44,7 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
         }
     } else {
         if (old_cur.ptr != NULL) {
-            assert(cur.ptr == old_cur.ptr + len);
+            assert(cur.ptr == old_cur.ptr + old_buf.capacity);
         } else {
             assert(cur.ptr == NULL);
         }

--- a/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -43,7 +43,9 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
             assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
         }
     } else {
-        assert(cur.ptr == old_cur.ptr + old_buf.capacity);
+        if (old_cur.ptr) {
+            assert(cur.ptr == old_cur.ptr + old_buf.capacity);
+        }
         assert(cur.len == old_cur.len - old_buf.capacity);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -44,9 +44,9 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
         }
     } else {
         if (old_cur.ptr != NULL) {
-            assert(cursor.ptr == old_cur.ptr + len);
+            assert(cur.ptr == old_cur.ptr + len);
         } else {
-            assert(cursor.ptr == NULL);
+            assert(cur.ptr == NULL);
         }
         assert(cur.len == old_cur.len - old_buf.capacity);
     }

--- a/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -43,7 +43,11 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
             assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
         }
     } else {
-        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
+        if (old_cur.ptr != NULL) {
+            assert(cursor.ptr == old_cur.ptr + len);
+        } else {
+            assert(cursor.ptr == NULL);
+        }
         assert(cur.len == old_cur.len - old_buf.capacity);
     }
 }

--- a/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
+++ b/verification/cbmc/proofs/aws_byte_cursor_read_and_fill_buffer/aws_byte_cursor_read_and_fill_buffer_harness.c
@@ -43,9 +43,7 @@ void aws_byte_cursor_read_and_fill_buffer_harness() {
             assert_byte_from_buffer_matches(cur.ptr, &old_byte_from_cur);
         }
     } else {
-        if (old_cur.ptr) {
-            assert(cur.ptr == old_cur.ptr + old_buf.capacity);
-        }
+        assert(AWS_IMPLIES(old.ptr != NULL, cursor.ptr == old.ptr + len));
         assert(cur.len == old_cur.len - old_buf.capacity);
     }
 }

--- a/verification/cbmc/proofs/aws_hash_table_clean_up/aws_hash_table_clean_up_harness.c
+++ b/verification/cbmc/proofs/aws_hash_table_clean_up/aws_hash_table_clean_up_harness.c
@@ -27,6 +27,7 @@ void aws_hash_table_clean_up_harness() {
     // This would normally raise a warning since the memory was deallocated, so use the pragma.
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
+#pragma CPROVER check disable "pointer-overflow"
     size_t i;
     size_t len = state->size * sizeof(state->slots[0]);
     __CPROVER_assume(i < len);

--- a/verification/cbmc/proofs/aws_ring_buffer_init/Makefile
+++ b/verification/cbmc/proofs/aws_ring_buffer_init/Makefile
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-###########
 UNWINDSET +=
 
 CBMCFLAGS +=
@@ -20,6 +19,8 @@ PROOF_SOURCES += $(PROOF_STUB)/error.c
 PROJECT_SOURCES += $(SRCDIR)/source/ring_buffer.c
 PROJECT_SOURCES += $(SRCDIR)/source/common.c
 
-###########
+# We abstract this function because manual inspection demonstrates it is unreachable.
+# Improves coverage metrics.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_ring_buffer_c_s_ring_buffer_mem_acquire
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_ring_buffer_init/aws_ring_buffer_init_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_init/aws_ring_buffer_init_harness.c
@@ -7,16 +7,21 @@
 #include <proof_helpers/make_common_data_structures.h>
 
 void aws_ring_buffer_init_harness() {
-    /* parameters */
-    struct aws_ring_buffer ring_buf;
+    /* Non-deterministic parameters. */
+    struct aws_ring_buffer *ring_buf = malloc(sizeof(*ring_buf));
     struct aws_allocator *allocator = aws_default_allocator();
     size_t size;
-    __CPROVER_assume(size > 0); /* Precondition */
 
-    if (aws_ring_buffer_init(&ring_buf, allocator, size) == AWS_OP_SUCCESS) {
-        /* assertions */
-        assert(aws_ring_buffer_is_valid(&ring_buf));
-        assert(ring_buf.allocator == allocator);
-        assert(ring_buf.allocation_end - ring_buf.allocation == size);
+    /* Preconditions. */
+    __CPROVER_assume(ring_buf != NULL);
+    __CPROVER_assume(allocator != NULL);
+    __CPROVER_assume(size > 0 && size < MAX_MALLOC); 
+
+    /* Operation under verification. */
+    if (aws_ring_buffer_init(ring_buf, allocator, size) == AWS_OP_SUCCESS) {
+        /* Postconditions. */
+        assert(aws_ring_buffer_is_valid(ring_buf));
+        assert(ring_buf->allocator == allocator);
+        assert(ring_buf->allocation_end - ring_buf->allocation == size);
     }
 }

--- a/verification/cbmc/proofs/aws_ring_buffer_init/aws_ring_buffer_init_harness.c
+++ b/verification/cbmc/proofs/aws_ring_buffer_init/aws_ring_buffer_init_harness.c
@@ -15,7 +15,7 @@ void aws_ring_buffer_init_harness() {
     /* Preconditions. */
     __CPROVER_assume(ring_buf != NULL);
     __CPROVER_assume(allocator != NULL);
-    __CPROVER_assume(size > 0 && size < MAX_MALLOC); 
+    __CPROVER_assume(size > 0 && size < MAX_MALLOC);
 
     /* Operation under verification. */
     if (aws_ring_buffer_init(ring_buf, allocator, size) == AWS_OP_SUCCESS) {

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -33,9 +33,15 @@ void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, 
     size_t position_tail;
     __CPROVER_assume(position_head < size);
     __CPROVER_assume(position_tail < size);
-    aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
-    aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
-    ring_buf->allocation_end = ring_buf->allocation + size;
+    if (ring_buf->allocation) {
+        aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
+        aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
+        ring_buf->allocation_end = ring_buf->allocation + size;
+    } else {
+        aws_atomic_store_ptr(&ring_buf->head, NULL);
+        aws_atomic_store_ptr(&ring_buf->tail, NULL);
+        ring_buf->allocation_end = NULL;
+    }
 }
 
 /**

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -33,7 +33,7 @@ void ensure_ring_buffer_has_allocated_members(struct aws_ring_buffer *ring_buf, 
     size_t position_tail;
     __CPROVER_assume(position_head < size);
     __CPROVER_assume(position_tail < size);
-    if (ring_buf->allocation) {
+    if (ring_buf->allocation != NULL) {
         aws_atomic_store_ptr(&ring_buf->head, (ring_buf->allocation + position_head));
         aws_atomic_store_ptr(&ring_buf->tail, (ring_buf->allocation + position_tail));
         ring_buf->allocation_end = ring_buf->allocation + size;


### PR DESCRIPTION
*Issue #, if available:*
N/A.

*Description of changes:*
1. Avoid null-pointer arithmetic;
2. Updates a few CBMC proofs; 
3. Upgrades CBMC templates;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
