### PR TITLE
Make libnuma linux only

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -294,7 +294,7 @@ void aws_common_library_init(struct aws_allocator *allocator) {
 
 /* NUMA is funky and we can't rely on libnuma.so being available. We also don't want to take a hard dependency on it,
  * try and load it if we can. */
-#if !defined(_WIN32) && !defined(WIN32)
+#ifdef AWS_OS_LINUX
         /* libnuma defines set_mempolicy() as a WEAK symbol. Loading into the global symbol table overwrites symbols and
            assumptions due to the way loaders and dlload are often implemented and those symbols are defined by things
            like libpthread.so on some unix distros. Sorry about the memory usage here, but it's our only safe choice.
@@ -361,7 +361,7 @@ void aws_common_library_clean_up(void) {
         aws_unregister_error_info(&s_list);
         aws_unregister_log_subject_info_list(&s_common_log_subject_list);
         aws_json_module_cleanup();
-#if !defined(_WIN32) && !defined(WIN32)
+#ifdef AWS_OS_LINUX
         if (g_libnuma_handle) {
             dlclose(g_libnuma_handle);
         }


### PR DESCRIPTION
*Issue #, if available:*

- `dlopen` will try to search current working directory for the share lib to load on [Mac](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html), which could lead to library hijacking
- it's not a issue for Linux according to [here](https://man7.org/linux/man-pages/man3/dlopen.3.html)

*Description of changes:*

- Make the load Linux only. 
- We can restore the libnuma usage for Mac later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
