### PR TITLE
system_info: Enable Overriding Number of Processors

### DIFF
--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -26,7 +26,15 @@
 
 #if defined(HAVE_SYSCONF)
 size_t aws_system_info_processor_count(void) {
-    long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+    long nprocs;
+
+    const char *env_num_procs = getenv("AWS_COMMON_MAX_PROCS");
+    if (AWS_UNLIKELY(env_num_procs)) {
+        nprocs = atoi(env_num_procs);
+    } else {
+        nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+    }
+    
     if (AWS_LIKELY(nprocs >= 0)) {
         return (size_t)nprocs;
     }


### PR DESCRIPTION
In the current implementation, sys_info.c::aws_system_info_processor_count() is used to determine the parallelization factor for thread pools. On POSIX systems, the API uses sysconf(_SC_NPROCESSORS_ONLN).

On large systems, such as the u-12tb1.112xlarge instance type, the SDK initiates thread pools with up to 448 threads. This high thread count can potentially lead to S3 operations returning "503 Slow Down" errors due to the high load on a bucket.

This commit introduces a fix to this issue by allowing users to limit the number of threads through a new environment variable, AWS_COMMON_MAX_PROCS. This enhancement provides users with greater control over the parallelization factor, particularly on large systems.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
