### PR TITLE
Verify backtrace is defined too, not just header presence

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -103,6 +103,7 @@ if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
     check_c_source_compiles("
     #include <execinfo.h>
     int main() {
+        backtrace(NULL, 0);
         return 0;
     }" AWS_HAVE_EXECINFO)
 endif()

--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -421,9 +421,9 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
     fprintf(fp, "No call stack information available\n");
 }
 
-size_t aws_backtrace(void **stack_frames, size_t size) {
+size_t aws_backtrace(void **stack_frames, size_t num_frames) {
     (void)stack_frames;
-    (void)size;
+    (void)num_frames;
     return 0;
 }
 

--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -158,8 +158,8 @@ static bool s_init_dbghelp() {
     return s_SymInitialize != NULL;
 }
 
-size_t aws_backtrace(void **stack_frames, size_t size) {
-    return (int)CaptureStackBackTrace(0, (ULONG)size, stack_frames, NULL);
+size_t aws_backtrace(void **stack_frames, size_t num_frames) {
+    return (int)CaptureStackBackTrace(0, (ULONG)num_frames, stack_frames, NULL);
 }
 
 char **aws_backtrace_symbols(void *const *stack_frames, size_t num_frames) {
@@ -273,9 +273,9 @@ void aws_backtrace_log(int log_level) {
     aws_mem_release(aws_default_allocator(), symbols);
 }
 #else /* !AWS_OS_WINDOWS_DESKTOP */
-size_t aws_backtrace(void **stack_frames, size_t size) {
+size_t aws_backtrace(void **stack_frames, size_t num_frames) {
     (void)stack_frames;
-    (void)size;
+    (void)num_frames;
     return 0;
 }
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth) {


### PR DESCRIPTION
* Adds additional requirements to the exec info check to also verify that backtrace() is actually available.  backtrace() is only available on android abi >= 33 but execinfo.h is present on earlier versions, leading to failures where we think backtrace() is available.
* clang-tidy issues where parameter name in declaration and definition differed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
