### PR TITLE
Add aws_byte_cursor_parse_uint64

### DIFF
--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -901,7 +901,7 @@ AWS_COMMON_API bool aws_isspace(uint8_t ch);
  * "999999999999999999999999999999999999999999" // larger than max u64
  */
 AWS_COMMON_API
-int aws_byte_cursor_parse_uint64(struct aws_byte_cursor cursor, uint64_t *dst);
+int aws_byte_cursor_utf8_parse_u64(struct aws_byte_cursor cursor, uint64_t *dst);
 
 /**
  * Read entire cursor as ASCII/UTF-8 unsigned base-16 number with NO "0x" prefix.
@@ -920,7 +920,7 @@ int aws_byte_cursor_parse_uint64(struct aws_byte_cursor cursor, uint64_t *dst);
  * "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" // larger than max u64
  */
 AWS_COMMON_API
-int aws_byte_cursor_parse_uint64_hex(struct aws_byte_cursor cursor, uint64_t *dst);
+int aws_byte_cursor_utf8_parse_u64_hex(struct aws_byte_cursor cursor, uint64_t *dst);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/common/byte_buf.h
+++ b/include/aws/common/byte_buf.h
@@ -882,6 +882,46 @@ AWS_COMMON_API bool aws_isxdigit(uint8_t ch);
  */
 AWS_COMMON_API bool aws_isspace(uint8_t ch);
 
+/**
+ * Read entire cursor as ASCII/UTF-8 unsigned base-10 number.
+ * Stricter than strtoull(), which allows whitespace and inputs that start with "0x"
+ *
+ * Examples:
+ * "0" -> 0
+ * "123" -> 123
+ * "00004" -> 4 // leading zeros ok
+ *
+ * Rejects things like:
+ * "-1" // negative numbers not allowed
+ * "1,000" // only characters 0-9 allowed
+ * "" // blank string not allowed
+ * " 0 " // whitespace not allowed
+ * "0x0" // hex not allowed
+ * "FF" // hex not allowed
+ * "999999999999999999999999999999999999999999" // larger than max u64
+ */
+AWS_COMMON_API
+int aws_byte_cursor_parse_uint64(struct aws_byte_cursor cursor, uint64_t *dst);
+
+/**
+ * Read entire cursor as ASCII/UTF-8 unsigned base-16 number with NO "0x" prefix.
+ *
+ * Examples:
+ * "F" -> 15
+ * "000000ff" -> 255 // leading zeros ok
+ * "Ff" -> 255 // mixed case ok
+ * "123" -> 291
+ * "FFFFFFFFFFFFFFFF" -> 18446744073709551616 // max u64
+ *
+ * Rejects things like:
+ * "0x0" // 0x prefix not allowed
+ * "" // blank string not allowed
+ * " F " // whitespace not allowed
+ * "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" // larger than max u64
+ */
+AWS_COMMON_API
+int aws_byte_cursor_parse_uint64_hex(struct aws_byte_cursor cursor, uint64_t *dst);
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_BYTE_BUF_H */

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -1652,15 +1652,11 @@ static int s_read_unsigned(struct aws_byte_cursor cursor, uint64_t *dst, uint8_t
             return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         }
 
