### PR TITLE
Don't silently ignore sanitizers if requested but unavailable

### DIFF
--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -46,6 +46,11 @@ function(aws_add_sanitizers target)
     cmake_parse_arguments(SANITIZER "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     check_c_compiler_flag(-fsanitize= HAS_SANITIZERS)
+
+    if(NOT HAS_SANITIZERS AND ENABLE_SANITIZERS)
+        message(FATAL_ERROR "ENABLE_SANITIZERS is set but sanitizers are not available")
+    endif()
+
     if(HAS_SANITIZERS)
 
         list(APPEND SANITIZER_SANITIZERS ${SANITIZERS})


### PR DESCRIPTION
Right now, if you set ENABLE_SANITIZERS but they're not available for some reason, we keep chugging along as if nothing went wrong, except that your build/tests won't actually have the sanitizers you asked for. Because ENABLE_SANITIZERS is opt-in, we should instead fail loudly so we don't silently run without the sanitizers you asked for.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
