### PR TITLE
fix: build and tests on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ else ()
         list(APPEND PLATFORM_LIBS dl m thr execinfo)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
         list(APPEND PLATFORM_LIBS dl m Threads::Threads execinfo)
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+        list(APPEND PLATFORM_LIBS m Threads::Threads execinfo)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
         list(APPEND PLATFORM_LIBS log)
         file(GLOB ANDROID_SRC "source/android/*.c")
@@ -180,7 +182,7 @@ aws_check_headers(${PROJECT_NAME} ${AWS_COMMON_HEADERS} ${AWS_TEST_HEADERS} ${AW
 
 #apple source already includes the definitions we want, and setting this posix source
 #version causes it to revert to an older version. So don't turn it on there, we don't need it.
-if (UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} MATCHES FreeBSD)
+if (UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} MATCHES FreeBSD|OpenBSD)
     #this only gets applied to aws-c-common (not its consumers).
     target_compile_definitions(${PROJECT_NAME} PRIVATE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500)
 endif()

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -473,7 +473,7 @@ int aws_thread_current_name(struct aws_allocator *allocator, struct aws_string *
 #define THREAD_NAME_BUFFER_SIZE 256
 int aws_thread_name(struct aws_allocator *allocator, aws_thread_id_t thread_id, struct aws_string **out_name) {
     *out_name = NULL;
-#if defined(AWS_PTHREAD_GETNAME_TAKES_2ARGS) || defined(AWS_PTHREAD_GETNAME_TAKES_3ARGS) || \
+#if defined(AWS_PTHREAD_GETNAME_TAKES_2ARGS) || defined(AWS_PTHREAD_GETNAME_TAKES_3ARGS) ||                            \
     defined(AWS_PTHREAD_GET_NAME_TAKES_2_ARGS)
     char name[THREAD_NAME_BUFFER_SIZE] = {0};
 #    ifdef AWS_PTHREAD_GETNAME_TAKES_3ARGS

--- a/tests/atomics_test.c
+++ b/tests/atomics_test.c
@@ -16,7 +16,7 @@
 #    ifndef alloca
 #        define alloca _alloca
 #    endif
-#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #    include <stdlib.h>
 #else
 #    include <alloca.h>


### PR DESCRIPTION
*Description of changes:*

This PR repairs and tidies up the build and tests on OpenBSD. Testing performed on OpenBSD 7.2/amd64.

```
100% tests passed, 0 tests failed out of 424

Total Test time (real) =  54.68 sec
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
