### PR TITLE
priority_queue.c: fix compile error with -Og

### DIFF
--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -100,7 +100,7 @@ static bool s_sift_up(struct aws_priority_queue *queue, size_t index) {
 
     bool did_move = false;
 
-    void *parent_item, *child_item;
+    void *parent_item = NULL, *child_item = NULL;
     size_t parent = PARENT_OF(index);
     while (index) {
         /*


### PR DESCRIPTION
It fails to compile with gcc option '-Og':

| aws-c-common/0.5.11-r0/git/source/priority_queue.c:116:13:
   error: 'parent_item' may be used uninitialized in this function [-Werror=maybe-uninitialized]
|   116 |         if (queue->pred(parent_item, child_item) > 0) {
|       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| cc1: all warnings being treated as errors

Initialize variables with NULL to fix the issue.

Signed-off-by: Kai Kang <kai.kang@windriver.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
