### PR TITLE
DO NOT MERGE YET: Added deferrment API for use in preventing priority inversions inside…

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -162,6 +162,7 @@ add_test_case(scheduler_cleanup_reentrants)
 add_test_case(scheduler_schedule_cancellation)
 add_test_case(scheduler_cleanup_idempotent)
 add_test_case(scheduler_task_delete_on_run)
+add_test_case(scheduler_task_deferrment)
 
 add_test_case(test_hash_table_create_find)
 add_test_case(test_hash_table_string_create_find)


### PR DESCRIPTION
Added deferrment API for use in preventing priority inversions inside event-loops



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
