### PR TITLE
Improved output from test harness

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -86,8 +86,7 @@ static int total_failures;
 
 #define FAIL(...)                                                                                                      \
     do {                                                                                                               \
-        fprintf(AWS_TESTING_REPORT_FD, __VA_ARGS__);                                                                   \
-        fprintf(AWS_TESTING_REPORT_FD, "\n");                                                                          \
+        PRINT_FAIL_INTERNAL0(__VA_ARGS__);                                                                             \
         POSTFAIL_INTERNAL();                                                                                           \
     } while (0)
 
@@ -447,7 +446,7 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
         const size_t leaked_bytes = aws_mem_tracer_count(allocator);
         if (leaked_bytes) {
             aws_mem_tracer_dump(allocator);
-            fprintf(AWS_TESTING_REPORT_FD, "%sTest leaked memory: %zu bytes\n", FAIL_PREFIX, leaked_bytes);
+            PRINT_FAIL_INTERNAL0("Test leaked memory: %zu bytes", leaked_bytes);
             goto fail;
         }
 

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -31,7 +31,7 @@ the AWS_UNSTABLE_TESTING_API compiler flag
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
-/** Prints a message to stdout using printf format that appends the function, file and line number.
+/** Prints a message to AWS_TESTING_REPORT_FD using printf format that appends the function, file and line number.
  * If format is null, returns 0 without printing anything; otherwise returns 1.
  */
 static int s_cunit_failure_message0(
@@ -52,7 +52,7 @@ static int s_cunit_failure_message0(
     vfprintf(AWS_TESTING_REPORT_FD, format, ap);
     va_end(ap);
 
-    fprintf(AWS_TESTING_REPORT_FD, " [%s():%s@#%d]\n", function, file, line);
+    fprintf(AWS_TESTING_REPORT_FD, " [%s(): %s:%d]\n", function, file, line);
 
     return 1;
 }
@@ -86,7 +86,8 @@ static int total_failures;
 
 #define FAIL(...)                                                                                                      \
     do {                                                                                                               \
-        PRINT_FAIL_INTERNAL0(__VA_ARGS__);                                                                             \
+        fprintf(AWS_TESTING_REPORT_FD, __VA_ARGS__);                                                                   \
+        fprintf(AWS_TESTING_REPORT_FD, "\n");                                                                          \
         POSTFAIL_INTERNAL();                                                                                           \
     } while (0)
 
@@ -434,30 +435,31 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
         test_res |= harness->on_after(allocator, setup_res, harness->ctx);
     }
 
-    if (!test_res) {
-        if (!harness->suppress_memcheck) {
-            /* Reset the logger as test can set their own logger and clean it up. */
-            aws_logger_set(&err_logger);
-            const size_t leaked_bytes = aws_mem_tracer_count(allocator);
-            if (leaked_bytes) {
-                aws_mem_tracer_dump(allocator);
-            }
-            ASSERT_UINT_EQUALS(0, aws_mem_tracer_count(allocator));
-        }
+    if (test_res != AWS_OP_SUCCESS) {
+        goto fail;
     }
 
-    /* clean up */
     if (!harness->suppress_memcheck) {
+        /* Reset the logger, as test can set their own logger and clean it up,
+         * but aws_mem_tracer_dump() needs a valid logger to be active */
+        aws_logger_set(&err_logger);
+
+        const size_t leaked_bytes = aws_mem_tracer_count(allocator);
+        if (leaked_bytes) {
+            aws_mem_tracer_dump(allocator);
+            fprintf(AWS_TESTING_REPORT_FD, "%sTest leaked memory: %zu bytes\n", FAIL_PREFIX, leaked_bytes);
+            goto fail;
+        }
+
         aws_mem_tracer_destroy(allocator);
     }
+
     aws_logger_set(NULL);
     aws_logger_clean_up(&err_logger);
 
-    if (!test_res) {
-        RETURN_SUCCESS("%s [ \033[32mOK\033[0m ]", harness->test_name);
-    } else {
-        FAIL("%s [ \033[31mFAILED\033[0m ]", harness->test_name);
-    }
+    RETURN_SUCCESS("%s [ \033[32mOK\033[0m ]", harness->test_name);
+fail:
+    FAIL("%s [ \033[31mFAILED\033[0m ]", harness->test_name);
 }
 
 /* Enables terminal escape sequences for text coloring on Windows. */

