### PR TITLE
Remove unimplemented prototype from ring_buffer.h

### DIFF
--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -91,11 +91,6 @@ AWS_COMMON_API bool aws_ring_buffer_buf_belongs_to_pool(
     const struct aws_ring_buffer *ring_buffer,
     const struct aws_byte_buf *buf);
 
-/**
- * Cleans up a ring buffer allocator instance. Does not clean up the ring buffer.
- */
-AWS_COMMON_API void aws_ring_buffer_allocator_clean_up(struct aws_allocator *allocator);
-
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/ring_buffer.inl>
 #endif /* AWS_NO_STATIC_IMPL */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Not sure if ring_buffer is used anywhere, but my IDE pointed out that the `aws_ring_buffer_allocator_clean_up` function is not implemented.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
