### PR TITLE
CMake feature detection with gcc 9.5.0 misses backtrace

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -93,6 +93,7 @@ string(REGEX MATCH "^(aarch64|arm)" ARM_CPU "${CMAKE_SYSTEM_PROCESSOR}")
 if(NOT LEGACY_COMPILER_SUPPORT OR ARM_CPU)
     check_c_source_compiles("
     #include <execinfo.h>
+    #include <stdlib.h>
     int main() {
         backtrace(NULL, 0);
         return 0;


### PR DESCRIPTION
When building with gcc 9.5.0, the AWS_HAVE_EXECINFO definition was not being set because NULL was undeclared.

*Description of changes:*
Duplicate of #1002  to run CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
