### PR TITLE
Add check for if_link.h

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -7,7 +7,7 @@ include(AwsCFlags)
 option(USE_CPU_EXTENSIONS "Whenever possible, use functions optimized for CPUs with specific extensions (ex: SSE, AVX)." ON)
 
 # In the current (11/2/21) state of mingw64, the packaged gcc is not capable of emitting properly aligned avx2 instructions under certain circumstances.
-# This leads to crashes for windows builds using mingw64 when invoking the avx2-enabled versions of certain functions.  Until we can find a better 
+# This leads to crashes for windows builds using mingw64 when invoking the avx2-enabled versions of certain functions.  Until we can find a better
 # work-around, disable avx2 (and all other extensions) in mingw builds.
 #
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
@@ -106,3 +106,9 @@ if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
         return 0;
     }" AWS_HAVE_EXECINFO)
 endif()
+
+check_c_source_compiles("
+#include <linux/if_link.h>
+int main() {
+    return 1;
+}" AWS_HAVE_LINUX_IF_LINK_H)

--- a/include/aws/common/config.h.in
+++ b/include/aws/common/config.h.in
@@ -18,5 +18,6 @@
 #cmakedefine AWS_HAVE_POSIX_LARGE_FILE_SUPPORT
 #cmakedefine AWS_HAVE_EXECINFO
 #cmakedefine AWS_HAVE_WINAPI_DESKTOP
+#cmakedefine AWS_HAVE_LINUX_IF_LINK_H
 
 #endif


### PR DESCRIPTION
*Description of changes:*

Adds a feature test to check for the existence of `if_link.h`. This is needed because we need to not include this header on some operating systems in `aws-c-iot`, like RHEL5, which currently are not working due to this header being included/used.

Needed for this PR: https://github.com/awslabs/aws-c-iot/pull/70

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
