### PR TITLE
Pin CBMC version to 5.81.0

### DIFF
--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,5 +1,5 @@
 cadical-tag: latest
-cbmc-version: latest
+cbmc-version: "5.81.0"
 cbmc-viewer-version: latest
 kissat-tag: latest
 litani-version: latest


### PR DESCRIPTION
This is due to a failure of aws_hash_table_clean_up with 5.82.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
