### PR TITLE
fix MSVC warning

### DIFF
--- a/tests/memtrace_test.c
+++ b/tests/memtrace_test.c
@@ -147,10 +147,16 @@ static int s_test_memtrace_stacks(struct aws_allocator *allocator, void *ctx) {
     char s_alloc_2_addr[32];
     char s_alloc_3_addr[32];
     char s_alloc_4_addr[32];
+#    if defined(_MSC_VER)
+#        pragma warning(push)
+#        pragma warning(disable : 4054) /* type cast function pointer to data pointer */
     snprintf(s_alloc_1_addr, AWS_ARRAY_SIZE(s_alloc_1_addr), "0x%tx", (uintptr_t)(void *)s_alloc_1);
     snprintf(s_alloc_2_addr, AWS_ARRAY_SIZE(s_alloc_2_addr), "0x%tx", (uintptr_t)(void *)s_alloc_2);
     snprintf(s_alloc_3_addr, AWS_ARRAY_SIZE(s_alloc_3_addr), "0x%tx", (uintptr_t)(void *)s_alloc_3);
     snprintf(s_alloc_4_addr, AWS_ARRAY_SIZE(s_alloc_4_addr), "0x%tx", (uintptr_t)(void *)s_alloc_4);
+#        pragma warning(pop)
+#    endif /* defined(_MSC_VER) */
+
     const char *log_buffer = (const char *)test_logger->log_buffer.buffer;
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_1") || strstr(log_buffer, s_alloc_1_addr));
     ASSERT_TRUE(strstr(log_buffer, "s_alloc_2") || strstr(log_buffer, s_alloc_2_addr));


### PR DESCRIPTION
this was only appearing on MSVC Debug builds, with BUILD_TESTING=ON

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
