### PR TITLE
CBMC proofs: add and fix declarations

### DIFF
--- a/verification/cbmc/proofs/aws_priority_queue_s_sift_down/aws_priority_queue_s_sift_down_harness.c
+++ b/verification/cbmc/proofs/aws_priority_queue_s_sift_down/aws_priority_queue_s_sift_down_harness.c
@@ -6,7 +6,7 @@
 #include <aws/common/priority_queue.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void __CPROVER_file_local_priority_queue_c_s_sift_down(struct aws_priority_queue *queue, size_t root);
+_Bool __CPROVER_file_local_priority_queue_c_s_sift_down(struct aws_priority_queue *queue, size_t root);
 
 void aws_priority_queue_s_sift_down_harness() {
     /* Data structure */

--- a/verification/cbmc/proofs/aws_priority_queue_s_sift_up/aws_priority_queue_s_sift_up_harness.c
+++ b/verification/cbmc/proofs/aws_priority_queue_s_sift_up/aws_priority_queue_s_sift_up_harness.c
@@ -6,7 +6,7 @@
 #include <aws/common/priority_queue.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void __CPROVER_file_local_priority_queue_c_s_sift_up(struct aws_priority_queue *queue, size_t root);
+_Bool __CPROVER_file_local_priority_queue_c_s_sift_up(struct aws_priority_queue *queue, size_t root);
 
 void aws_priority_queue_s_sift_up_harness() {
     /* Data structure */

--- a/verification/cbmc/stubs/memset_override_0.c
+++ b/verification/cbmc/stubs/memset_override_0.c
@@ -12,6 +12,7 @@
  * Benchmark your particular proof to know for sure.
  */
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/verification/cbmc/stubs/s_expand_table_override.c
+++ b/verification/cbmc/stubs/s_expand_table_override.c
@@ -9,6 +9,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+int __CPROVER_file_local_hash_table_c_s_update_template_size(
+    struct hash_table_state *template,
+    size_t expected_elements);
+
 int __CPROVER_file_local_hash_table_c_s_expand_table(struct aws_hash_table *map) {
     struct hash_table_state *old_state = map->p_impl;
     struct hash_table_state template = *old_state;

--- a/verification/cbmc/stubs/s_sift_either_override.c
+++ b/verification/cbmc/stubs/s_sift_either_override.c
@@ -21,9 +21,7 @@
 
 #include <aws/common/priority_queue.h>
 
-bool __CPROVER_file_local_priority_queue_c_s_sift_either(struct aws_priority_queue *queue, size_t index) {
+void __CPROVER_file_local_priority_queue_c_s_sift_either(struct aws_priority_queue *queue, size_t index) {
     assert(aws_priority_queue_is_valid(queue));
     assert(index < queue->container.length);
-    bool did_move;
-    return did_move;
 }


### PR DESCRIPTION
*Description of changes:*

CBMC produced a number of warnings - fix these by adding missing forward declarations, and adjust the types of conflicting declarations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
