### PR TITLE
CMake feature detection with gcc 7.3.1 misses backtrace

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -93,6 +93,7 @@ string(REGEX MATCH "^(aarch64|arm)" ARM_CPU "${CMAKE_SYSTEM_PROCESSOR}")
 if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
     check_c_source_compiles("
     #include <execinfo.h>
+    #include <stdlib.h>
     int main() {
         backtrace(NULL, 0);
         return 0;


### PR DESCRIPTION
When building with gcc 7.3.1 (or 9.5.0), the `AWS_HAVE_EXECINFO` definition was not being set because `NULL` was undeclared.

*Issue #, if available:* None

*Description of changes:*

During test failure analysis I found the following output in a log:
```
 Fatal error condition occurred in /opt/pkg-cache/packages/Aws-c-common/Aws-c-common-0.2.x.140777.0/AL2012/generic-flavor/src/source/allocator.c:121: allocator != ((void *)0)
  Exiting Application
  No call stack information available
```

There is supposed to be a stack trace, but none is available.  I tracked this down to a broken feature detector added in v0.8.2 of the library when used with gcc 7.3.1:
```
/tmp/foo.c: In function ‘main’:
/tmp/foo.c:3:19: error: ‘NULL’ undeclared (first use in this function)
         backtrace(NULL, 0);
                   ^~~~
/tmp/foo.c:3:19: note: each undeclared identifier is reported only once for each function it appears in
```

By adding `stdlib.h` the feature detector works, and the `AWS_HAVE_EXECINFO` is enabled.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