-        const uint64_t prev_val = val;
-
-        val *= base;
-        if (val < prev_val) {
+        if (aws_mul_u64_checked(val, base, &val)) {
             return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
         }
 
-        val += cval;
-        if (val < prev_val) {
+        if (aws_add_u64_checked(val, cval, &val)) {
             return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
         }
     }

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -1665,10 +1665,10 @@ static int s_read_unsigned(struct aws_byte_cursor cursor, uint64_t *dst, uint8_t
     return AWS_OP_SUCCESS;
 }
 
-int aws_byte_cursor_parse_uint64(struct aws_byte_cursor cursor, uint64_t *dst) {
+int aws_byte_cursor_utf8_parse_u64(struct aws_byte_cursor cursor, uint64_t *dst) {
     return s_read_unsigned(cursor, dst, 10 /*base*/);
 }
 
-int aws_byte_cursor_parse_uint64_hex(struct aws_byte_cursor cursor, uint64_t *dst) {
+int aws_byte_cursor_utf8_parse_u64_hex(struct aws_byte_cursor cursor, uint64_t *dst) {
     return s_read_unsigned(cursor, dst, 16 /*base*/);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -282,6 +282,8 @@ add_test_case(test_isalpha)
 add_test_case(test_isdigit)
 add_test_case(test_isxdigit)
 add_test_case(test_isspace)
+add_test_case(test_byte_cursor_parse_uint64)
+add_test_case(test_byte_cursor_parse_uint64_hex)
 
 add_test_case(byte_swap_test)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -282,8 +282,8 @@ add_test_case(test_isalpha)
 add_test_case(test_isdigit)
 add_test_case(test_isxdigit)
 add_test_case(test_isspace)
-add_test_case(test_byte_cursor_parse_uint64)
-add_test_case(test_byte_cursor_parse_uint64_hex)
+add_test_case(test_byte_cursor_utf8_parse_u64)
+add_test_case(test_byte_cursor_utf8_parse_u64_hex)
 
 add_test_case(byte_swap_test)
 

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -1120,3 +1120,96 @@ static int s_test_isspace(struct aws_allocator *allocator, void *ctx) {
     return 0;
 }
 AWS_TEST_CASE(test_isspace, s_test_isspace)
+
+AWS_TEST_CASE(test_byte_cursor_parse_uint64, s_byte_cursor_parse_uint64);
+static int s_byte_cursor_parse_uint64(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    uint64_t val;
+
+    /* sanity check */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0"), &val));
+    ASSERT_UINT_EQUALS(0, val);
+
+    /* every acceptable character */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("9876543210"), &val));
+    ASSERT_UINT_EQUALS(9876543210, val);
+
+    /* max value */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("18446744073709551615"), &val));
+    ASSERT_UINT_EQUALS(UINT64_MAX, val);
+
+    /* leading zeros should have no effect */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("00000000000018446744073709551615"), &val));
+    ASSERT_UINT_EQUALS(UINT64_MAX, val);
+
+    /* one bigger than max */
+    ASSERT_ERROR(
+        AWS_ERROR_OVERFLOW_DETECTED,
+        aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("18446744073709551616"), &val));
+
+    /* overflow on base multiply */
+    ASSERT_ERROR(
+        AWS_ERROR_OVERFLOW_DETECTED,
+        aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("184467440737095516150"), &val));
+
+    /* whitespace is not ok */
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str(" 0"), &val));
+
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0 "), &val));
+
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0 0"), &val));
+
+    /* blank strings are not ok */
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str(""), &val));
+
+    /* hex is not ok */
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0x0"), &val));
+
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("FF"), &val));
+
+    return 0;
+}
+
+AWS_TEST_CASE(test_byte_cursor_parse_uint64_hex, s_byte_cursor_parse_uint64_hex);
+static int s_byte_cursor_parse_uint64_hex(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
+    (void)ctx;
+
+    uint64_t val;
+
+    /* sanity check */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("0"), &val));
+    ASSERT_UINT_EQUALS(0x0, val);
+
+    /* every possible character */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("9876543210"), &val));
+    ASSERT_UINT_EQUALS(0x9876543210, val);
+
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("ABCDEFabcdef"), &val));
+    ASSERT_UINT_EQUALS(0xABCDEFabcdefULL, val);
+
+    /* max value */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("ffffffffffffffff"), &val));
+    ASSERT_UINT_EQUALS(UINT64_MAX, val);
+
+    /* ignore leading zeroes */
+    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("0000000000000000ffffffffffffffff"), &val));
+    ASSERT_UINT_EQUALS(UINT64_MAX, val);
+
+    /* overflow */
+    ASSERT_ERROR(
+        AWS_ERROR_OVERFLOW_DETECTED,
+        aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("10000000000000000"), &val));
+
+    /* overflow - regression test */
+    ASSERT_ERROR(
+        AWS_ERROR_OVERFLOW_DETECTED,
+        aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("fffffffffffffffff"), &val));
+
+    /* invalid character */
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("g"), &val));
+
+    return 0;
+}

--- a/tests/byte_buf_test.c
+++ b/tests/byte_buf_test.c
@@ -1121,58 +1121,59 @@ static int s_test_isspace(struct aws_allocator *allocator, void *ctx) {
 }
 AWS_TEST_CASE(test_isspace, s_test_isspace)
 
-AWS_TEST_CASE(test_byte_cursor_parse_uint64, s_byte_cursor_parse_uint64);
-static int s_byte_cursor_parse_uint64(struct aws_allocator *allocator, void *ctx) {
+AWS_TEST_CASE(test_byte_cursor_utf8_parse_u64, s_byte_cursor_utf8_parse_u64);
+static int s_byte_cursor_utf8_parse_u64(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
 
     uint64_t val;
 
     /* sanity check */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("0"), &val));
     ASSERT_UINT_EQUALS(0, val);
 
     /* every acceptable character */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("9876543210"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("9876543210"), &val));
     ASSERT_UINT_EQUALS(9876543210, val);
 
     /* max value */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("18446744073709551615"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("18446744073709551615"), &val));
     ASSERT_UINT_EQUALS(UINT64_MAX, val);
 
     /* leading zeros should have no effect */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("00000000000018446744073709551615"), &val));
