### PR TITLE
sprintf() -> snprintf()

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,5 +15,5 @@ jobs:
       uses: DoozyX/clang-format-lint-action@v0.3.1
       with:
         # List of extensions to check
-        extensions: c,h
-        source: 'source include'
+        extensions: c,h,inl
+        source: 'source include tests verification'

--- a/source/uri.c
+++ b/source/uri.c
@@ -14,7 +14,6 @@
 #if _MSC_VER
 #    pragma warning(disable : 4221) /* aggregate initializer using local variable addresses */
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
-#    pragma warning(disable : 4996) /* sprintf */
 #endif
 
 enum parser_state {
@@ -143,7 +142,7 @@ int aws_uri_init_from_builder_options(
     if (options->port) {
         aws_byte_buf_append(&uri->uri_str, &port_app);
         char port_arr[6] = {0};
-        sprintf(port_arr, "%" PRIu16, options->port);
+        snprintf(port_arr, sizeof(port_arr), "%" PRIu16, options->port);
         struct aws_byte_cursor port_csr = aws_byte_cursor_from_c_str(port_arr);
         aws_byte_buf_append(&uri->uri_str, &port_csr);
     }

--- a/source/uuid.c
+++ b/source/uuid.c
@@ -23,6 +23,8 @@
 /* disables warning non const declared initializers for Microsoft compilers */
 #    pragma warning(disable : 4204)
 #    pragma warning(disable : 4706)
+/* sscanf warning */
+#    pragma warning(disable : 4996)
 #endif
 
 int aws_uuid_init(struct aws_uuid *uuid) {

--- a/source/uuid.c
+++ b/source/uuid.c
@@ -23,8 +23,6 @@
 /* disables warning non const declared initializers for Microsoft compilers */
 #    pragma warning(disable : 4204)
 #    pragma warning(disable : 4706)
-/* sprintf warning (we already check the bounds in this case). */
-#    pragma warning(disable : 4996)
 #endif
 
 int aws_uuid_init(struct aws_uuid *uuid) {
@@ -67,10 +65,12 @@ int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *
 }
 
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output) {
-    AWS_ERROR_PRECONDITION(output->capacity - output->len >= AWS_UUID_STR_LEN, AWS_ERROR_SHORT_BUFFER);
+    size_t space_remaining = output->capacity - output->len;
+    AWS_ERROR_PRECONDITION(space_remaining >= AWS_UUID_STR_LEN, AWS_ERROR_SHORT_BUFFER);
 
-    sprintf(
+    snprintf(
         (char *)(output->buffer + output->len),
+        space_remaining,
         UUID_FORMAT,
         uuid->uuid_data[0],
         uuid->uuid_data[1],

--- a/tests/json_test.c
+++ b/tests/json_test.c
@@ -212,7 +212,7 @@ static int s_test_json_parse_from_string(struct aws_allocator *allocator, void *
 
     aws_json_value_destroy(root);
 
-    //Make sure that destroying NULL does not have any bad effects.
+    // Make sure that destroying NULL does not have any bad effects.
     aws_json_value_destroy(NULL);
 
     aws_common_library_clean_up();

--- a/tests/logging/log_channel_test.c
+++ b/tests/logging/log_channel_test.c
@@ -89,8 +89,9 @@ static bool s_verify_mock_equal(
 
     size_t line_count = aws_array_list_length(&impl->log_lines);
     if (line_count != array_length) {
-        sprintf(
+        snprintf(
             s_test_error_message,
+            sizeof(s_test_error_message),
             "Expected %" PRIu64 " lines, but received %" PRIu64 "",
             (uint64_t)array_length,
             (uint64_t)line_count);
@@ -100,14 +101,15 @@ static bool s_verify_mock_equal(
     for (size_t i = 0; i < array_length; ++i) {
         struct aws_string *captured = NULL;
         if (aws_array_list_get_at(&impl->log_lines, &captured, i)) {
-            sprintf(s_test_error_message, "Unable to fetch log line from array list");
+            snprintf(s_test_error_message, sizeof(s_test_error_message), "Unable to fetch log line from array list");
             return false;
         }
 
         const struct aws_string *original = *(test_lines[i]);
         if (!aws_string_eq(original, captured)) {
-            sprintf(
+            snprintf(
                 s_test_error_message,
+                sizeof(s_test_error_message),
                 "Expected log line:\n%s\nbut received log line:\n%s",
                 (char *)original->bytes,
                 (char *)captured->bytes);
@@ -144,7 +146,7 @@ static int s_do_channel_test(
         struct aws_string *test_line_copy = aws_string_new_from_string(log_channel.allocator, *(test_lines[i]));
 
         if ((log_channel.vtable->send)(&log_channel, test_line_copy)) {
-            sprintf(s_test_error_message, "Failed call to log channel send");
+            snprintf(s_test_error_message, sizeof(s_test_error_message), "Failed call to log channel send");
             result = AWS_OP_ERR;
         }
 


### PR DESCRIPTION
Issue: Today my Mac started issuing warnings about sprintf().
Changes: Use snprintf() instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
