### PR TITLE
[aws_json_module] keep module_allocator alive for aws-sdk-cpp use

### DIFF
--- a/source/json.c
+++ b/source/json.c
@@ -376,7 +376,12 @@ void aws_json_module_init(struct aws_allocator *allocator) {
 
 void aws_json_module_cleanup(void) {
     if (s_aws_json_module_initialized) {
+        /*
+         * Note: not setting the module_allocator to NULL to avoid deallocation-after-cleanup issues
+         *       that happen with `aws-sdk-cpp` threads that are still running after main() exists.
+         *       See issue #964 for details. Depends on resolving aws-sdk-cpp issue #2274.
         s_aws_json_module_allocator = NULL;
+         */
         s_aws_json_module_initialized = false;
     }
 }


### PR DESCRIPTION
This keeps the JSON module_allocator alive even after clean-up, to prevent late-deallocation issues occurring in aws-sdk-cpp from causing programs to fail after main() has returned.

Resolves #964.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
