### PR TITLE
Use `NULL` in place of `malloc(0)` in CBMC `byte_buf` proofs

### DIFF
--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -20,7 +20,7 @@ bool aws_byte_buf_has_allocator(const struct aws_byte_buf *const buf) {
 void ensure_byte_buf_has_allocated_buffer_member(struct aws_byte_buf *const buf) {
     if (buf) {
         buf->allocator = (nondet_bool()) ? NULL : aws_default_allocator();
-        buf->buffer = malloc(sizeof(*(buf->buffer)) * buf->capacity);
+        buf->buffer = (buf->capacity == 0) ? NULL : malloc(sizeof(*(buf->buffer)) * buf->capacity);
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This PR avoids a `malloc(0)` call, which is implementation defined per C standard, and uses `NULL` in place of it.

Moreover, this change also makes the proof allocator identical to the code allocator:
https://github.com/awslabs/aws-c-common/blob/3b373b5095c543840a76be0053f2fc1f8326f030/source/byte_buf.c#L21

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
