### PR TITLE
Adjust logging function to fix segfault if filename and file are not set

### DIFF
--- a/include/aws/common/logging.h
+++ b/include/aws/common/logging.h
@@ -314,6 +314,7 @@ extern struct aws_logger_vtable g_pipeline_logger_owned_vtable;
 /*
  * Initializes a logger that does not perform any allocation during logging.  Log lines larger than the internal
  * constant are truncated.  Formatting matches the standard logger.  Used for memory tracing logging.
+ * If no file or filename is set in the aws_logger_standard_options, then it will use stderr.
  */
 AWS_COMMON_API
 int aws_logger_init_noalloc(

--- a/source/logging.c
+++ b/source/logging.c
@@ -547,8 +547,16 @@ int aws_logger_init_noalloc(
         impl->file = options->file;
         impl->should_close = false;
     } else { /* _MSC_VER */
-        impl->file = aws_fopen(options->filename, "w");
-        impl->should_close = true;
+        if (options->filename != NULL) {
+            impl->file = aws_fopen(options->filename, "w");
+            impl->should_close = true;
+        } else {
+            impl->file = stderr;
+            impl->should_close = false;
+            AWS_LOGF_WARN(
+                AWS_ERROR_INVALID_FILE_HANDLE,
+                "No file or filename passed to aws_logger_init_noalloc. Using stderr...");
+        }
     }
 
     aws_mutex_init(&impl->lock);

--- a/source/logging.c
+++ b/source/logging.c
@@ -553,9 +553,6 @@ int aws_logger_init_noalloc(
         } else {
             impl->file = stderr;
             impl->should_close = false;
-            AWS_LOGF_WARN(
-                AWS_ERROR_INVALID_FILE_HANDLE,
-                "No file or filename passed to aws_logger_init_noalloc. Using stderr...");
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

Adjusted `aws_logger_init_noalloc` to no longer assume a file name has  been set. If no file or filename is set, it will now use `stderr` ~~and log a warning~~. This fixes an issue we are seeing in some testing.

Edit: Now it just defaults to `stderr`, as logging a warning was causing issues on Windows. I also updated the header to note that it will default to `stderr` if `filename` and `file` are both not set.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
