### PR TITLE
change '#if _MSC_VER' to '#ifdef _MSC_VER'

### DIFF
--- a/include/aws/common/private/lookup3.inl
+++ b/include/aws/common/private/lookup3.inl
@@ -60,7 +60,7 @@ on 1 byte), but shoehorning those bytes into integers efficiently is messy.
 # include <endian.h>    /* attempt to define endianness */
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable:4127) /*Disable "conditional expression is constant" */
 #endif /* _MSC_VER */
@@ -1055,7 +1055,7 @@ int main()
 #endif  /* SELF_TEST */
 
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif /* _MSC_VER */
 

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -26,7 +26,7 @@ the AWS_UNSTABLE_TESTING_API compiler flag
 #    define AWS_TESTING_REPORT_FD stderr
 #endif
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #    pragma warning(disable : 4221) /* aggregate initializer using local variable addresses */
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif

--- a/source/log_formatter.c
+++ b/source/log_formatter.c
@@ -16,7 +16,7 @@
  * Default formatter implementation
  */
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 

--- a/source/logging.c
+++ b/source/logging.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <stdarg.h>
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
@@ -468,7 +468,7 @@ static int s_noalloc_stderr_logger_log(
     va_list format_args;
     va_start(format_args, format);
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4221) /* allow struct member to reference format_buffer  */
 #endif
@@ -484,7 +484,7 @@ static int s_noalloc_stderr_logger_log(
         .amount_written = 0,
     };
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #    pragma warning(pop) /* disallow struct member to reference local value */
 #endif
 

--- a/source/uri.c
+++ b/source/uri.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #    pragma warning(disable : 4221) /* aggregate initializer using local variable addresses */
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-cpp/issues/330

*Description of changes:*
change `#if _MSC_VER` to `#ifdef _MSC_VER`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
