### PR TITLE
Make sure file paths are not empty strings to avoid segfault on Windows

### DIFF
--- a/source/file.c
+++ b/source/file.c
@@ -12,6 +12,11 @@
 #include <errno.h>
 
 FILE *aws_fopen(const char *file_path, const char *mode) {
+    if (!file_path || strlen(file_path) == 0) {
+        AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to open file %s", file_path);
+        return NULL;
+    }
+
     struct aws_string *file_path_str = aws_string_new_from_c_str(aws_default_allocator(), file_path);
     struct aws_string *mode_str = aws_string_new_from_c_str(aws_default_allocator(), mode);
 
@@ -23,6 +28,11 @@ FILE *aws_fopen(const char *file_path, const char *mode) {
 }
 
 int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocator *alloc, const char *filename) {
+    if (!filename || strlen(filename) == 0) {
+        AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to open file %s", filename);
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
+
     AWS_ZERO_STRUCT(*out_buf);
     FILE *fp = aws_fopen(filename, "rb");
 

--- a/source/file.c
+++ b/source/file.c
@@ -28,10 +28,6 @@ FILE *aws_fopen(const char *file_path, const char *mode) {
 }
 
 int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocator *alloc, const char *filename) {
-    if (!filename || strlen(filename) == 0) {
-        AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to open file %s", filename);
-        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
-    }
 
     AWS_ZERO_STRUCT(*out_buf);
     FILE *fp = aws_fopen(filename, "rb");
@@ -76,6 +72,9 @@ int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocat
 
     AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to open file %s with errno %d", filename, errno);
 
+    if (errno == 0) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
     return aws_translate_and_raise_io_error(errno);
 }
 

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -141,6 +141,9 @@ int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
     if (s_is_string_empty(dir_path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
+    if (!aws_directory_exists(dir_path)) {
+        return AWS_OP_SUCCESS;
+    }
 
     int ret_val = AWS_OP_SUCCESS;
 

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -14,6 +14,10 @@
 #include <windows.h>
 
 FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string *mode) {
+    if (!file_path || aws_string_eq_c_str(file_path, "")) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
+
     struct aws_wstring *w_file_path = aws_string_convert_to_wstring(aws_default_allocator(), file_path);
     struct aws_wstring *w_mode = aws_string_convert_to_wstring(aws_default_allocator(), mode);
 
@@ -31,6 +35,9 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
 }
 
 struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct aws_wstring *path) {
+    if (!path || !aws_wstring_is_valid(path)) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
 
     wchar_t prefix[] = L"\\\\?\\";
     size_t prefix_size = sizeof(prefix);
@@ -56,6 +63,10 @@ struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct
 }
 
 int aws_directory_create(const struct aws_string *dir_path) {
+    if (!dir_path || aws_string_eq_c_str(dir_path, "")) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
+
     struct aws_wstring *w_dir_path = aws_string_convert_to_wstring(aws_default_allocator(), dir_path);
     struct aws_wstring *long_dir_path = s_to_long_path(aws_default_allocator(), w_dir_path);
     aws_wstring_destroy(w_dir_path);
@@ -84,6 +95,10 @@ int aws_directory_create(const struct aws_string *dir_path) {
 }
 
 bool aws_directory_exists(const struct aws_string *dir_path) {
+    if (!dir_path || aws_string_eq_c_str(dir_path, "")) {
+        return false;
+    }
+
     struct aws_wstring *w_dir_path = aws_string_convert_to_wstring(aws_default_allocator(), dir_path);
     struct aws_wstring *long_dir_path = s_to_long_path(aws_default_allocator(), w_dir_path);
     aws_wstring_destroy(w_dir_path);
@@ -158,6 +173,10 @@ int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
 }
 
 int aws_file_delete(const struct aws_string *file_path) {
+    if (!file_path || aws_string_eq_c_str(file_path, "")) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
+
     struct aws_wstring *w_file_path = aws_string_convert_to_wstring(aws_default_allocator(), file_path);
     struct aws_wstring *long_file_path = s_to_long_path(aws_default_allocator(), w_file_path);
     aws_wstring_destroy(w_file_path);
@@ -182,6 +201,10 @@ int aws_file_delete(const struct aws_string *file_path) {
 }
 
 int aws_directory_or_file_move(const struct aws_string *from, const struct aws_string *to) {
+    if (!from || aws_string_eq_c_str(from, "") || !to || aws_string_eq_c_str(to, "")) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
+
     struct aws_wstring *w_from_path = aws_string_convert_to_wstring(aws_default_allocator(), from);
     struct aws_wstring *long_from_path = s_to_long_path(aws_default_allocator(), w_from_path);
     aws_wstring_destroy(w_from_path);
@@ -216,6 +239,11 @@ int aws_directory_traverse(
     bool recursive,
     aws_on_directory_entry *on_entry,
     void *user_data) {
+
+    if (!path || aws_string_eq_c_str(path, "")) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+    }
+
     struct aws_wstring *w_path_wchar = aws_string_convert_to_wstring(allocator, path);
     struct aws_wstring *long_path_wchar = s_to_long_path(allocator, w_path_wchar);
     aws_wstring_destroy(w_path_wchar);
@@ -440,6 +468,10 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
 }
 
 bool aws_path_exists(const struct aws_string *path) {
+    if (!path || aws_string_eq_c_str(path, "")) {
+        return false;
+    }
+
     struct aws_wstring *wchar_path = aws_string_convert_to_wstring(aws_default_allocator(), path);
     bool ret_val = PathFileExistsW(aws_wstring_c_str(wchar_path)) == TRUE;
     aws_wstring_destroy(wchar_path);
@@ -455,6 +487,10 @@ int aws_fseek(FILE *file, int64_t offset, int whence) {
 }
 
 int aws_file_get_length(FILE *file, int64_t *length) {
+    if (file == NULL) {
+        return aws_raise_error(AWS_ERROR_INVALID_FILE_HANDLE);
+    }
+
     int fd = _fileno(file);
     if (fd == -1) {
         return aws_raise_error(AWS_ERROR_INVALID_FILE_HANDLE);

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -13,8 +13,16 @@
 #include <stdio.h>
 #include <windows.h>
 
+static bool s_is_string_non_empty(const struct aws_string *str) {
+    return str != NULL && str->len > 0;
+}
+
+static bool s_is_wstring_non_empty(const struct aws_wstring *str) {
+    return str != NULL && str->len > 0;
+}
+
 FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string *mode) {
-    if (!file_path || aws_string_eq_c_str(file_path, "")) {
+    if (!s_is_string_non_empty(file_path) || !s_is_string_non_empty(mode)) {
         return NULL;
     }
 
@@ -35,7 +43,7 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
 }
 
 struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct aws_wstring *path) {
-    if (!path || !aws_wstring_is_valid(path)) {
+    if (!s_is_wstring_non_empty(path)) {
         return NULL;
     }
 
@@ -63,7 +71,7 @@ struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct
 }
 
 int aws_directory_create(const struct aws_string *dir_path) {
-    if (!dir_path || aws_string_eq_c_str(dir_path, "")) {
+    if (!s_is_string_non_empty(dir_path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -95,7 +103,7 @@ int aws_directory_create(const struct aws_string *dir_path) {
 }
 
 bool aws_directory_exists(const struct aws_string *dir_path) {
-    if (!dir_path || aws_string_eq_c_str(dir_path, "")) {
+    if (!s_is_string_non_empty(dir_path)) {
         return false;
     }
 
@@ -130,8 +138,8 @@ static bool s_delete_file_or_directory(const struct aws_directory_entry *entry, 
 }
 
 int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
-    if (!aws_directory_exists(dir_path)) {
-        return AWS_OP_SUCCESS;
+    if (!s_is_string_non_empty(dir_path)) {
+        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
     int ret_val = AWS_OP_SUCCESS;
@@ -173,7 +181,7 @@ int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
 }
 
 int aws_file_delete(const struct aws_string *file_path) {
-    if (!file_path || aws_string_eq_c_str(file_path, "")) {
+    if (!s_is_string_non_empty(file_path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -201,7 +209,7 @@ int aws_file_delete(const struct aws_string *file_path) {
 }
 
 int aws_directory_or_file_move(const struct aws_string *from, const struct aws_string *to) {
-    if (!from || aws_string_eq_c_str(from, "") || !to || aws_string_eq_c_str(to, "")) {
+    if (!s_is_string_non_empty(from) || !s_is_string_non_empty(to)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -240,7 +248,7 @@ int aws_directory_traverse(
     aws_on_directory_entry *on_entry,
     void *user_data) {
 
-    if (!path || aws_string_eq_c_str(path, "")) {
+    if (!s_is_string_non_empty(path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -468,7 +476,7 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
 }
 
 bool aws_path_exists(const struct aws_string *path) {
-    if (!path || aws_string_eq_c_str(path, "")) {
+    if (!s_is_string_non_empty(path)) {
         return false;
     }
 

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -15,7 +15,7 @@
 
 FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string *mode) {
     if (!file_path || aws_string_eq_c_str(file_path, "")) {
-        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+        return NULL;
     }
 
     struct aws_wstring *w_file_path = aws_string_convert_to_wstring(aws_default_allocator(), file_path);
@@ -36,7 +36,7 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
 
 struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct aws_wstring *path) {
     if (!path || !aws_wstring_is_valid(path)) {
-        return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
+        return NULL;
     }
 
     wchar_t prefix[] = L"\\\\?\\";

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -13,16 +13,16 @@
 #include <stdio.h>
 #include <windows.h>
 
-static bool s_is_string_non_empty(const struct aws_string *str) {
-    return str != NULL && str->len > 0;
+static bool s_is_string_empty(const struct aws_string *str) {
+    return str == NULL || str->len == 0;
 }
 
-static bool s_is_wstring_non_empty(const struct aws_wstring *str) {
-    return str != NULL && str->len > 0;
+static bool s_is_wstring_empty(const struct aws_wstring *str) {
+    return str == NULL || str->len == 0;
 }
 
 FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string *mode) {
-    if (!s_is_string_non_empty(file_path) || !s_is_string_non_empty(mode)) {
+    if (s_is_string_empty(file_path) || s_is_string_empty(mode)) {
         return NULL;
     }
 
@@ -43,7 +43,7 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
 }
 
 struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct aws_wstring *path) {
-    if (!s_is_wstring_non_empty(path)) {
+    if (s_is_wstring_empty(path)) {
         return NULL;
     }
 
@@ -71,7 +71,7 @@ struct aws_wstring *s_to_long_path(struct aws_allocator *allocator, const struct
 }
 
 int aws_directory_create(const struct aws_string *dir_path) {
-    if (!s_is_string_non_empty(dir_path)) {
+    if (s_is_string_empty(dir_path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -103,7 +103,7 @@ int aws_directory_create(const struct aws_string *dir_path) {
 }
 
 bool aws_directory_exists(const struct aws_string *dir_path) {
-    if (!s_is_string_non_empty(dir_path)) {
+    if (s_is_string_empty(dir_path)) {
         return false;
     }
 
@@ -138,7 +138,7 @@ static bool s_delete_file_or_directory(const struct aws_directory_entry *entry, 
 }
 
 int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
-    if (!s_is_string_non_empty(dir_path)) {
+    if (s_is_string_empty(dir_path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -181,7 +181,7 @@ int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
 }
 
 int aws_file_delete(const struct aws_string *file_path) {
-    if (!s_is_string_non_empty(file_path)) {
+    if (s_is_string_empty(file_path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -209,7 +209,7 @@ int aws_file_delete(const struct aws_string *file_path) {
 }
 
 int aws_directory_or_file_move(const struct aws_string *from, const struct aws_string *to) {
-    if (!s_is_string_non_empty(from) || !s_is_string_non_empty(to)) {
+    if (s_is_string_empty(from) || s_is_string_empty(to)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -248,7 +248,7 @@ int aws_directory_traverse(
     aws_on_directory_entry *on_entry,
     void *user_data) {
 
-    if (!s_is_string_non_empty(path)) {
+    if (s_is_string_empty(path)) {
         return aws_raise_error(AWS_ERROR_FILE_INVALID_PATH);
     }
 
@@ -476,7 +476,7 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
 }
 
 bool aws_path_exists(const struct aws_string *path) {
-    if (!s_is_string_non_empty(path)) {
+    if (s_is_string_empty(path)) {
         return false;
     }
 


### PR DESCRIPTION
*Description of changes:*

Adds some conditions to check to make sure empty strings are not processed if they are passed to file operating functions. This prevents segfaults on Java and C++ that occur if you pass an empty string for the key or certificate path when creating an MQTT client.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
