### PR TITLE
Adds aws_normalize_directory_separator

### DIFF
--- a/include/aws/common/file.h
+++ b/include/aws/common/file.h
@@ -163,6 +163,13 @@ AWS_COMMON_API
 char aws_get_platform_directory_separator(void);
 
 /**
+ * Normalizes the path by replacing any directory separator with the local platform's directory separator.
+ * @param path path to normalize. Must be writeable.
+ */
+AWS_COMMON_API
+void aws_normalize_directory_separator(struct aws_byte_buf *path);
+
+/**
  * Returns the current user's home directory.
  */
 AWS_COMMON_API

--- a/source/file.c
+++ b/source/file.c
@@ -87,6 +87,19 @@ bool aws_is_any_directory_separator(char value) {
     return value == '\\' || value == '/';
 }
 
+void aws_normalize_directory_separator(struct aws_byte_buf *path) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(path));
+
+    const char local_platform_separator = aws_get_platform_directory_separator();
+    for (size_t i = 0; i < path->len; ++i) {
+        if (aws_is_any_directory_separator((char)path->buffer[i])) {
+            path->buffer[i] = local_platform_separator;
+        }
+    }
+
+    AWS_POSTCONDITION(aws_byte_buf_is_valid(path));
+}
+
 struct aws_directory_iterator {
     struct aws_linked_list list_data;
     struct aws_allocator *allocator;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -475,6 +475,8 @@ add_test_case(directory_non_empty_deletion_recursively_succeeds_test)
 add_test_case(directory_move_succeeds_test)
 add_test_case(directory_move_src_non_existent_test)
 add_test_case(test_home_directory_not_null)
+add_test_case(test_normalize_posix_directory_separator)
+add_test_case(test_normalize_windows_directory_separator)
 
 add_test_case(promise_test_wait_forever)
 add_test_case(promise_test_wait_for_a_bit)

--- a/tests/file_test.c
+++ b/tests/file_test.c
@@ -404,3 +404,38 @@ static int s_test_home_directory_not_null(struct aws_allocator *allocator, void 
 }
 
 AWS_TEST_CASE(test_home_directory_not_null, s_test_home_directory_not_null);
+
+static int s_test_normalize_posix_directory_separator(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_string *buffer = aws_string_new_from_c_str(allocator, "./test/path/abc");
+    struct aws_byte_buf path_buf = aws_byte_buf_from_array(buffer->bytes, buffer->len);
+    aws_normalize_directory_separator(&path_buf);
+    for (size_t i = 0; i < path_buf.len; ++i) {
+        if (aws_is_any_directory_separator((char)path_buf.buffer[i])) {
+            ASSERT_INT_EQUALS(aws_get_platform_directory_separator(), path_buf.buffer[i]);
+        }
+    }
+
+    aws_string_destroy(buffer);
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(test_normalize_posix_directory_separator, s_test_normalize_posix_directory_separator);
+
+static int s_test_normalize_windows_directory_separator(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_string *buffer = aws_string_new_from_c_str(allocator, ".\\test\\path\\abc");
+    struct aws_byte_buf path_buf = aws_byte_buf_from_array(buffer->bytes, buffer->len);
+    aws_normalize_directory_separator(&path_buf);
+    for (size_t i = 0; i < path_buf.len; ++i) {
+        if (aws_is_any_directory_separator((char)path_buf.buffer[i])) {
+            ASSERT_INT_EQUALS(aws_get_platform_directory_separator(), path_buf.buffer[i]);
+        }
+    }
+    aws_string_destroy(buffer);
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(test_normalize_windows_directory_separator, s_test_normalize_windows_directory_separator);


### PR DESCRIPTION
*Description of changes:*
- Add a cross platform path normalizer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
