### PR TITLE
Fix x86/x64 AVX feature check

### DIFF
--- a/source/arch/intel/asm/cpuid.c
+++ b/source/arch/intel/asm/cpuid.c
@@ -5,7 +5,7 @@
 
 #include <aws/common/cpuid.h>
 
-void aws_run_cpuid(uint32_t eax, uint32_t ecx, uint32_t *abcd) {
+void aws_run_cpuid_impl(uint32_t eax, uint32_t ecx, uint32_t *abcd) {
     uint32_t ebx = 0;
     uint32_t edx = 0;
 

--- a/source/arch/intel/msvc/cpuid.c
+++ b/source/arch/intel/msvc/cpuid.c
@@ -7,6 +7,6 @@
 
 #include <intrin.h>
 
-void aws_run_cpuid(uint32_t eax, uint32_t ecx, uint32_t *abcd) {
+void aws_run_cpuid_impl(uint32_t eax, uint32_t ecx, uint32_t *abcd) {
     __cpuidex((int32_t *)abcd, eax, ecx);
 }


### PR DESCRIPTION
Issue: Crash on an old processor, due to mistakenly believing an old processor supported AVX2 instructions.

Fix: Before checking features via the CPUID instruction, query the max supported feature_id (aka EAX, aka leaf).

Caveats: Haven't tested this yet on hardware that exhibits the crash, but the bounds-check seems reasonable. My evidence is:
- I tried running CPUID on some older CPUs and did observe that if you queried beyond their max supported feature_id, the results were sometimes non-zero.
    -  Tested on i5-2500k, it only supports querying up to feature_id 12. Querying feature_id 13 results in `0x00000007 0x00000340 0x00000340 0x00000000`
- This [wikipedia page](https://en.wikipedia.org/wiki/CPUID#Calling_CPUID) says "CPUID should be called with EAX = 0 first, as this will store in the EAX register the highest EAX calling parameter (leaf) that the CPU implements"
- Microsoft [sample code](https://docs.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?view=msvc-160#example) does a bounds check first.
- Intel [sample code](https://software.intel.com/content/dam/develop/external/us/en/documents/how-to-detect-new-instruction-support-in-the-4th-generation-intel-core-processor-family.pdf) that our feature checks are based on (search for "check_4th_gen_intel_core_features"). progressively checks features, and would not check for AVX2 before checking many lesser features.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
