### PR TITLE
Append pthread to platform libs if cmake supplied Threads is not good enough

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,15 @@ else ()
 
     if (UNIX OR APPLE)
         find_package(Threads REQUIRED)
-    endif ()
+
+        if (NOT ANDROID AND NOT CMAKE_THREAD_LIBS_INIT)
+            check_symbol_exists(pthread_mutexattr_init "<pthread.h>" HAVE_PTHREAD_MUTEXATTR_INIT)
+            if (NOT HAVE_PTHREAD_MUTEXATTR_INIT)
+                # fsanitize=... results in GLIBC library to provide some pthread APIs but not all
+                list(APPEND PLATFORM_LIBS pthread)
+            endif()
+        endif()
+    endif()
 
     if (APPLE)
         # Don't add the exact path to CoreFoundation as this would hardcode the SDK version


### PR DESCRIPTION
*Issue #, if available:*
*original PR created from a fork branch: [895](https://github.com/awslabs/aws-c-common/pull/895)*
aws-c-common has an explicit dependency on pthread's pthread_mutexattr_settype [here in mutex.c ](https://github.com/awslabs/aws-c-common/blob/057746b2e094f4b7a31743d8ba5a9fd0155f69f3/source/posix/mutex.c#L26).
However, aws-c-common cmake script does not instruct cmake to *explicitly* link with pthread.

Appending fsanitize=address to CMAKE_CXX_FLAGS results in GLIBC library to provide ***some*** pthread API but not all. Therefore, `find_package(Threads REQUIRED)` starts to "find" fake pthread APIs in GLIBC and stops to set `CMAKE_THREAD_LIBS_INIT` (which is typically expected to contain Threads lib implementation (which is typically pthread)). In addition, if user sets OpenSSL as a crypto lib implementation, aws-lc is not being built too (aws-lc has a hard set lining dependency on pthread, aws-lc hides the issue being described/fixed in this pull request).

The end result is that aws-c-common fails to link (in case of fsanitize= and OpenSSL crypto) because pthread_mutexattr_settype symbol is not found.

*Description of changes:*
Link explicitly with pthread unless cmake found Threads library provides necessary symbol (i.e. still provide user with a theoretical ability to use custom Threads lib).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
