### PR TITLE
Adding cmake include for check_symbol_exists() now used in aws-c-io

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -3,6 +3,7 @@
 
 include(CheckCCompilerFlag)
 include(CheckIncludeFile)
+include(CheckSymbolExists)
 include(CMakeParseArguments) # needed for CMake v3.4 and lower
 
 option(AWS_ENABLE_LTO "Enables LTO on libraries. Ensure this is set on all consumed targets, or linking will fail" OFF)


### PR DESCRIPTION
*Issue #, if available:*
 * Fixes downstream build of aws-c-io

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
