### PR TITLE
Move CBMC back to latest

### DIFF
--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,5 +1,5 @@
 cadical-tag: latest
-cbmc-version: "5.81.0"
+cbmc-version: latest
 cbmc-viewer-version: latest
 kissat-tag: latest
 litani-version: latest


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This reverts commit 9848a8cf3979c9a820027f705ca985091885afc0 ("Pin CBMC version to 5.81.0", PR #1022): CBMC 5.83.0 includes https://github.com/diffblue/cbmc/pull/7700, which fixes the problem spotted by aws-c-common's tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
