### PR TITLE
fix: __NETBSD__ -> __NetBSD__

### DIFF
--- a/cmake/AwsThreadName.cmake
+++ b/cmake/AwsThreadName.cmake
@@ -110,7 +110,7 @@ function(aws_set_thread_name_method target)
         #define _GNU_SOURCE
         #include <pthread.h>
 
-        #if defined(__FreeBSD__) || defined(__NETBSD__) || defined(__OpenBSD__)
+        #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
         #include <pthread_np.h>
         #endif
 

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -23,7 +23,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#if defined(__FreeBSD__) || defined(__NETBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #    include <pthread_np.h>
 typedef cpuset_t cpu_set_t;
 #elif defined(__OpenBSD__)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The correct spelling of this constant is `__NetBSD__`.

Note: I don't have a NetBSD system and can't assert things build on NetBSD after with this change. But, it's not wrong to fix this all the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
