### PR TITLE
fix: #902 Do not set -moutline-atomics flag under iOS arm64

### DIFF
--- a/cmake/AwsCFlags.cmake
+++ b/cmake/AwsCFlags.cmake
@@ -123,7 +123,7 @@ function(aws_set_common_properties target)
        # -moutline-atomics generates code for both older load/store exclusive atomics and also
        # Arm's Large System Extensions (LSE) which scale substantially better on large core count systems
         check_c_compiler_flag("-moutline-atomics -Werror" HAS_MOUTLINE_ATOMICS)
-        if (HAS_MOUTLINE_ATOMICS AND AWS_ARCH_ARM64)
+        if (HAS_MOUTLINE_ATOMICS AND AWS_ARCH_ARM64 AND NOT IOS)
             list(APPEND AWS_C_FLAGS -moutline-atomics)
         endif()
 


### PR DESCRIPTION
Signed-off-by: 邓佳佳 <dengjiajia@corp.netease.com>

*Issue #902, if available:*

*Description of changes:*
Added `NOT IOS` to solve link errors under iOS arm64

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
