### PR TITLE
Authorize requests to GitHub API in `Run CBMC proofs` workflow

### DIFF
--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -63,7 +63,7 @@ jobs:
         run: |
           # Search within 5 most recent releases for latest available package
           CBMC_REL="https://api.github.com/repos/diffblue/cbmc/releases?page=1&per_page=5"
-          CBMC_DEB=$(curl -s $CBMC_REL | jq -r '.[].assets[].browser_download_url' | grep -e 'ubuntu-20.04' | head -n 1)
+          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[].assets[].browser_download_url' | grep -e 'ubuntu-20.04' | head -n 1)
           CBMC_ARTIFACT_NAME=$(basename $CBMC_DEB)
           curl -o $CBMC_ARTIFACT_NAME -L $CBMC_DEB
           sudo dpkg -i $CBMC_ARTIFACT_NAME
@@ -81,7 +81,7 @@ jobs:
         shell: bash
         run: |
           CBMC_VIEWER_REL="https://api.github.com/repos/model-checking/cbmc-viewer/releases/latest"
-          CBMC_VIEWER_VERSION=$(curl -s $CBMC_VIEWER_REL | jq -r .name | sed  's/viewer-//')
+          CBMC_VIEWER_VERSION=$(curl -s $CBMC_VIEWER_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r .name | sed  's/viewer-//')
           pip3 install cbmc-viewer==$CBMC_VIEWER_VERSION
       - name: Install CBMC viewer ${{ env.CBMC_VIEWER_VERSION }}
         if: ${{ env.CBMC_VIEWER_VERSION != 'latest' }}
@@ -97,7 +97,7 @@ jobs:
         run: |
           # Search within 5 most recent releases for latest available package
           LITANI_REL="https://api.github.com/repos/awslabs/aws-build-accumulator/releases?page=1&per_page=5"
-          LITANI_DEB=$(curl -s $LITANI_REL | jq -r '.[].assets[0].browser_download_url' | head -n 1)
+          LITANI_DEB=$(curl -s $LITANI_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[].assets[0].browser_download_url' | head -n 1)
           DBN_PKG_FILENAME=$(basename $LITANI_DEB)
           curl -L $LITANI_DEB -o $DBN_PKG_FILENAME
           sudo apt-get update
@@ -119,7 +119,7 @@ jobs:
           if ${{ env.KISSAT_TAG == 'latest' }}
           then
             KISSAT_REL="https://api.github.com/repos/arminbiere/kissat/releases/latest"
-            KISSAT_TAG_NAME=$(curl -s $KISSAT_REL | jq -r '.tag_name')
+            KISSAT_TAG_NAME=$(curl -s $KISSAT_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.tag_name')
           else
             KISSAT_TAG_NAME=${{ env.KISSAT_TAG }}
           fi
@@ -138,7 +138,7 @@ jobs:
           if ${{ env.CADICAL_TAG == 'latest' }}
           then
             CADICAL_REL="https://api.github.com/repos/arminbiere/cadical/releases/latest"
-            CADICAL_TAG_NAME=$(curl -s $CADICAL_REL | jq -r '.tag_name')
+            CADICAL_TAG_NAME=$(curl -s $CADICAL_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.tag_name')
           else
             CADICAL_TAG_NAME=${{ env.CADICAL_TAG }}
           fi


### PR DESCRIPTION
*Issue #, if available:* N/A - The `Run CBMC proofs` jobs have been intermittently failing as of late (see, for example, [this CI run](https://github.com/awslabs/aws-c-common/actions/runs/6043368449/job/16400257070?pr=1054)). This appears to happen while parsing the requests done to the GitHub API (requests done with `curl`, parsing done with `jq`).

The issue is similar to the one in [this discussion](https://github.com/orgs/community/discussions/33700). As mentioned in the last comment, it's possible that requests to the GitHub API are being rate-limited since they're not being authorized.

*Description of changes:* This PR changes the `Run CBMC proofs` workflow so that it authorizes the requests to the GitHub API with the secret available through `${{ secrets.GITHUB_TOKEN }}`. I've followed the example shown in GitHub documentation [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). Unfortunately, changes to GA workflows cannot be reliably test, especially considering that the failure is intermittent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
