### PR TITLE
Include `winsock.h` to define `htonl` on Windows

### DIFF
--- a/include/aws/common/byte_order.inl
+++ b/include/aws/common/byte_order.inl
@@ -11,6 +11,7 @@
 
 #ifdef _WIN32
 #    include <stdlib.h>
+#    include <winsock.h>
 #else
 #    include <netinet/in.h>
 #endif /* _MSC_VER */


### PR DESCRIPTION
[`htonl`](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-htonl) is defined in `winsock.h`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
