### PR TITLE
Report actual bytes leaked/Fix realloc tracing

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -474,10 +474,11 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
          * but aws_mem_tracer_dump() needs a valid logger to be active */
         aws_logger_set(&err_logger);
 
+        const size_t leaked_allocations = aws_mem_tracer_count(allocator);
         const size_t leaked_bytes = aws_mem_tracer_bytes(allocator);
         if (leaked_bytes) {
             aws_mem_tracer_dump(allocator);
-            PRINT_FAIL_INTERNAL0("Test leaked memory: %zu bytes", leaked_bytes);
+            PRINT_FAIL_INTERNAL0("Test leaked memory: %zu bytes %zu allocations", leaked_bytes, leaked_allocations);
             goto fail;
         }
 

--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -472,7 +472,7 @@ static inline int s_aws_run_test_case(struct aws_test_harness *harness) {
          * but aws_mem_tracer_dump() needs a valid logger to be active */
         aws_logger_set(&err_logger);
 
-        const size_t leaked_bytes = aws_mem_tracer_count(allocator);
+        const size_t leaked_bytes = aws_mem_tracer_bytes(allocator);
         if (leaked_bytes) {
             aws_mem_tracer_dump(allocator);
             PRINT_FAIL_INTERNAL0("Test leaked memory: %zu bytes", leaked_bytes);

--- a/source/allocator_sba.c
+++ b/source/allocator_sba.c
@@ -406,7 +406,7 @@ static void *s_sba_alloc(struct small_block_allocator *sba, size_t size) {
     return aws_mem_acquire(sba->allocator, size);
 }
 
-static void s_sba_free(struct small_block_allocator *sba, void *addr) {
+AWS_SUPPRESS_ASAN AWS_SUPPRESS_TSAN static void s_sba_free(struct small_block_allocator *sba, void *addr) {
     if (!addr) {
         return;
     }

--- a/source/allocator_sba.c
+++ b/source/allocator_sba.c
@@ -406,7 +406,7 @@ static void *s_sba_alloc(struct small_block_allocator *sba, size_t size) {
     return aws_mem_acquire(sba->allocator, size);
 }
 
-AWS_SUPPRESS_ASAN AWS_SUPPRESS_TSAN static void s_sba_free(struct small_block_allocator *sba, void *addr) {
+static void s_sba_free(struct small_block_allocator *sba, void *addr) {
     if (!addr) {
         return;
     }

--- a/source/memtrace.c
+++ b/source/memtrace.c
@@ -438,11 +438,18 @@ static void s_trace_mem_release(struct aws_allocator *allocator, void *ptr) {
 static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *old_ptr, size_t old_size, size_t new_size) {
     struct alloc_tracer *tracer = allocator->impl;
     void *new_ptr = old_ptr;
-    if (aws_mem_realloc(tracer->traced_allocator, &new_ptr, old_size, new_size)) {
-        return NULL;
-    }
 
+    /*
+    * Careful with the ordering of state clean up here.
+    * Tracer keeps a hash table (alloc ptr as key) of meta info about each allocation.
+    * To avoid race conditions during realloc state update needs to be done in
+    * following order to avoid race conditions:
+    * - remove meta info (other threads cant reuse that key, cause ptr is still valid )
+    * - realloc (cant fail, ptr might remain the same)
+    * - add meta info for reallocated mem
+    */
     s_alloc_tracer_untrack(tracer, old_ptr);
+    aws_mem_realloc(tracer->traced_allocator, &new_ptr, old_size, new_size);
     s_alloc_tracer_track(tracer, new_ptr, new_size);
 
     return new_ptr;

--- a/source/memtrace.c
+++ b/source/memtrace.c
@@ -440,14 +440,14 @@ static void *s_trace_mem_realloc(struct aws_allocator *allocator, void *old_ptr,
     void *new_ptr = old_ptr;
 
     /*
-    * Careful with the ordering of state clean up here.
-    * Tracer keeps a hash table (alloc ptr as key) of meta info about each allocation.
-    * To avoid race conditions during realloc state update needs to be done in
-    * following order to avoid race conditions:
-    * - remove meta info (other threads cant reuse that key, cause ptr is still valid )
-    * - realloc (cant fail, ptr might remain the same)
-    * - add meta info for reallocated mem
-    */
+     * Careful with the ordering of state clean up here.
+     * Tracer keeps a hash table (alloc ptr as key) of meta info about each allocation.
+     * To avoid race conditions during realloc state update needs to be done in
+     * following order to avoid race conditions:
+     * - remove meta info (other threads cant reuse that key, cause ptr is still valid )
+     * - realloc (cant fail, ptr might remain the same)
+     * - add meta info for reallocated mem
+     */
     s_alloc_tracer_untrack(tracer, old_ptr);
     aws_mem_realloc(tracer->traced_allocator, &new_ptr, old_size, new_size);
     s_alloc_tracer_track(tracer, new_ptr, new_size);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -317,6 +317,8 @@ add_test_case(sba_threaded_allocs_and_frees)
 add_test_case(sba_threaded_reallocs)
 add_test_case(sba_churn)
 add_test_case(sba_metrics)
+add_test_case(default_threaded_reallocs)
+add_test_case(default_threaded_allocs_and_frees)
 
 add_test_case(test_memtrace_none)
 add_test_case(test_memtrace_count)

--- a/tests/alloc_test.c
+++ b/tests/alloc_test.c
@@ -148,7 +148,10 @@ static void s_threaded_alloc_worker(void *user_data) {
     }
 }
 
-static void s_thread_test(struct aws_allocator *allocator, void (*thread_fn)(void *), struct aws_allocator *test_allocator) {
+static void s_thread_test(
+    struct aws_allocator *allocator,
+    void (*thread_fn)(void *),
+    struct aws_allocator *test_allocator) {
     const struct aws_thread_options *thread_options = aws_default_thread_options();
     struct aws_thread threads[NUM_TEST_THREADS];
     struct allocator_thread_test_data thread_data[NUM_TEST_THREADS];

--- a/tests/alloc_test.c
+++ b/tests/alloc_test.c
@@ -343,7 +343,6 @@ static int s_default_threaded_allocs_and_frees(struct aws_allocator *allocator, 
 
     s_thread_test(allocator, s_threaded_alloc_worker, allocator);
 
-
     return 0;
 }
 AWS_TEST_CASE(default_threaded_allocs_and_frees, s_default_threaded_allocs_and_frees)

--- a/tests/alloc_test.c
+++ b/tests/alloc_test.c
@@ -186,7 +186,7 @@ static int s_sba_threaded_allocs_and_frees(struct aws_allocator *allocator, void
 }
 AWS_TEST_CASE(sba_threaded_allocs_and_frees, s_sba_threaded_allocs_and_frees)
 
-static void s_sba_threaded_realloc_worker(void *user_data) {
+static void s_threaded_realloc_worker(void *user_data) {
     struct allocator_thread_test_data *thread_data = user_data;
     struct aws_allocator *test_allocator = thread_data->test_allocator;
     void *alloc = NULL;
@@ -215,7 +215,7 @@ static int s_sba_threaded_reallocs(struct aws_allocator *allocator, void *ctx) {
 
     struct aws_allocator *sba = aws_small_block_allocator_new(allocator, true);
 
-    s_thread_test(allocator, s_sba_threaded_realloc_worker, sba);
+    s_thread_test(allocator, s_threaded_realloc_worker, sba);
 
     aws_small_block_allocator_destroy(sba);
 
@@ -331,7 +331,7 @@ static int s_default_threaded_reallocs(struct aws_allocator *allocator, void *ct
     (void)ctx;
     srand(15);
 
-    s_thread_test(allocator, s_sba_threaded_realloc_worker, allocator);
+    s_thread_test(allocator, s_threaded_realloc_worker, allocator);
 
     return 0;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Report actual bytes leaked and not number of leaks as it says in the log message.

Fix the bug with memtracer keeping incorrect records for realloc.
Previous logic for tracking realloc usage was
- realloc
- untrack old
- track new
Problem with that was that memtrace realloc was not thread safe as a whole. Ex. say thread 1 does a realloc operation, it calls parent realloc and then thread 2 takes control and realloc reuses address that thread 1 just released and clobbers the records for that address, so when thread 1 gets control back, record for the address will have changed and thread 1 will update tracking data incorrectly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
