### PR TITLE
Added a function to split debug info out of shared libs and executables

### DIFF
--- a/cmake/AwsSharedLibSetup.cmake
+++ b/cmake/AwsSharedLibSetup.cmake
@@ -8,7 +8,7 @@ if (UNIX AND NOT APPLE)
     include(GNUInstallDirs)
     set(LIBRARY_DIRECTORY ${CMAKE_INSTALL_LIBDIR})
     set(RUNTIME_DIRECTORY ${CMAKE_INSTALL_BINDIR})
-    
+
     # this is the absolute dumbest thing in the world, but find_package won't work without it
     # also I verified this is correctly NOT "lib64" when CMAKE_C_FLAGS includes "-m32"
     if (${LIBRARY_DIRECTORY} STREQUAL "lib64")
@@ -49,5 +49,21 @@ function(aws_prepare_symbol_visibility_args target lib_prefix)
     if (BUILD_SHARED_LIBS)
         target_compile_definitions(${target} PUBLIC "-D${lib_prefix}_USE_IMPORT_EXPORT")
         target_compile_definitions(${target} PRIVATE "-D${lib_prefix}_EXPORTS")
+    endif()
+endfunction()
+
+# Strips debug info from the target shared library or executable, and puts it in a $<TARGET_FILE:${target}>.dbg
+# archive, then links the original binary to the dbg archive so gdb will find it
+# This only applies to Unix shared libs and executables, windows has pdbs.
+# This is only done on Release and RelWithDebInfo build types
+function(aws_split_debug_info target)
+    if (UNIX AND CMAKE_BUILD_TYPE MATCHES Rel AND CMAKE_STRIP AND CMAKE_OBJCOPY)
+        get_target_property(target_type ${target} TYPE)
+        if (target_type STREQUAL "SHARED_LIBRARY" OR target_type STREQUAL "EXECUTABLE")
+            add_custom_command(TARGET ${target} POST_BUILD
+                COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:${target}> $<TARGET_FILE:${target}>.dbg
+                COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:${target}>
+                COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:${target}>.dbg $<TARGET_FILE:${target}>)
+        endif()
     endif()
 endfunction()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
