### PR TITLE
hide json module init and cleanup

### DIFF
--- a/include/aws/common/json.h
+++ b/include/aws/common/json.h
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <aws/common/byte_buf.h>
 #include <aws/common/common.h>
 
 struct aws_json_value;
-struct aws_byte_buf;
 
 // ====================
 // Create and pass type

--- a/include/aws/common/json.h
+++ b/include/aws/common/json.h
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/common/byte_buf.h>
 #include <aws/common/common.h>
 
 struct aws_json_value;
+struct aws_byte_buf;
 
 // ====================
 // Create and pass type
@@ -267,19 +267,6 @@ bool aws_json_value_is_object(const struct aws_json_value *value);
 
 // ====================
 // Memory Management
-
-/**
- * Initializes the JSON module for use.
- * @param allocator The allocator to use for creating aws_json_value structs.
- */
-AWS_COMMON_API
-void aws_json_module_init(struct aws_allocator *allocator);
-
-/**
- * Cleans up the JSON module. Should be called when finished using the module.
- */
-AWS_COMMON_API
-void aws_json_module_cleanup(void);
 
 /**
  * Removes the aws_json_value from memory. If the aws_json_value is a object or array, it will also destroy

--- a/include/aws/common/private/json_impl.h
+++ b/include/aws/common/private/json_impl.h
@@ -1,5 +1,5 @@
-#ifndef AWS_COMMON_JSON_IMPL_H
-#define AWS_COMMON_JSON_IMPL_H
+#ifndef AWS_COMMON_PRIVATE_JSON_IMPL_H
+#define AWS_COMMON_PRIVATE_JSON_IMPL_H
 
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -19,4 +19,4 @@ void aws_json_module_init(struct aws_allocator *allocator);
  */
 void aws_json_module_cleanup(void);
 
-#endif // AWS_COMMON_JSON_IMPL_H
+#endif // AWS_COMMON_PRIVATE_JSON_IMPL_H

--- a/include/aws/common/private/json_impl.h
+++ b/include/aws/common/private/json_impl.h
@@ -1,0 +1,22 @@
+#ifndef AWS_COMMON_JSON_IMPL_H
+#define AWS_COMMON_JSON_IMPL_H
+
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/common/common.h>
+
+/**
+ * Initializes the JSON module for use.
+ * @param allocator The allocator to use for creating aws_json_value structs.
+ */
+void aws_json_module_init(struct aws_allocator *allocator);
+
+/**
+ * Cleans up the JSON module. Should be called when finished using the module.
+ */
+void aws_json_module_cleanup(void);
+
+#endif // AWS_COMMON_JSON_IMPL_H

--- a/source/common.c
+++ b/source/common.c
@@ -4,10 +4,10 @@
  */
 
 #include <aws/common/common.h>
-#include <aws/common/json.h>
 #include <aws/common/logging.h>
 #include <aws/common/math.h>
 #include <aws/common/private/dlloads.h>
+#include <aws/common/private/json_impl.h>
 #include <aws/common/private/thread_shared.h>
 
 #include <stdarg.h>

--- a/source/json.c
+++ b/source/json.c
@@ -7,6 +7,7 @@
 #include <aws/common/string.h>
 
 #include <aws/common/json.h>
+#include <aws/common/private/json_impl.h>
 
 #include <aws/common/external/cJSON.h>
 
@@ -280,7 +281,10 @@ static void s_aws_cJSON_free(void *ptr) {
 void aws_json_module_init(struct aws_allocator *allocator) {
     if (!s_aws_json_module_initialized) {
         s_aws_json_module_allocator = allocator;
-        struct cJSON_Hooks allocation_hooks = {.malloc_fn = s_aws_cJSON_alloc, .free_fn = s_aws_cJSON_free};
+        struct cJSON_Hooks allocation_hooks = {
+            .malloc_fn = s_aws_cJSON_alloc,
+            .free_fn = s_aws_cJSON_free,
+        };
         cJSON_InitHooks(&allocation_hooks);
         s_aws_json_module_initialized = true;
     }

--- a/tests/json_test.c
+++ b/tests/json_test.c
@@ -17,7 +17,7 @@ AWS_TEST_CASE(test_json_parse_from_string, s_test_json_parse_from_string)
 static int s_test_json_parse_from_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_json_module_init(allocator);
+    aws_common_library_init(allocator);
     struct aws_json_value *root = aws_json_value_new_from_string(allocator, aws_byte_cursor_from_c_str(s_test_json));
 
     ASSERT_NOT_NULL(root);
@@ -84,17 +84,16 @@ static int s_test_json_parse_from_string(struct aws_allocator *allocator, void *
     ASSERT_INT_EQUALS(aws_json_value_get_number(string_node, NULL), AWS_OP_ERR);
 
     aws_json_value_destroy(root);
-    aws_json_module_cleanup();
+    aws_common_library_clean_up();
 
-    return 0;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(test_json_parse_to_string, s_test_json_parse_to_string)
 static int s_test_json_parse_to_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_json_module_init(allocator);
-
+    aws_common_library_init(allocator);
     struct aws_json_value *root = aws_json_value_new_object(allocator);
 
     struct aws_json_value *array = aws_json_value_new_array(allocator);
@@ -103,9 +102,12 @@ static int s_test_json_parse_to_string(struct aws_allocator *allocator, void *ct
     aws_json_value_add_array_element(array, aws_json_value_new_number(allocator, 3));
     aws_json_value_add_to_object(root, aws_byte_cursor_from_c_str("array"), array);
 
-    aws_json_value_add_to_object(root, aws_byte_cursor_from_c_str("boolean"), aws_json_value_new_boolean(allocator, true));
     aws_json_value_add_to_object(
-        root, aws_byte_cursor_from_c_str("color"), aws_json_value_new_string(allocator, aws_byte_cursor_from_c_str("gold")));
+        root, aws_byte_cursor_from_c_str("boolean"), aws_json_value_new_boolean(allocator, true));
+    aws_json_value_add_to_object(
+        root,
+        aws_byte_cursor_from_c_str("color"),
+        aws_json_value_new_string(allocator, aws_byte_cursor_from_c_str("gold")));
     aws_json_value_add_to_object(root, aws_byte_cursor_from_c_str("null"), aws_json_value_new_null(allocator));
     aws_json_value_add_to_object(root, aws_byte_cursor_from_c_str("number"), aws_json_value_new_number(allocator, 123));
 
@@ -126,7 +128,7 @@ static int s_test_json_parse_to_string(struct aws_allocator *allocator, void *ct
     aws_string_destroy_secure(result_string);
 
     aws_json_value_destroy(root);
-    aws_json_module_cleanup();
+    aws_common_library_clean_up();
 
-    return 0;
+    return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
`aws_json_module_init` should only be called once and called with the lib initial, so, hide it from other lib.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
