### PR TITLE
Improved fix for string-overflow warning.

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -91,12 +91,3 @@ if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
         return 0;
     }" AWS_HAVE_EXECINFO)
 endif()
-
-if (NOT MSVC)
-    set(CMAKE_REQUIRED_FLAGS "-Werror -Wno-error=stringop-overflow")
-    check_c_source_compiles("
-    int main() {
-        return 0;
-    }" AWS_SHOULD_DISABLE_STRINGOP_OVERFLOW)
-    unset(CMAKE_REQUIRED_FLAGS)
-endif()


### PR DESCRIPTION
The previous attempt to fix this warning required both AwsFeatureTests.cmake and AwsTestHarness.cmake to be included in every CMakeLists.txt to work properly.

With this change, the fix works without including both files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