--- a/source/memtrace.c
+++ b/source/memtrace.c
@@ -5,19 +5,19 @@
 
 #include <aws/common/atomics.h>
 #include <aws/common/byte_buf.h>
+#include <aws/common/clock.h>
 #include <aws/common/hash_table.h>
 #include <aws/common/logging.h>
 #include <aws/common/mutex.h>
 #include <aws/common/priority_queue.h>
 #include <aws/common/string.h>
 #include <aws/common/system_info.h>
-#include <aws/common/time.h>
 
 /* describes a single live allocation.
  * allocated by aws_default_allocator() */
 struct alloc_info {
     size_t size;
-    time_t time;
+    uint64_t time;
     uint64_t stack; /* hash of stack frame pointers */
 };
 
@@ -128,7 +128,7 @@ static void s_alloc_tracer_track(struct alloc_tracer *tracer, void *ptr, size_t 
     struct alloc_info *alloc = aws_mem_calloc(aws_default_allocator(), 1, sizeof(struct alloc_info));
     AWS_FATAL_ASSERT(alloc);
     alloc->size = size;
-    alloc->time = time(NULL);
+    aws_high_res_clock_get_ticks(&alloc->time);
 
     if (tracer->level == AWS_MEMTRACE_STACKS) {
         /* capture stack frames, skip 2 for this function and the allocation vtable function */
@@ -300,14 +300,14 @@ void aws_mem_tracer_dump(struct aws_allocator *trace_allocator) {
 
     size_t num_allocs = aws_hash_table_get_entry_count(&tracer->allocs);
     AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "################################################################################\n");
+        AWS_LS_COMMON_MEMTRACE, "################################################################################");
     AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "#  BEGIN MEMTRACE DUMP                                                         #\n");
+        AWS_LS_COMMON_MEMTRACE, "#  BEGIN MEMTRACE DUMP                                                         #");
     AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "################################################################################\n");
+        AWS_LS_COMMON_MEMTRACE, "################################################################################");
     AWS_LOGF_TRACE(
         AWS_LS_COMMON_MEMTRACE,
-        "tracer: %zu bytes still allocated in %zu allocations\n",
+        "tracer: %zu bytes still allocated in %zu allocations",
         aws_atomic_load_int(&tracer->allocated),
         num_allocs);
 
@@ -333,21 +333,24 @@ void aws_mem_tracer_dump(struct aws_allocator *trace_allocator) {
             &allocs, aws_default_allocator(), num_allocs, sizeof(struct alloc_info *), s_alloc_compare));
     aws_hash_table_foreach(&tracer->allocs, s_insert_allocs, &allocs);
     /* dump allocs by time */
-    AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "################################################################################\n");
-    AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "Leaks in order of allocation:\n");
-    AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "################################################################################\n");
+    AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "Leaks in order of allocation:");
+    AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
     while (aws_priority_queue_size(&allocs)) {
         struct alloc_info *alloc = NULL;
         aws_priority_queue_pop(&allocs, &alloc);
-        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "ALLOC %zu bytes\n", alloc->size);
         if (alloc->stack) {
             struct aws_hash_element *item = NULL;
             AWS_FATAL_ASSERT(
                 AWS_OP_SUCCESS == aws_hash_table_find(&stack_info, (void *)(uintptr_t)alloc->stack, &item));
             struct stack_metadata *stack = item->value;
-            AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "  stacktrace:\n%s\n", (const char *)aws_string_bytes(stack->trace));
+            AWS_LOGF_TRACE(
+                AWS_LS_COMMON_MEMTRACE,
+                "ALLOC %zu bytes, stacktrace:\n%s\n",
+                alloc->size,
+                aws_string_c_str(stack->trace));
+        } else {
+            AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "ALLOC %zu bytes", alloc->size);
         }
     }
 
