### PR TITLE
aws_secure_zero() checks NULL before calling memset()

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -38,6 +38,12 @@ int (*g_numa_node_of_cpu_ptr)(int cpu) = NULL;
 void *g_libnuma_handle = NULL;
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
+    /* don't pass NULL to memset(), it's undefined behavior */
+    if (pBuf == NULL) {
+        AWS_ASSERT(bufsize == 0);
+        return;
+    }
+
 #if defined(_WIN32)
     SecureZeroMemory(pBuf, bufsize);
 #else

--- a/source/common.c
+++ b/source/common.c
@@ -39,8 +39,8 @@ void *g_libnuma_handle = NULL;
 
 void aws_secure_zero(void *pBuf, size_t bufsize) {
     /* don't pass NULL to memset(), it's undefined behavior */
-    if (pBuf == NULL) {
-        AWS_ASSERT(bufsize == 0);
+    if (pBuf == NULL || bufsize == 0) {
+        AWS_ASSERT(bufsize == 0); /* if you believe your NULL buffer has a size, then you have issues */
         return;
     }
 

--- a/tests/zero_test.c
+++ b/tests/zero_test.c
@@ -37,6 +37,9 @@ static int s_test_secure_zero_fn(struct aws_allocator *allocator, void *ctx) {
         }
     }
 
+    /* check that it's safe to pass NULL */
+    aws_secure_zero(NULL, 0);
+
     return SUCCESS;
 }
 


### PR DESCRIPTION
*Issue #:* https://github.com/awslabs/aws-c-common/issues/950

*Description of changes:* `aws_secure_zero()` checks for `NULL` before calling `memset()`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
