### PR TITLE
Add CBMC proof for `aws_byte_buf_append_and_update`

### DIFF
--- a/verification/cbmc/proofs/aws_byte_buf_append_and_update/Makefile
+++ b/verification/cbmc/proofs/aws_byte_buf_append_and_update/Makefile
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+###########
+include ../Makefile.aws_byte_buf
+
+CBMCFLAGS +=
+
+PROOF_UID = aws_byte_buf_append_and_update
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(PROOFDIR)/$(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(PROOF_STUB)/error.c
+
+PROJECT_SOURCES += $(SRCDIR)/source/allocator.c
+PROJECT_SOURCES += $(SRCDIR)/source/byte_buf.c
+PROJECT_SOURCES += $(SRCDIR)/source/common.c
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_byte_buf_append_and_update/aws_byte_buf_append_and_update_harness.c
+++ b/verification/cbmc/proofs/aws_byte_buf_append_and_update/aws_byte_buf_append_and_update_harness.c
@@ -1,0 +1,38 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_byte_buf_append_and_update_harness() {
+    struct aws_byte_buf to;
+    ensure_byte_buf_has_allocated_buffer_member(&to);
+    __CPROVER_assume(aws_byte_buf_is_valid(&to));
+
+    /* save current state of the data structure */
+    struct aws_byte_buf to_old = to;
+
+    struct aws_byte_cursor from_and_update;
+    ensure_byte_cursor_has_allocated_buffer_member(&from_and_update);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&from_and_update));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor from_and_update_old = from_and_update;
+
+    if (aws_byte_buf_append_and_update(&to, &from_and_update) == AWS_OP_SUCCESS) {
+        assert(to.len == to_old.len + from_and_update.len);
+    } else {
+        /* if the operation return an error, to must not change */
+        assert_bytes_match(to_old.buffer, to.buffer, to.len);
+        assert(to_old.len == to.len);
+    }
+
+    assert(aws_byte_buf_is_valid(&to));
+    assert(aws_byte_cursor_is_valid(&from_and_update));
+    assert(to_old.allocator == to.allocator);
+    assert(to_old.capacity == to.capacity);
+    assert_bytes_match(from_and_update_old.ptr, from_and_update.ptr, from_and_update.len);
+    assert(from_and_update_old.len == from_and_update.len);
+}

--- a/verification/cbmc/proofs/aws_byte_buf_append_and_update/cbmc-proof.txt
+++ b/verification/cbmc/proofs/aws_byte_buf_append_and_update/cbmc-proof.txt
@@ -1,0 +1,1 @@
+This file marks the directory as containing a CBMC proof


### PR DESCRIPTION
*Description of changes:*

If there was a CBMC memory safety proof for `aws_byte_buf_append_and_update`, the issue https://github.com/awslabs/aws-c-common/issues/997 would have been caught before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
