### PR TITLE
Fixes specifications for aws_hash proofs

### DIFF
--- a/source/hash_table.c
+++ b/source/hash_table.c
@@ -1000,7 +1000,7 @@ bool aws_hash_callback_string_eq(const void *a, const void *b) {
     AWS_PRECONDITION(aws_string_is_valid(a));
     AWS_PRECONDITION(aws_string_is_valid(b));
     bool rval = aws_string_eq(a, b);
-    AWS_RETURN_WITH_POSTCONDITION(rval, aws_c_string_is_valid(a) && aws_c_string_is_valid(b));
+    AWS_RETURN_WITH_POSTCONDITION(rval, aws_string_is_valid(a) && aws_string_is_valid(b));
 }
 
 void aws_hash_callback_string_destroy(void *a) {

--- a/verification/cbmc/proofs/aws_hash_callback_string_destroy/aws_hash_callback_string_destroy_harness.c
+++ b/verification/cbmc/proofs/aws_hash_callback_string_destroy/aws_hash_callback_string_destroy_harness.c
@@ -11,7 +11,7 @@
 void aws_hash_callback_string_destroy_harness() {
     struct aws_string *str = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
 
-    __CPROVER_assume(aws_c_string_is_valid(str));
+    __CPROVER_assume(aws_string_is_valid(str));
 
     aws_hash_callback_string_destroy(str);
 }

--- a/verification/cbmc/proofs/aws_hash_callback_string_eq/aws_hash_callback_string_eq_harness.c
+++ b/verification/cbmc/proofs/aws_hash_callback_string_eq/aws_hash_callback_string_eq_harness.c
@@ -12,8 +12,8 @@ void aws_hash_callback_string_eq_harness() {
     const struct aws_string *str1 = nondet_allocate_string_bounded_length(MAX_STRING_LEN);
     const struct aws_string *str2 = nondet_bool() ? str1 : nondet_allocate_string_bounded_length(MAX_STRING_LEN);
 
-    __CPROVER_assume(aws_c_string_is_valid(str1));
-    __CPROVER_assume(aws_c_string_is_valid(str2));
+    __CPROVER_assume(aws_string_is_valid(str1));
+    __CPROVER_assume(aws_string_is_valid(str2));
 
     bool rval = aws_hash_callback_string_eq(str1, str2);
     if (rval) {

--- a/verification/cbmc/stubs/aws_hash_iter_overrides.c
+++ b/verification/cbmc/stubs/aws_hash_iter_overrides.c
@@ -86,5 +86,8 @@ void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents) {
     rval.slot = iter->slot;
     rval.limit = iter->limit - 1;
     rval.status = AWS_HASH_ITER_STATUS_DELETE_CALLED;
+    rval.map->p_impl->entry_count = iter->map->p_impl->entry_count;
+    if (rval.map->p_impl->entry_count)
+        rval.map->p_impl->entry_count--;
     *iter = rval;
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
1. Use the correct invariant for `aws_string`;
2. Fixes a bug in `hash_iter_delete` stub.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
