### PR TITLE
Reduce spam when configuring multiple projects at once

### DIFF
--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -48,7 +48,6 @@ function(aws_add_sanitizers target)
     endif()
 
     list(APPEND SANITIZER_SANITIZERS ${SANITIZERS})
-    message(STATUS "attempting to use sanitizer list ${SANITIZER_SANITIZERS}")
 
     foreach(sanitizer IN LISTS SANITIZER_SANITIZERS)
 
@@ -66,7 +65,6 @@ function(aws_add_sanitizers target)
     endforeach()
 
     if(PRESENT_SANITIZERS)
-        message(STATUS "Supported sanitizers ${PRESENT_SANITIZERS}")
         target_compile_options(${target} PRIVATE -fno-omit-frame-pointer -fsanitize=${PRESENT_SANITIZERS})
         target_link_libraries(${target} PUBLIC "-fno-omit-frame-pointer -fsanitize=${PRESENT_SANITIZERS}")
 


### PR DESCRIPTION
**Issue:**
When configuring multiple projects at once (as we do in most aws-crt-LANG repos), we'd get 24 lines of spam like
```
[cmake] -- attempting to use sanitizer list address;undefined
[cmake] -- Supported sanitizers address,undefined
[cmake] -- attempting to use sanitizer list address;undefined
[cmake] -- Supported sanitizers address,undefined
[cmake] -- attempting to use sanitizer list address;undefined
[cmake] -- Supported sanitizers address,undefined
...
```

**Description of changes:**
Don't print these lines. We can already infer which sanitizers we're attempting to use, and which are supported, by these lines which print out once:
```
[cmake] -- Performing Test HAS_SANITIZER_address
[cmake] -- Performing Test HAS_SANITIZER_address - Success
[cmake] -- Performing Test HAS_SANITIZER_undefined
[cmake] -- Performing Test HAS_SANITIZER_undefined - Success
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
