### PR TITLE
Always pull out value of errno right after sys call

### DIFF
--- a/source/file.c
+++ b/source/file.c
@@ -41,7 +41,7 @@ int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocat
 
     if (fp) {
         if (fseek(fp, 0L, SEEK_END)) {
-            int errno_value = errno;
+            int errno_value = errno; /* Always cache errno before potential side-effect */
             AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to seek file %s with errno %d", filename, errno_value);
             fclose(fp);
             return aws_translate_and_raise_io_error(errno_value);
@@ -60,7 +60,7 @@ int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocat
         out_buf->buffer[out_buf->len] = 0;
 
         if (fseek(fp, 0L, SEEK_SET)) {
-            int errno_value = errno;
+            int errno_value = errno; /* Always cache errno before potential side-effect */
             AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to seek file %s with errno %d", filename, errno_value);
             aws_byte_buf_clean_up(out_buf);
             fclose(fp);
@@ -68,7 +68,7 @@ int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocat
         }
 
         size_t read = fread(out_buf->buffer, 1, out_buf->len, fp);
-        int errno_cpy = errno;
+        int errno_cpy = errno; /* Always cache errno before potential side-effect */
         fclose(fp);
         if (read < out_buf->len) {
             AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to read file %s with errno %d", filename, errno_cpy);

--- a/source/file.c
+++ b/source/file.c
@@ -41,9 +41,10 @@ int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocat
 
     if (fp) {
         if (fseek(fp, 0L, SEEK_END)) {
-            AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to seek file %s with errno %d", filename, errno);
+            int errno_value = errno;
+            AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to seek file %s with errno %d", filename, errno_value);
             fclose(fp);
-            return aws_translate_and_raise_io_error(errno);
+            return aws_translate_and_raise_io_error(errno_value);
         }
 
         size_t allocation_size = (size_t)ftell(fp) + 1;
@@ -59,16 +60,18 @@ int aws_byte_buf_init_from_file(struct aws_byte_buf *out_buf, struct aws_allocat
         out_buf->buffer[out_buf->len] = 0;
 
         if (fseek(fp, 0L, SEEK_SET)) {
-            AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to seek file %s with errno %d", filename, errno);
+            int errno_value = errno;
+            AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to seek file %s with errno %d", filename, errno_value);
             aws_byte_buf_clean_up(out_buf);
             fclose(fp);
-            return aws_translate_and_raise_io_error(errno);
+            return aws_translate_and_raise_io_error(errno_value);
         }
 
         size_t read = fread(out_buf->buffer, 1, out_buf->len, fp);
+        int errno_cpy = errno;
         fclose(fp);
         if (read < out_buf->len) {
-            AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to read file %s with errno %d", filename, errno);
+            AWS_LOGF_ERROR(AWS_LS_COMMON_IO, "static: Failed to read file %s with errno %d", filename, errno_cpy);
             aws_secure_zero(out_buf->buffer, out_buf->len);
             aws_byte_buf_clean_up(out_buf);
             return aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);

--- a/source/log_writer.c
+++ b/source/log_writer.c
@@ -27,7 +27,7 @@ static int s_aws_file_writer_write(struct aws_log_writer *writer, const struct a
 
     size_t length = output->len;
     if (fwrite(output->bytes, 1, length, impl->log_file) < length) {
-        int errno_value = errno;
+        int errno_value = errno; /* Always cache errno before potential side-effect */
         return aws_translate_and_raise_io_error(errno_value);
     }
 

--- a/source/log_writer.c
+++ b/source/log_writer.c
@@ -27,7 +27,8 @@ static int s_aws_file_writer_write(struct aws_log_writer *writer, const struct a
 
     size_t length = output->len;
     if (fwrite(output->bytes, 1, length, impl->log_file) < length) {
-        return aws_translate_and_raise_io_error(errno);
+        int errno_value = errno;
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     return AWS_OP_SUCCESS;

--- a/source/logging.c
+++ b/source/logging.c
@@ -502,7 +502,7 @@ static int s_noalloc_stderr_logger_log(
 
     int write_result = AWS_OP_SUCCESS;
     if (fwrite(format_buffer, 1, format_data.amount_written, impl->file) < format_data.amount_written) {
-        int errno_value = errno;
+        int errno_value = errno; /* Always cache errno before potential side-effect */
         aws_translate_and_raise_io_error(errno_value);
         write_result = AWS_OP_ERR;
     }

--- a/source/logging.c
+++ b/source/logging.c
@@ -502,7 +502,8 @@ static int s_noalloc_stderr_logger_log(
 
     int write_result = AWS_OP_SUCCESS;
     if (fwrite(format_buffer, 1, format_data.amount_written, impl->file) < format_data.amount_written) {
-        aws_translate_and_raise_io_error(errno);
+        int errno_value = errno;
+        aws_translate_and_raise_io_error(errno_value);
         write_result = AWS_OP_ERR;
     }
 

--- a/source/posix/file.c
+++ b/source/posix/file.c
@@ -17,7 +17,7 @@
 FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string *mode) {
     FILE *f = fopen(aws_string_c_str(file_path), aws_string_c_str(mode));
     if (!f) {
-        int errno_cpy = errno;
+        int errno_cpy = errno; /* Always cache errno before potential side-effect */
         aws_translate_and_raise_io_error(errno_cpy);
         AWS_LOGF_ERROR(
             AWS_LS_COMMON_IO,
@@ -33,7 +33,7 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
 
 int aws_directory_create(const struct aws_string *dir_path) {
     int mkdir_ret = mkdir(aws_string_c_str(dir_path), S_IRWXU | S_IRWXG | S_IRWXO);
-    int errno_value = errno;
+    int errno_value = errno; /* Always cache errno before potential side-effect */
 
     /** nobody cares if it already existed. */
     if (mkdir_ret != 0 && errno_value != EEXIST) {
@@ -93,21 +93,21 @@ int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
     }
 
     int error_code = rmdir(aws_string_c_str(dir_path));
-    int errno_value = errno;
+    int errno_value = errno; /* Always cache errno before potential side-effect */
 
     return error_code == 0 ? AWS_OP_SUCCESS : aws_translate_and_raise_io_error(errno_value);
 }
 
 int aws_directory_or_file_move(const struct aws_string *from, const struct aws_string *to) {
     int error_code = rename(aws_string_c_str(from), aws_string_c_str(to));
-    int errno_value = errno;
+    int errno_value = errno; /* Always cache errno before potential side-effect */
 
     return error_code == 0 ? AWS_OP_SUCCESS : aws_translate_and_raise_io_error(errno_value);
 }
 
 int aws_file_delete(const struct aws_string *file_path) {
     int error_code = unlink(aws_string_c_str(file_path));
-    int errno_value = errno;
+    int errno_value = errno; /* Always cache errno before potential side-effect */
 
     if (!error_code || errno_value == ENOENT) {
         return AWS_OP_SUCCESS;
@@ -123,7 +123,7 @@ int aws_directory_traverse(
     aws_on_directory_entry *on_entry,
     void *user_data) {
     DIR *dir = opendir(aws_string_c_str(path));
-    int errno_value = errno;
+    int errno_value = errno; /* Always cache errno before potential side-effect */
 
     if (!dir) {
         return aws_translate_and_raise_io_error(errno_value);
@@ -273,8 +273,8 @@ int aws_fseek(FILE *file, int64_t offset, int whence) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
     int result = fseek(file, offset, whence);
-#endif /* AWS_HAVE_POSIX_LFS */
-    int errno_value = errno;
+#endif                       /* AWS_HAVE_POSIX_LFS */
+    int errno_value = errno; /* Always cache errno before potential side-effect */
 
     if (result != 0) {
         return aws_translate_and_raise_io_error(errno_value);
@@ -293,7 +293,7 @@ int aws_file_get_length(FILE *file, int64_t *length) {
     }
 
     if (fstat(fd, &file_stats)) {
-        int errno_value = errno;
+        int errno_value = errno; /* Always cache errno before potential side-effect */
         return aws_translate_and_raise_io_error(errno_value);
     }
 

--- a/source/posix/file.c
+++ b/source/posix/file.c
@@ -33,10 +33,11 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
 
 int aws_directory_create(const struct aws_string *dir_path) {
     int mkdir_ret = mkdir(aws_string_c_str(dir_path), S_IRWXU | S_IRWXG | S_IRWXO);
+    int errno_value = errno;
 
     /** nobody cares if it already existed. */
-    if (mkdir_ret != 0 && errno != EEXIST) {
-        return aws_translate_and_raise_io_error(errno);
+    if (mkdir_ret != 0 && errno_value != EEXIST) {
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     return AWS_OP_SUCCESS;
@@ -92,24 +93,27 @@ int aws_directory_delete(const struct aws_string *dir_path, bool recursive) {
     }
 
     int error_code = rmdir(aws_string_c_str(dir_path));
+    int errno_value = errno;
 
-    return error_code == 0 ? AWS_OP_SUCCESS : aws_translate_and_raise_io_error(errno);
+    return error_code == 0 ? AWS_OP_SUCCESS : aws_translate_and_raise_io_error(errno_value);
 }
 
 int aws_directory_or_file_move(const struct aws_string *from, const struct aws_string *to) {
     int error_code = rename(aws_string_c_str(from), aws_string_c_str(to));
+    int errno_value = errno;
 
-    return error_code == 0 ? AWS_OP_SUCCESS : aws_translate_and_raise_io_error(errno);
+    return error_code == 0 ? AWS_OP_SUCCESS : aws_translate_and_raise_io_error(errno_value);
 }
 
 int aws_file_delete(const struct aws_string *file_path) {
     int error_code = unlink(aws_string_c_str(file_path));
+    int errno_value = errno;
 
-    if (!error_code || errno == ENOENT) {
+    if (!error_code || errno_value == ENOENT) {
         return AWS_OP_SUCCESS;
     }
 
-    return aws_translate_and_raise_io_error(errno);
+    return aws_translate_and_raise_io_error(errno_value);
 }
 
 int aws_directory_traverse(
@@ -119,9 +123,10 @@ int aws_directory_traverse(
     aws_on_directory_entry *on_entry,
     void *user_data) {
     DIR *dir = opendir(aws_string_c_str(path));
+    int errno_value = errno;
 
     if (!dir) {
-        return aws_translate_and_raise_io_error(errno);
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     struct aws_byte_cursor current_path = aws_byte_cursor_from_string(path);
@@ -269,9 +274,10 @@ int aws_fseek(FILE *file, int64_t offset, int whence) {
     }
     int result = fseek(file, offset, whence);
 #endif /* AWS_HAVE_POSIX_LFS */
+    int errno_value = errno;
 
     if (result != 0) {
-        return aws_translate_and_raise_io_error(errno);
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     return AWS_OP_SUCCESS;
@@ -287,7 +293,8 @@ int aws_file_get_length(FILE *file, int64_t *length) {
     }
 
     if (fstat(fd, &file_stats)) {
-        return aws_translate_and_raise_io_error(errno);
+        int errno_value = errno;
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     *length = file_stats.st_size;

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -165,8 +165,9 @@ static void *thread_fn(void *arg) {
          * and makes sure the numa node of the cpu we launched this thread on is where memory gets allocated. However,
          * we don't want to fail the application if this fails, so make the call, and ignore the result. */
         long resp = g_set_mempolicy_ptr(AWS_MPOL_PREFERRED_ALIAS, NULL, 0);
+        int errno_value = errno;
         if (resp) {
-            AWS_LOGF_WARN(AWS_LS_COMMON_THREAD, "call to set_mempolicy() failed with errno %d", errno);
+            AWS_LOGF_WARN(AWS_LS_COMMON_THREAD, "call to set_mempolicy() failed with errno %d", errno_value);
         }
     }
     wrapper.func(wrapper.arg);

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -165,7 +165,7 @@ static void *thread_fn(void *arg) {
          * and makes sure the numa node of the cpu we launched this thread on is where memory gets allocated. However,
          * we don't want to fail the application if this fails, so make the call, and ignore the result. */
         long resp = g_set_mempolicy_ptr(AWS_MPOL_PREFERRED_ALIAS, NULL, 0);
-        int errno_value = errno;
+        int errno_value = errno; /* Always cache errno before potential side-effect */
         if (resp) {
             AWS_LOGF_WARN(AWS_LS_COMMON_THREAD, "call to set_mempolicy() failed with errno %d", errno_value);
         }

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -507,7 +507,7 @@ bool aws_path_exists(const struct aws_string *path) {
 
 int aws_fseek(FILE *file, int64_t offset, int whence) {
     if (_fseeki64(file, offset, whence)) {
-        int errno_value = errno;
+        int errno_value = errno; /* Always cache errno before potential side-effect */
         return aws_translate_and_raise_io_error(errno_value);
     }
 
@@ -526,7 +526,7 @@ int aws_file_get_length(FILE *file, int64_t *length) {
 
     HANDLE os_file = (HANDLE)_get_osfhandle(fd);
     if (os_file == INVALID_HANDLE_VALUE) {
-        int errno_value = errno;
+        int errno_value = errno; /* Always cache errno before potential side-effect */
         return aws_translate_and_raise_io_error(errno_value);
     }
 

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -507,7 +507,8 @@ bool aws_path_exists(const struct aws_string *path) {
 
 int aws_fseek(FILE *file, int64_t offset, int whence) {
     if (_fseeki64(file, offset, whence)) {
-        return aws_translate_and_raise_io_error(errno);
+        int errno_value = errno;
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     return AWS_OP_SUCCESS;
@@ -525,7 +526,8 @@ int aws_file_get_length(FILE *file, int64_t *length) {
 
     HANDLE os_file = (HANDLE)_get_osfhandle(fd);
     if (os_file == INVALID_HANDLE_VALUE) {
-        return aws_translate_and_raise_io_error(errno);
+        int errno_value = errno;
+        return aws_translate_and_raise_io_error(errno_value);
     }
 
     LARGE_INTEGER os_size;


### PR DESCRIPTION
A pass through all uses of errno.  There were a number of places where a system call was made and then the errno check for it occurred after other things that might side-affect the value of errno (like logging).

This PR establishes a new pattern for system call error checking.  The following approaches are acceptable:
```
int result = system_call(...);
int errno_value = errno;
if (result) {
   ... // do stuff with errno_value
}
```

or if there's a concern with thread local access performance?:

```
int result = system_call(...);
if (result) {
   int errno_value = errno;
   ... // do stuff with errno_value
}
```

Applying this pattern universally sometimes leads to what looks like trivial separation:

```
int result = system_call(...);
if (result) {
   int errno_value = errno;
   return aws_raise_error(translate_io_error(errno_value));
}
```

but it's important to follow the pattern everywhere since skipping it in the above case makes it far easier for someone to
accidentally break things in the future by inserting logic between the system call and the aws_raise_error() call, ala:

```
int result = system_call(...);
if (result) {
   AWS_LOGF_ERROR(...);
   return aws_raise_error(translate_io_error(errno));
}
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
