### PR TITLE
Use formatting specifiers correctly

### DIFF
--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -213,7 +213,7 @@ int aws_thread_launch(
     if (options && options->cpu_id >= 0) {
         AWS_LOGF_INFO(
             AWS_LS_COMMON_THREAD,
-            "id=%p: cpu affinity of cpu_id " PRIi32 " was specified, attempting to honor the value.",
+            "id=%p: cpu affinity of cpu_id %" PRIi32 " was specified, attempting to honor the value.",
             (void *)thread,
             options->cpu_id);
 
@@ -226,7 +226,7 @@ int aws_thread_launch(
         group_afinity.Mask = (KAFFINITY)((uint64_t)1 << proc_num);
         AWS_LOGF_DEBUG(
             AWS_LS_COMMON_THREAD,
-            "id=%p: computed mask " PRIx64 " on group " PRIu16 ".",
+            "id=%p: computed mask %" PRIx64 " on group %" PRIu16 ".",
             (void *)thread,
             (uint64_t)group_afinity.Mask,
             (uint16_t)group_afinity.Group);
@@ -234,7 +234,7 @@ int aws_thread_launch(
         BOOL set_group_val = SetThreadGroupAffinity(thread->thread_handle, &group_afinity, NULL);
         AWS_LOGF_DEBUG(
             AWS_LS_COMMON_THREAD,
-            "id=%p: SetThreadGroupAffinity() result " PRIi8 ".",
+            "id=%p: SetThreadGroupAffinity() result %" PRIi8 ".",
             (void *)thread,
             (int8_t)set_group_val);
 
@@ -247,20 +247,20 @@ int aws_thread_launch(
             BOOL set_processor_val = SetThreadIdealProcessorEx(thread->thread_handle, &processor_number, NULL);
             AWS_LOGF_DEBUG(
                 AWS_LS_COMMON_THREAD,
-                "id=%p: SetThreadIdealProcessorEx() result " PRIi8 ".",
+                "id=%p: SetThreadIdealProcessorEx() result %" PRIi8 ".",
                 (void *)thread,
                 (int8_t)set_processor_val);
             if (!set_processor_val) {
                 AWS_LOGF_WARN(
                     AWS_LS_COMMON_THREAD,
-                    "id=%p: SetThreadIdealProcessorEx() failed with " PRIx32 ".",
+                    "id=%p: SetThreadIdealProcessorEx() failed with %" PRIx32 ".",
                     (void *)thread,
                     (uint32_t)GetLastError());
             }
         } else {
             AWS_LOGF_WARN(
                 AWS_LS_COMMON_THREAD,
-                "id=%p: SetThreadGroupAffinity() failed with " PRIx32 ".",
+                "id=%p: SetThreadGroupAffinity() failed with %" PRIx32 ".",
                 (void *)thread,
                 (uint32_t)GetLastError());
         }


### PR DESCRIPTION
We saw output like this on Windows because the format specifiers in the logging functions were lacking a percent sign:

> DEBUG   [AWS-thread] id=0000000001683600: SetThreadGroupAffinity() result hhi.
> DEBUG   [AWS-thread] id=0000000001683600: SetThreadIdealProcessorEx() result hhi.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
