### PR TITLE
Let cursor equals assert print string on failure

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -337,29 +337,17 @@ static int total_skip;
             break;                                                                                                     \
         }                                                                                                              \
         if (assert_ex_s != assert_got_s) {                                                                             \
-            fprintf(AWS_TESTING_REPORT_FD, "%sSize mismatch: %zu != %zu: ", FAIL_PREFIX, assert_ex_s, assert_got_s);   \
+            fprintf(AWS_TESTING_REPORT_FD, "%sSize mismatch: %zu != %zu: \n", FAIL_PREFIX, assert_ex_s, assert_got_s);   \
+            fprintf(AWS_TESTING_REPORT_FD, "%sGot: \"" PRInSTR "\"; Expected: \"%s\" \n", FAIL_PREFIX,                 \
+                    AWS_BYTE_CURSOR_PRI(cursor), cstring);                                                             \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0("ASSERT_CURSOR_VALUE_STRING_EQUALS(%s, %s)", #cursor, #cstring);                  \
             }                                                                                                          \
             POSTFAIL_INTERNAL();                                                                                       \
         }                                                                                                              \
         if (memcmp(assert_ex_p, assert_got_p, assert_got_s) != 0) {                                                    \
-            if (assert_got_s <= 1024) {                                                                                \
-                for (size_t assert_i = 0; assert_i < assert_ex_s; ++assert_i) {                                        \
-                    if (assert_ex_p[assert_i] != assert_got_p[assert_i]) {                                             \
-                        fprintf(                                                                                       \
-                            AWS_TESTING_REPORT_FD,                                                                     \
-                            "%sMismatch at byte[%zu]: 0x%02X != 0x%02X: ",                                             \
-                            FAIL_PREFIX,                                                                               \
-                            assert_i,                                                                                  \
-                            assert_ex_p[assert_i],                                                                     \
-                            assert_got_p[assert_i]);                                                                   \
-                        break;                                                                                         \
-                    }                                                                                                  \
-                }                                                                                                      \
-            } else {                                                                                                   \
-                fprintf(AWS_TESTING_REPORT_FD, "%sData mismatch: ", FAIL_PREFIX);                                      \
-            }                                                                                                          \
+            fprintf(AWS_TESTING_REPORT_FD, "%sData mismatch; Got: \"" PRInSTR "\"; Expected: \"%s\" \n", FAIL_PREFIX,  \
+                    AWS_BYTE_CURSOR_PRI(cursor), cstring);                                                             \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0("ASSERT_CURSOR_VALUE_STRING_EQUALS(%s, %s)", #cursor, #cstring);                  \
             }                                                                                                          \

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -337,17 +337,25 @@ static int total_skip;
             break;                                                                                                     \
         }                                                                                                              \
         if (assert_ex_s != assert_got_s) {                                                                             \
-            fprintf(AWS_TESTING_REPORT_FD, "%sSize mismatch: %zu != %zu: \n", FAIL_PREFIX, assert_ex_s, assert_got_s);   \
-            fprintf(AWS_TESTING_REPORT_FD, "%sGot: \"" PRInSTR "\"; Expected: \"%s\" \n", FAIL_PREFIX,                 \
-                    AWS_BYTE_CURSOR_PRI(cursor), cstring);                                                             \
+            fprintf(AWS_TESTING_REPORT_FD, "%sSize mismatch: %zu != %zu: \n", FAIL_PREFIX, assert_ex_s, assert_got_s); \
+            fprintf(                                                                                                   \
+                AWS_TESTING_REPORT_FD,                                                                                 \
+                "%sGot: \"" PRInSTR "\"; Expected: \"%s\" \n",                                                         \
+                FAIL_PREFIX,                                                                                           \
+                AWS_BYTE_CURSOR_PRI(cursor),                                                                           \
+                cstring);                                                                                              \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0("ASSERT_CURSOR_VALUE_STRING_EQUALS(%s, %s)", #cursor, #cstring);                  \
             }                                                                                                          \
             POSTFAIL_INTERNAL();                                                                                       \
         }                                                                                                              \
         if (memcmp(assert_ex_p, assert_got_p, assert_got_s) != 0) {                                                    \
-            fprintf(AWS_TESTING_REPORT_FD, "%sData mismatch; Got: \"" PRInSTR "\"; Expected: \"%s\" \n", FAIL_PREFIX,  \
-                    AWS_BYTE_CURSOR_PRI(cursor), cstring);                                                             \
+            fprintf(                                                                                                   \
+                AWS_TESTING_REPORT_FD,                                                                                 \
+                "%sData mismatch; Got: \"" PRInSTR "\"; Expected: \"%s\" \n",                                          \
+                FAIL_PREFIX,                                                                                           \
+                AWS_BYTE_CURSOR_PRI(cursor),                                                                           \
+                cstring);                                                                                              \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0("ASSERT_CURSOR_VALUE_STRING_EQUALS(%s, %s)", #cursor, #cstring);                  \
             }                                                                                                          \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In cases where cursor equals assert fails print the contents of both cursor and the compared string.
Current logic for how assert fails is copied from bin array asserts, but arguably most strings we assert on are fairly short and its easier to debug if full strings are printed


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
