### PR TITLE
Part 1 of aws_thread_clean_up fix and contract clarification

### DIFF
--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -325,7 +325,9 @@ int aws_thread_launch(
      * Managed threads need to stay unjoinable from an external perspective.  We'll handle it after thread function
      * completion.
      */
-    if (!is_managed_thread) {
+    if (is_managed_thread) {
+        aws_thread_clean_up(thread);
+    } else {
         thread->detach_state = AWS_THREAD_JOINABLE;
     }
 

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -95,6 +95,14 @@ void aws_thread_join_and_free_wrapper_list(struct aws_linked_list *wrapper_list)
 
         join_thread_wrapper->thread_copy.detach_state = AWS_THREAD_JOINABLE;
         aws_thread_join(&join_thread_wrapper->thread_copy);
+
+        /*
+         * This doesn't actually do anything when using posix threads, but it keeps us
+         * in sync with the Windows version as well as the lifecycle contract we're
+         * presenting for threads.
+         */
+        aws_thread_clean_up(&join_thread_wrapper->thread_copy);
+
         aws_mem_release(join_thread_wrapper->allocator, join_thread_wrapper);
 
         aws_thread_decrement_unjoined_count();

--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -54,6 +54,7 @@ void aws_thread_join_and_free_wrapper_list(struct aws_linked_list *wrapper_list)
         iter = aws_linked_list_next(iter);
         join_thread_wrapper->thread_copy.detach_state = AWS_THREAD_JOINABLE;
         aws_thread_join(&join_thread_wrapper->thread_copy);
+        aws_thread_clean_up(&join_thread_wrapper->thread_copy);
         aws_mem_release(join_thread_wrapper->allocator, join_thread_wrapper);
 
         aws_thread_decrement_unjoined_count();

--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -271,7 +271,9 @@ int aws_thread_launch(
      * Managed threads need to stay unjoinable from an external perspective.  We'll handle it after thread function
      * completion.
      */
-    if (!is_managed_thread) {
+    if (is_managed_thread) {
+        aws_thread_clean_up(thread);
+    } else {
         thread->detach_state = AWS_THREAD_JOINABLE;
     }
 

--- a/tests/promise_test.c
+++ b/tests/promise_test.c
@@ -4,8 +4,8 @@
  */
 
 #include <aws/common/clock.h>
-#include <aws/common/thread.h>
 #include <aws/common/promise.h>
+#include <aws/common/thread.h>
 
 #include <aws/testing/aws_test_harness.h>
 
@@ -15,7 +15,7 @@ struct promise_test_work {
     uint64_t work_time;
     int error_code;
     void *value;
-    void (*dtor)(void*);
+    void (*dtor)(void *);
 };
 
 static void s_promise_test_worker(void *data) {
@@ -86,7 +86,8 @@ static int s_promise_test_wait_for_a_bit(struct aws_allocator *allocator, void *
     };
     struct aws_thread worker_thread = s_promise_test_launch_worker(&work);
     /* wait until the worker finishes, in 500ms intervals */
-    while (!aws_promise_wait_for(promise, 500));
+    while (!aws_promise_wait_for(promise, 500))
+        ;
 
     ASSERT_TRUE(aws_promise_error_code(promise) == 0);
     ASSERT_NULL(aws_promise_value(promise));

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -121,8 +121,6 @@ static int s_do_managed_thread_join_test(struct aws_allocator *allocator, size_t
             aws_thread_launch(&threads[i], s_managed_thread_fn, (void *)&thread_data[i], &thread_options),
             "thread creation failed");
 
-        aws_thread_clean_up(&threads[i]);
-
         ASSERT_INT_EQUALS(
             AWS_THREAD_MANAGED, aws_thread_get_detach_state(&threads[i]), "thread state should have returned JOINABLE");
     }
@@ -177,8 +175,6 @@ static int s_test_managed_thread_join_timeout(struct aws_allocator *allocator, v
     ASSERT_SUCCESS(
         aws_thread_launch(&thread, s_managed_thread_fn, (void *)&thread_data, &thread_options),
         "thread creation failed");
-
-    aws_thread_clean_up(&thread);
 
     ASSERT_TRUE(aws_thread_get_managed_thread_count() == 1);
 


### PR DESCRIPTION
* Clarify aws_thread_clean_up contract
* Invoke aws_thread_clean_up on all managed threads
* Update tests that were calling clean_up on managed threads

This PR requires https://github.com/awslabs/aws-c-io/pull/400/ as well.

The two PRs together are intended to resolve https://github.com/awslabs/aws-c-io/issues/398

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
