### PR TITLE
Update datetime to support millisecond precision

### DIFF
--- a/include/aws/common/date_time.h
+++ b/include/aws/common/date_time.h
@@ -48,6 +48,7 @@ enum aws_date_day_of_week {
 
 struct aws_date_time {
     time_t timestamp;
+    uint16_t milliseconds;
     char tz[6];
     struct tm gmt_time;
     struct tm local_time;

--- a/source/date_time.c
+++ b/source/date_time.c
@@ -12,6 +12,7 @@
 #include <aws/common/time.h>
 
 #include <ctype.h>
+#include <math.h>
 
 static const char *RFC822_DATE_FORMAT_STR_MINUS_Z = "%a, %d %b %Y %H:%M:%S GMT";
 static const char *RFC822_DATE_FORMAT_STR_WITH_Z = "%a, %d %b %Y %H:%M:%S %Z";
@@ -187,8 +188,9 @@ void aws_date_time_init_epoch_millis(struct aws_date_time *dt, uint64_t ms_since
 }
 
 void aws_date_time_init_epoch_secs(struct aws_date_time *dt, double sec_ms) {
-    dt->timestamp = (time_t)(sec_ms * AWS_TIMESTAMP_MILLIS);
-    dt->milliseconds = 0U;
+    double integral = 0;
+    dt->milliseconds = (uint16_t)(round(modf(sec_ms, &integral) * AWS_TIMESTAMP_MILLIS));
+    dt->timestamp = (time_t)integral;
     dt->gmt_time = s_get_time_struct(dt, false);
     dt->local_time = s_get_time_struct(dt, true);
 }

--- a/source/date_time.c
+++ b/source/date_time.c
@@ -171,18 +171,17 @@ struct tm s_get_time_struct(struct aws_date_time *dt, bool local_time) {
 }
 
 void aws_date_time_init_now(struct aws_date_time *dt) {
-    uint64_t current_time_ns = 0, current_time_ms = 0;
+    uint64_t current_time_ns = 0;
     aws_sys_clock_get_ticks(&current_time_ns);
-    current_time_ms = aws_timestamp_convert(current_time_ns, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, NULL);
-    dt->timestamp = (time_t)(current_time_ms / AWS_TIMESTAMP_MILLIS);
-    dt->milliseconds = (uint16_t)(current_time_ms % AWS_TIMESTAMP_MILLIS);
-    dt->gmt_time = s_get_time_struct(dt, false);
-    dt->local_time = s_get_time_struct(dt, true);
+    aws_date_time_init_epoch_millis(
+        dt, aws_timestamp_convert(current_time_ns, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, NULL));
 }
 
 void aws_date_time_init_epoch_millis(struct aws_date_time *dt, uint64_t ms_since_epoch) {
-    dt->timestamp = (time_t)(ms_since_epoch / AWS_TIMESTAMP_MILLIS);
-    dt->milliseconds = (uint16_t)(ms_since_epoch % AWS_TIMESTAMP_MILLIS);
+    uint64_t milliseconds = 0;
+    dt->timestamp =
+        (time_t)aws_timestamp_convert(ms_since_epoch, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_SECS, &milliseconds);
+    dt->milliseconds = (uint16_t)milliseconds;
     dt->gmt_time = s_get_time_struct(dt, false);
     dt->local_time = s_get_time_struct(dt, true);
 }
@@ -754,12 +753,13 @@ double aws_date_time_as_epoch_secs(const struct aws_date_time *dt) {
 }
 
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt) {
-    return ((uint64_t)dt->timestamp * AWS_TIMESTAMP_NANOS) +
-           (uint64_t)(dt->milliseconds * (AWS_TIMESTAMP_NANOS / AWS_TIMESTAMP_MILLIS));
+    return aws_timestamp_convert((uint64_t)dt->timestamp, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL) +
+           aws_timestamp_convert((uint64_t)dt->milliseconds, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL);
 }
 
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt) {
-    return ((uint64_t)dt->timestamp * AWS_TIMESTAMP_MILLIS) + (uint64_t)(dt->milliseconds);
+    return aws_timestamp_convert((uint64_t)dt->timestamp, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_MILLIS, NULL) +
+           (uint64_t)dt->milliseconds;
 }
 
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time) {

--- a/tests/date_time_test.c
+++ b/tests/date_time_test.c
@@ -579,6 +579,7 @@ static int s_test_unix_epoch_parsing_fn(struct aws_allocator *allocator, void *c
 
     struct aws_date_time date_time;
 
+    /* Test milliseconds are zeroed out. */
     aws_date_time_init_epoch_secs(&date_time, 1033545909.0);
     ASSERT_INT_EQUALS(AWS_DATE_DAY_OF_WEEK_WEDNESDAY, aws_date_time_day_of_week(&date_time, false));
     ASSERT_UINT_EQUALS(2, aws_date_time_month_day(&date_time, false));
@@ -587,6 +588,18 @@ static int s_test_unix_epoch_parsing_fn(struct aws_allocator *allocator, void *c
     ASSERT_UINT_EQUALS(8, aws_date_time_hour(&date_time, false));
     ASSERT_UINT_EQUALS(5, aws_date_time_minute(&date_time, false));
     ASSERT_UINT_EQUALS(9, aws_date_time_second(&date_time, false));
+    ASSERT_UINT_EQUALS(0U, date_time.milliseconds);
+
+    /* Test milliseconds of `date_time` match the milliseconds from decimal portion of the input, double timestamp. */
+    aws_date_time_init_epoch_secs(&date_time, 1033545909.50542123);
+    ASSERT_INT_EQUALS(AWS_DATE_DAY_OF_WEEK_WEDNESDAY, aws_date_time_day_of_week(&date_time, false));
+    ASSERT_UINT_EQUALS(2, aws_date_time_month_day(&date_time, false));
+    ASSERT_UINT_EQUALS(AWS_DATE_MONTH_OCTOBER, aws_date_time_month(&date_time, false));
+    ASSERT_UINT_EQUALS(2002, aws_date_time_year(&date_time, false));
+    ASSERT_UINT_EQUALS(8, aws_date_time_hour(&date_time, false));
+    ASSERT_UINT_EQUALS(5, aws_date_time_minute(&date_time, false));
+    ASSERT_UINT_EQUALS(9, aws_date_time_second(&date_time, false));
+    ASSERT_UINT_EQUALS(505U, date_time.milliseconds);
 
     uint8_t date_output[AWS_DATE_TIME_STR_MAX_LEN];
     AWS_ZERO_ARRAY(date_output);
@@ -609,6 +622,7 @@ static int s_test_millis_parsing_fn(struct aws_allocator *allocator, void *ctx) 
 
     struct aws_date_time date_time;
 
+    /* Test milliseconds are zeroed. */
     aws_date_time_init_epoch_millis(&date_time, 1033545909000);
     ASSERT_INT_EQUALS(AWS_DATE_DAY_OF_WEEK_WEDNESDAY, aws_date_time_day_of_week(&date_time, false));
     ASSERT_UINT_EQUALS(2, aws_date_time_month_day(&date_time, false));
@@ -617,6 +631,18 @@ static int s_test_millis_parsing_fn(struct aws_allocator *allocator, void *ctx) 
     ASSERT_UINT_EQUALS(8, aws_date_time_hour(&date_time, false));
     ASSERT_UINT_EQUALS(5, aws_date_time_minute(&date_time, false));
     ASSERT_UINT_EQUALS(9, aws_date_time_second(&date_time, false));
+    ASSERT_UINT_EQUALS(0U, date_time.milliseconds);
+
+    /* Test milliseconds of `date_time` match the milliseconds from the 64-bit timestamp parameter. */
+    aws_date_time_init_epoch_millis(&date_time, 1033545909619);
+    ASSERT_INT_EQUALS(AWS_DATE_DAY_OF_WEEK_WEDNESDAY, aws_date_time_day_of_week(&date_time, false));
+    ASSERT_UINT_EQUALS(2, aws_date_time_month_day(&date_time, false));
+    ASSERT_UINT_EQUALS(AWS_DATE_MONTH_OCTOBER, aws_date_time_month(&date_time, false));
+    ASSERT_UINT_EQUALS(2002, aws_date_time_year(&date_time, false));
+    ASSERT_UINT_EQUALS(8, aws_date_time_hour(&date_time, false));
+    ASSERT_UINT_EQUALS(5, aws_date_time_minute(&date_time, false));
+    ASSERT_UINT_EQUALS(9, aws_date_time_second(&date_time, false));
+    ASSERT_UINT_EQUALS(619U, date_time.milliseconds);
 
     uint8_t date_output[AWS_DATE_TIME_STR_MAX_LEN];
     AWS_ZERO_ARRAY(date_output);


### PR DESCRIPTION
This adds a millisecond member to `aws_date_time` so that `aws_date_time_as_millis` and `aws_date_time_as_nanos` can return millisecond precision. The "init" functions are also updated appropriately to set the millisecond member.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
