### PR TITLE
Remove aws_ring_buffer_allocator_init declaration from public header

### DIFF
--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -92,12 +92,6 @@ AWS_COMMON_API bool aws_ring_buffer_buf_belongs_to_pool(
     const struct aws_byte_buf *buf);
 
 /**
- * Initializes the supplied allocator to be based on the provided ring buffer. Allocations must be allocated
- * and freed in the same order, or the ring buffer will assert.
- */
-AWS_COMMON_API int aws_ring_buffer_allocator_init(struct aws_allocator *allocator, struct aws_ring_buffer *ring_buffer);
-
-/**
  * Cleans up a ring buffer allocator instance. Does not clean up the ring buffer.
  */
 AWS_COMMON_API void aws_ring_buffer_allocator_clean_up(struct aws_allocator *allocator);


### PR DESCRIPTION
Make header not lie about the existence of `aws_ring_buffer_allocator_init` implementation.

I tried to call this API in my function but got an unresolved symbol.

```
 nm -gC crt/aws-c-common/libaws-c-common.a | grep aws_ring_buffer_
00000000000043be T aws_ring_buffer_check_atomic_ptr
00000000000043fe T aws_ring_buffer_is_empty
000000000000443f T aws_ring_buffer_is_valid
00000000000003d3 T aws_ring_buffer_acquire
000000000000095e T aws_ring_buffer_acquire_up_to
0000000000001363 T aws_ring_buffer_buf_belongs_to_pool
000000000000035c T aws_ring_buffer_clean_up
0000000000000216 T aws_ring_buffer_init
000000000000125b T aws_ring_buffer_release
```

And it's not there... looks like the implementation was recently removed but the declaration in the public header is still there.  This PR removes it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
