### PR TITLE
Fix race condition in cJSON_Parse.* calls

### DIFF
--- a/include/aws/common/external/cJSON.h
+++ b/include/aws/common/external/cJSON.h
@@ -181,8 +181,10 @@ CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
 CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
 CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
 CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
-/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
+/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds.
+ * NOTE: disabled, since this method is not thread-safe. See comments in source/external/cJSON.c.
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
+ */
 
 /* Check item type and return its value */
 CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);

--- a/source/external/cJSON.c
+++ b/source/external/cJSON.c
@@ -89,12 +89,19 @@ typedef struct {
   const unsigned char *json;
   size_t position;
 } error;
+/*
+ * NOTE: the use of this static global variable is not thread-safe,
+ *       hence writing to / reading from it is disabled in this code.
+ *
+ *       See https://cjson.docsforge.com/#thread-safety (concurrent reads)
+ *       See https://github.com/awslabs/aws-c-common/issues/953 (concurrent writes)
 static error global_error = { NULL, 0 };
 
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
 {
   return (const char*) (global_error.json + global_error.position);
 }
+ */
 
 CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
 {
@@ -1094,6 +1101,14 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer
   parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
   cJSON *item = NULL;
 
+  /* reset error position
+   *
+   * NOTE: disabled due to thread safety (see note at the top of this file).
+   *
+  global_error.json = NULL;
+  global_error.position = 0;
+   */
+
   if (value == NULL || 0 == buffer_length)
   {
       goto fail;
@@ -1136,6 +1151,31 @@ fail:
   if (item != NULL)
   {
       cJSON_Delete(item);
+  }
+
+  if (value != NULL)
+  {
+      error local_error;
+      local_error.json = (const unsigned char*)value;
+      local_error.position = 0;
+
+      if (buffer.offset < buffer.length)
+      {
+          local_error.position = buffer.offset;
+      }
+      else if (buffer.length > 0)
+      {
+          local_error.position = buffer.length - 1;
+      }
+
+      if (return_parse_end != NULL)
+      {
+          *return_parse_end = (const char*)local_error.json + local_error.position;
+      }
+
+      /* NOTE: disabled due to thread safety (see note at the top of this file).
+      global_error = local_error;
+       */
   }
 
   return NULL;

--- a/source/external/cJSON.c
+++ b/source/external/cJSON.c
@@ -1094,10 +1094,6 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer
   parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
   cJSON *item = NULL;
 
-  /* reset error position */
-  global_error.json = NULL;
-  global_error.position = 0;
-
   if (value == NULL || 0 == buffer_length)
   {
       goto fail;
@@ -1140,29 +1136,6 @@ fail:
   if (item != NULL)
   {
       cJSON_Delete(item);
-  }
-
-  if (value != NULL)
-  {
-      error local_error;
-      local_error.json = (const unsigned char*)value;
-      local_error.position = 0;
-
-      if (buffer.offset < buffer.length)
-      {
-          local_error.position = buffer.offset;
-      }
-      else if (buffer.length > 0)
-      {
-          local_error.position = buffer.length - 1;
-      }
-
-      if (return_parse_end != NULL)
-      {
-          *return_parse_end = (const char*)local_error.json + local_error.position;
-      }
-
-      global_error = local_error;
   }
 
   return NULL;


### PR DESCRIPTION
Concurrent calls to `cJSON_Parse.*` routines mutually overwrite the `static` `global_error` variable, which produces a write race condition caught by the thread sanitizer.

Since `cJSON_GetErrorPtr` is not used (as it is not thread-safe), it does not make sense to fill in the value of the global variable and thus trigger the race condition. 

A mutex would incur slow-down.

Hence remove access to the `static` `global_error` variable from `cJSON_Parse.*` routines.
To avoid using `cJSON_GetErrorPtr` in the future, comment it out.

Resolves #953.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
