### PR TITLE
Have aws_date_time_as_epoch_secs return milliseconds as the decimal

### DIFF
--- a/source/date_time.c
+++ b/source/date_time.c
@@ -749,7 +749,7 @@ int aws_date_time_to_utc_time_short_str(
 }
 
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt) {
-    return (double)dt->timestamp;
+    return (double)dt->timestamp + (double)(dt->milliseconds / 1000.0);
 }
 
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt) {


### PR DESCRIPTION
Forgot to update this function to include the milliseconds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