@@ -365,18 +368,18 @@ void aws_mem_tracer_dump(struct aws_allocator *trace_allocator) {
                                   sizeof(struct stack_metadata *),
                                   s_stack_info_compare_size));
         aws_hash_table_foreach(&stack_info, s_insert_stacks, &stacks_by_size);
-        AWS_LOGF_TRACE(
-            AWS_LS_COMMON_MEMTRACE,
-            "################################################################################\n");
-        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "Stacks by bytes leaked:\n");
-        AWS_LOGF_TRACE(
-            AWS_LS_COMMON_MEMTRACE,
-            "################################################################################\n");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "Stacks by bytes leaked:");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
         while (aws_priority_queue_size(&stacks_by_size) > 0) {
             struct stack_metadata *stack = NULL;
             aws_priority_queue_pop(&stacks_by_size, &stack);
-            AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "%zu bytes in %zu allocations:\n", stack->size, stack->count);
-            AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "%s\n", (const char *)aws_string_bytes(stack->trace));
+            AWS_LOGF_TRACE(
+                AWS_LS_COMMON_MEMTRACE,
+                "%zu bytes in %zu allocations:\n%s\n",
+                stack->size,
+                stack->count,
+                aws_string_c_str(stack->trace));
         }
         aws_priority_queue_clean_up(&stacks_by_size);
 
@@ -389,30 +392,30 @@ void aws_mem_tracer_dump(struct aws_allocator *trace_allocator) {
                                   num_stacks,
                                   sizeof(struct stack_metadata *),
                                   s_stack_info_compare_count));
-        AWS_LOGF_TRACE(
-            AWS_LS_COMMON_MEMTRACE,
-            "################################################################################\n");
-        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "Stacks by number of leaks:\n");
-        AWS_LOGF_TRACE(
-            AWS_LS_COMMON_MEMTRACE,
-            "################################################################################\n");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "Stacks by number of leaks:");
+        AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
         aws_hash_table_foreach(&stack_info, s_insert_stacks, &stacks_by_count);
         while (aws_priority_queue_size(&stacks_by_count) > 0) {
             struct stack_metadata *stack = NULL;
             aws_priority_queue_pop(&stacks_by_count, &stack);
-            AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "%zu allocations leaking %zu bytes:\n", stack->count, stack->size);
-            AWS_LOGF_TRACE(AWS_LS_COMMON_MEMTRACE, "%s\n", (const char *)aws_string_bytes(stack->trace));
+            AWS_LOGF_TRACE(
+                AWS_LS_COMMON_MEMTRACE,
+                "%zu allocations leaking %zu bytes:\n%s\n",
+                stack->count,
+                stack->size,
+                aws_string_c_str(stack->trace));
         }
         aws_priority_queue_clean_up(&stacks_by_count);
         aws_hash_table_clean_up(&stack_info);
     }
 
     AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "################################################################################\n");
+        AWS_LS_COMMON_MEMTRACE, "################################################################################");
     AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "#  END MEMTRACE DUMP                                                           #\n");
+        AWS_LS_COMMON_MEMTRACE, "#  END MEMTRACE DUMP                                                           #");
     AWS_LOGF_TRACE(
-        AWS_LS_COMMON_MEMTRACE, "################################################################################\n");
+        AWS_LS_COMMON_MEMTRACE, "################################################################################");
 
     aws_mutex_unlock(&tracer->mutex);
 }


### PR DESCRIPTION
**Description of changes:**

- aws_test_harness.h changes:
    - Do not try to clean anything up if test fails. I was having issues with Address Sanitizer detecting use-after-free from the cleanup code, which would bury the fact that the test was already failing for other reasons.
    - Format line numbers so that clicking them in vscode jumps you to that line.

- memtrace.c changes:
    - Remove extraneous newlines from memtrace output. We should have removed these years ago, when we changed it to use to the logger instead of printf.
    - Use high precision clock so that "Leaks in order of allocation" is the actual order of allocation. Millisecond precision wasn't cutting it
    - Use different characters `~~~~~` to divide subtopics. When everything used `#####` the topics and subtopics all blended together visually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
