### PR TITLE
Added extern_c_begin and extern_c_end to JSON

### DIFF
--- a/include/aws/common/json.h
+++ b/include/aws/common/json.h
@@ -11,6 +11,8 @@
 
 struct aws_json_value;
 
+AWS_EXTERN_C_BEGIN
+
 // ====================
 // Create and pass type
 
@@ -411,5 +413,7 @@ int aws_byte_buf_append_json_string_formatted(const struct aws_json_value *value
 AWS_COMMON_API
 struct aws_json_value *aws_json_value_new_from_string(struct aws_allocator *allocator, struct aws_byte_cursor string);
 // ====================
+
+AWS_EXTERN_C_END
 
 #endif // AWS_COMMON_JSON_H


### PR DESCRIPTION
*Description of changes:*

Adds `AWS_EXTERN_C_BEGIN` and `AWS_EXTERN_C_END` to the JSON headers so it can be used in C++ for `aws-crt-cpp`.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
