### PR TITLE
Add aws_min_non_0_64()

### DIFF
--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -186,6 +186,7 @@ AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
+AWS_STATIC_IMPL uint64_t aws_min_non_0_u64(uint64_t a, uint64_t b);
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);

--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -244,6 +244,18 @@ AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b) {
     return a < b ? a : b;
 }
 
+AWS_STATIC_IMPL uint64_t aws_min_non_0_u64(uint64_t a, uint64_t b) {
+    if (a == 0) {
+        return b;
+    }
+
+    if (b == 0) {
+        return a;
+    }
+
+    return aws_min_u64(a, b);
+}
+
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b) {
     return a > b ? a : b;
 }


### PR DESCRIPTION
helper function aws_min_non_0_64 used in multiple places moved to common.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
