### PR TITLE
define AWS_SUPPRESS_ASAN for MSVC

### DIFF
--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -79,6 +79,8 @@ AWS_STATIC_ASSERT(CALL_OVERLOAD_TEST(1, 2, 3) == 3);
 #    if __has_feature(address_sanitizer)
 #        define AWS_SUPPRESS_ASAN __attribute__((no_sanitize("address")))
 #    endif
+#elif defined(_MSC_VER) && __SANITIZE_ADDRESS__
+#    define AWS_SUPPRESS_ASAN __declspec(no_sanitize_address)
 #endif
 
 #if !defined(AWS_SUPPRESS_ASAN)

--- a/include/aws/common/private/lookup3.inl
+++ b/include/aws/common/private/lookup3.inl
@@ -496,12 +496,12 @@ static uint32_t hashlittle( const void *key, size_t length, uint32_t initval)
  * the key.  *pc is better mixed than *pb, so use *pc first.  If you want
  * a 64-bit value do something like "*pc + (((uint64_t)*pb)<<32)".
  */
+AWS_SUPPRESS_ASAN      /* AddressSanitizer hates this implementation, even though it's innocuous */
 static void hashlittle2(
   const void *key,       /* the key to hash */
   size_t      length,    /* length of the key */
   uint32_t   *pc,        /* IN: primary initval, OUT: primary hash */
   uint32_t   *pb)        /* IN: secondary initval, OUT: secondary hash */
-  AWS_SUPPRESS_ASAN      /* AddressSanitizer hates this implementation, even though it's innocuous */
 {
   uint32_t a,b,c;                                          /* internal state */
   union { const void *ptr; size_t i; } u;     /* needed for Mac Powerbook G4 */


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-cpp/issues/2213

*Description of changes:*

MSVC ASAN reports issues with the AWS SDK due to a "buffer overflow" in `hashlittle2`. `AWS_SUPPRESS_ASAN` is now defined correctly for Windows MSVC when sanitizer is enabled. `AWS_SUPPRESS_ASAN` is already set for the function but had to be moved above function declaration to work with MSVC's `declspec`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
