### PR TITLE
Disable CPU extensions on mingw64 builds on Windows

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -6,6 +6,14 @@ include(AwsCFlags)
 
 option(USE_CPU_EXTENSIONS "Whenever possible, use functions optimized for CPUs with specific extensions (ex: SSE, AVX)." ON)
 
+# In the current (11/2/21) state of mingw64, the packaged gcc is not capable of emitting properly aligned avx2 instructions under certain circumstances.
+# This leads to crashes for windows builds using mingw64 when invoking the avx2-enabled versions of certain functions.  Until we can find a better 
+# work-around (in theory that inline nature of encode_stride should address this, but it doesn't in practice), disable avx2 (and all other extensions) in mingw builds.
+if (MINGW)
+    message(STATUS "MINGW detected!  Disabling avx2 and other CPU extensions");
+    set(USE_CPU_EXTENSIONS OFF)
+endif()
+
 if(NOT CMAKE_CROSSCOMPILING)
     check_c_source_runs("
     #include <stdbool.h>

--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -9,6 +9,9 @@ option(USE_CPU_EXTENSIONS "Whenever possible, use functions optimized for CPUs w
 # In the current (11/2/21) state of mingw64, the packaged gcc is not capable of emitting properly aligned avx2 instructions under certain circumstances.
 # This leads to crashes for windows builds using mingw64 when invoking the avx2-enabled versions of certain functions.  Until we can find a better 
 # work-around (in theory that inline nature of encode_stride should address this, but it doesn't in practice), disable avx2 (and all other extensions) in mingw builds.
+#
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
+#
 if (MINGW)
     message(STATUS "MINGW detected!  Disabling avx2 and other CPU extensions");
     set(USE_CPU_EXTENSIONS OFF)

--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -8,7 +8,7 @@ option(USE_CPU_EXTENSIONS "Whenever possible, use functions optimized for CPUs w
 
 # In the current (11/2/21) state of mingw64, the packaged gcc is not capable of emitting properly aligned avx2 instructions under certain circumstances.
 # This leads to crashes for windows builds using mingw64 when invoking the avx2-enabled versions of certain functions.  Until we can find a better 
-# work-around (in theory that inline nature of encode_stride should address this, but it doesn't in practice), disable avx2 (and all other extensions) in mingw builds.
+# work-around, disable avx2 (and all other extensions) in mingw builds.
 #
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
 #

--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -13,7 +13,7 @@ option(USE_CPU_EXTENSIONS "Whenever possible, use functions optimized for CPUs w
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
 #
 if (MINGW)
-    message(STATUS "MINGW detected!  Disabling avx2 and other CPU extensions");
+    message(STATUS "MINGW detected!  Disabling avx2 and other CPU extensions")
     set(USE_CPU_EXTENSIONS OFF)
 endif()
 


### PR DESCRIPTION
Outstanding gcc bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412) can generate misaligned avx2 instructions (not 32 bit aligned) under certain circumstances.  Let's disable arch-specific code in that case until a better solution presents itself.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
