### PR TITLE
aws_secure_zero: handle NULL pointer argument

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -38,6 +38,9 @@ int (*g_numa_node_of_cpu_ptr)(int cpu) = NULL;
 void *g_libnuma_handle = NULL;
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
+    if (pBuf == NULL || bufsize == 0) {
+        return;
+    }
 #if defined(_WIN32)
     SecureZeroMemory(pBuf, bufsize);
 #else


### PR DESCRIPTION
This fixes undefined behaviour when passing a NULL buffer to `aws_secure_zero`.

Resolves #950.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
