### PR TITLE
Fix FAIL macro

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -84,9 +84,9 @@ static int total_failures;
         return FAILURE;                                                                                                \
     } while (0)
 
-#define FAIL(format, ...)                                                                                              \
+#define FAIL(...)                                                                                                      \
     do {                                                                                                               \
-        PRINT_FAIL_INTERNAL0(format, ##__VA_ARGS__);                                                                   \
+        PRINT_FAIL_INTERNAL0(__VA_ARGS__);                                                                             \
         POSTFAIL_INTERNAL();                                                                                           \
     } while (0)
 


### PR DESCRIPTION
In MSVC, the FAIL() macro from aws_test_harness.h didn't compile when there were no additional args after the format string

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
