### PR TITLE
Remove 'NOT' from a conditional

### DIFF
--- a/format-check.sh
+++ b/format-check.sh
@@ -4,7 +4,7 @@ if [[ -z $CLANG_FORMAT ]] ; then
     CLANG_FORMAT=clang-format
 fi
 
-if NOT type $CLANG_FORMAT 2> /dev/null ; then
+if ! type $CLANG_FORMAT 2> /dev/null ; then
     echo "No appropriate clang-format found."
     exit 1
 fi


### PR DESCRIPTION
`NOT` is not a bash keyword.
The negation is done via '!'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
