### PR TITLE
Fix Android Large File Support checks

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -17,20 +17,26 @@ option(AWS_WARNINGS_ARE_ERRORS "Compiler warning is treated as an error. Try tur
 # https://www.gnu.org/software/libc/manual/html_node/File-Position-Primitive.html
 # https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
 function(aws_check_posix_lfs extra_flags variable)
-    set(old_flags "${CMAKE_REQUIRED_FLAGS}")
-    set(CMAKE_REQUIRED_FLAGS "${extra_flags}")
+    list(APPEND CMAKE_REQUIRED_FLAGS ${extra_flags})
     check_c_source_compiles("
-    #include <stdio.h>
+        #include <stdio.h>
 
-    /* fails to compile if off_t smaller than 64bits */
-    typedef char array[sizeof(off_t) >= 8 ? 1 : -1];
+        /* fails to compile if off_t smaller than 64bits */
+        typedef char array[sizeof(off_t) >= 8 ? 1 : -1];
 
-    int main() {
-        FILE *f = fopen(\"realbig.txt\", \"r\");
-        fseeko(f, 0, 0);
-        return 0;
-    }"  ${variable})
-    set(CMAKE_REQUIRED_FLAGS "${old_flags}")
+        int main() {
+            return 0;
+        }"
+        HAS_64BIT_FILE_OFFSET_${variable})
+
+    if (HAS_64BIT_FILE_OFFSET_${variable})
+        # sometimes off_t is 64bit, but fseeko() is missing (ex: Android API < 24)
+        check_symbol_exists(fseeko "stdio.h" HAS_FSEEKO_${variable})
+
+        if (HAS_FSEEKO_${variable})
+            set(${variable} 1 PARENT_SCOPE)
+        endif()
+    endif()
 endfunction()
 
 # This function will set all common flags on a target
@@ -117,12 +123,12 @@ function(aws_set_common_properties target)
         # Doing this check here, instead of AwsFeatureTests.cmake,
         # because we might need to modify AWS_C_FLAGS to enable it.
         set(HAS_LFS FALSE)
-        aws_check_posix_lfs("" HAS_POSIX_LARGE_FILE_SUPPORT_BY_DEFAULT)
-        if (HAS_POSIX_LARGE_FILE_SUPPORT_BY_DEFAULT)
+        aws_check_posix_lfs("" BY_DEFAULT)
+        if (BY_DEFAULT)
             set(HAS_LFS TRUE)
         else()
-            aws_check_posix_lfs("-D_FILE_OFFSET_BITS=64" HAS_POSIX_LARGE_FILE_SUPPORT_VIA_DEFINES)
-            if (HAS_POSIX_LARGE_FILE_SUPPORT_VIA_DEFINES)
+            aws_check_posix_lfs("-D_FILE_OFFSET_BITS=64" VIA_DEFINES)
+            if (VIA_DEFINES)
                 list(APPEND AWS_C_FLAGS "-D_FILE_OFFSET_BITS=64")
                 set(HAS_LFS TRUE)
             endif()


### PR DESCRIPTION
32bit Android can have 64bit off_t, but no fseeko().

The check_c_source_compiles() sample program was supposed to check for this, but the missing fseeko() was only treated as a compiler warning and didn't fail the check. Therefore, explicitly check for fseeko as a separate check. (I couldn't figure out how to get check_c_source_compiles() to do warnings-as-errors)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
