### PR TITLE
Replace old ARM images with raspbian-bullseye image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.26
+  BUILDER_VERSION: v0.9.35
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-c-common
@@ -27,8 +27,7 @@ jobs:
           - manylinux1-x86
           - manylinux2014-x64
           - manylinux2014-x86
-          - debian-stretch-arm32v5
-          - debian-stretch-arm32v7
+          - raspbian-bullseye
           - fedora-34-x64
           - opensuse-leap
           - rhel8-x64


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Replace the ARM images which use an unsupported version of Python. Prompted by awslabs/aws-crt-builder#220


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
