### PR TITLE
make aws_json_value_destroy noop on null values

### DIFF
--- a/source/json.c
+++ b/source/json.c
@@ -383,7 +383,7 @@ void aws_json_module_cleanup(void) {
 
 void aws_json_value_destroy(struct aws_json_value *value) {
     struct cJSON *cjson = (struct cJSON *)value;
-    if (!cJSON_IsInvalid(cjson)) {
+    if (cjson != NULL && !cJSON_IsInvalid(cjson)) {
         cJSON_Delete(cjson);
     }
 }

--- a/source/json.c
+++ b/source/json.c
@@ -383,6 +383,8 @@ void aws_json_module_cleanup(void) {
 
 void aws_json_value_destroy(struct aws_json_value *value) {
     struct cJSON *cjson = (struct cJSON *)value;
+    /* Note: cJSON_IsInvalid returns false for NULL values, so we need explicit
+        check for NULL to skip delete */
     if (cjson != NULL && !cJSON_IsInvalid(cjson)) {
         cJSON_Delete(cjson);
     }

--- a/tests/json_test.c
+++ b/tests/json_test.c
@@ -211,6 +211,10 @@ static int s_test_json_parse_from_string(struct aws_allocator *allocator, void *
     ASSERT_INT_EQUALS(aws_json_value_get_number(string_node, NULL), AWS_OP_ERR);
 
     aws_json_value_destroy(root);
+
+    //Make sure that destroying NULL does not have any bad effects.
+    aws_json_value_destroy(NULL);
+
     aws_common_library_clean_up();
 
     return AWS_OP_SUCCESS;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make destroying null json value a no-op

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