+    ASSERT_SUCCESS(
+        aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("00000000000018446744073709551615"), &val));
     ASSERT_UINT_EQUALS(UINT64_MAX, val);
 
     /* one bigger than max */
     ASSERT_ERROR(
         AWS_ERROR_OVERFLOW_DETECTED,
-        aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("18446744073709551616"), &val));
+        aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("18446744073709551616"), &val));
 
     /* overflow on base multiply */
     ASSERT_ERROR(
         AWS_ERROR_OVERFLOW_DETECTED,
-        aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("184467440737095516150"), &val));
+        aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("184467440737095516150"), &val));
 
     /* whitespace is not ok */
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str(" 0"), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str(" 0"), &val));
 
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0 "), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("0 "), &val));
 
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0 0"), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("0 0"), &val));
 
     /* blank strings are not ok */
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str(""), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str(""), &val));
 
     /* hex is not ok */
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("0x0"), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("0x0"), &val));
 
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64(aws_byte_cursor_from_c_str("FF"), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64(aws_byte_cursor_from_c_str("FF"), &val));
 
     return 0;
 }
 
-AWS_TEST_CASE(test_byte_cursor_parse_uint64_hex, s_byte_cursor_parse_uint64_hex);
+AWS_TEST_CASE(test_byte_cursor_utf8_parse_u64_hex, s_byte_cursor_parse_uint64_hex);
 static int s_byte_cursor_parse_uint64_hex(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     (void)ctx;
@@ -1180,36 +1181,37 @@ static int s_byte_cursor_parse_uint64_hex(struct aws_allocator *allocator, void 
     uint64_t val;
 
     /* sanity check */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("0"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("0"), &val));
     ASSERT_UINT_EQUALS(0x0, val);
 
     /* every possible character */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("9876543210"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("9876543210"), &val));
     ASSERT_UINT_EQUALS(0x9876543210, val);
 
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("ABCDEFabcdef"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("ABCDEFabcdef"), &val));
     ASSERT_UINT_EQUALS(0xABCDEFabcdefULL, val);
 
     /* max value */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("ffffffffffffffff"), &val));
+    ASSERT_SUCCESS(aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("ffffffffffffffff"), &val));
     ASSERT_UINT_EQUALS(UINT64_MAX, val);
 
     /* ignore leading zeroes */
-    ASSERT_SUCCESS(aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("0000000000000000ffffffffffffffff"), &val));
+    ASSERT_SUCCESS(
+        aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("0000000000000000ffffffffffffffff"), &val));
     ASSERT_UINT_EQUALS(UINT64_MAX, val);
 
     /* overflow */
     ASSERT_ERROR(
         AWS_ERROR_OVERFLOW_DETECTED,
-        aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("10000000000000000"), &val));
+        aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("10000000000000000"), &val));
 
     /* overflow - regression test */
     ASSERT_ERROR(
         AWS_ERROR_OVERFLOW_DETECTED,
-        aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("fffffffffffffffff"), &val));
+        aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("fffffffffffffffff"), &val));
 
     /* invalid character */
-    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_parse_uint64_hex(aws_byte_cursor_from_c_str("g"), &val));
+    ASSERT_ERROR(AWS_ERROR_INVALID_ARGUMENT, aws_byte_cursor_utf8_parse_u64_hex(aws_byte_cursor_from_c_str("g"), &val));
 
     return 0;
 }


### PR DESCRIPTION
The `aws_strutil_read_unsigned_num` function is defined in the `/include/private` folder of `aws-c-http`:

https://github.com/awslabs/aws-c-http/blob/main/include/aws/http/private/strutil.h#L12-L31

We also need the same functionality in `aws-c-s3`.

This commit is the first step of the following refactor:

* Move the `aws_strutil_read_unsigned_num` function to `aws-c-common` (renamed to `aws_byte_cursor_parse_uint64`)
* Delete the function definition in `aws-c-http` and the corresponding copy `aws_s3_strutil_read_unsigned_num` in `aws-c-s3`
* fix callers of the function in `aws-c-http` and `aws-c-s3` so they use the version from `aws-c-common`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
