### PR TITLE
Remove dangling symlink in CMBC proofs

### DIFF
--- a/verification/cbmc/proofs/prepare.py
+++ b/verification/cbmc/proofs/prepare.py
@@ -1,1 +1,0 @@
-../templates/template-for-repository/proofs/prepare.py


### PR DESCRIPTION
The templates submodule was removed in #919 so this symlink is now dangling.

- Original PR: https://github.com/awslabs/aws-c-common/pull/1031
- Not sure why the trick didn't work

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
