### PR TITLE
Add error codes for file read/write/open failures

### DIFF
--- a/include/aws/common/error.h
+++ b/include/aws/common/error.h
@@ -132,6 +132,14 @@ void aws_unregister_error_info(const struct aws_error_info_list *error_info);
 
 /**
  * Convert a c library io error into an aws error, and raise it.
+ * If no conversion is found, fallback_aws_error_code is raised.
+ * Always returns AWS_OP_ERR.
+ */
+AWS_COMMON_API
+int aws_translate_and_raise_io_error_or(int error_no, int fallback_aws_error_code);
+
+/**
+ * Convert a c library io error into an aws error, and raise it.
  * If no conversion is found, AWS_ERROR_SYS_CALL_FAILURE is raised.
  * Always returns AWS_OP_ERR.
  */
@@ -202,6 +210,9 @@ enum aws_common_error {
     AWS_ERROR_INVALID_UTF8,
     AWS_ERROR_GET_HOME_DIRECTORY_FAILED,
     AWS_ERROR_INVALID_XML,
+    AWS_ERROR_FILE_OPEN_FAILURE,
+    AWS_ERROR_FILE_READ_FAILURE,
+    AWS_ERROR_FILE_WRITE_FAILURE,
     AWS_ERROR_END_COMMON_RANGE = AWS_ERROR_ENUM_END_RANGE(AWS_C_COMMON_PACKAGE_ID)
 };
 

--- a/include/aws/common/file.h
+++ b/include/aws/common/file.h
@@ -191,6 +191,8 @@ bool aws_path_exists(const struct aws_string *path);
  *   fseeko() on linux
  *
  * whence can either be SEEK_SET or SEEK_END
+ *
+ * Returns AWS_OP_SUCCESS, or AWS_OP_ERR (after an error has been raised).
  */
 AWS_COMMON_API
 int aws_fseek(FILE *file, int64_t offset, int whence);

--- a/source/common.c
+++ b/source/common.c
@@ -220,7 +220,7 @@ static struct aws_error_info errors[] = {
     ),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_SYS_CALL_FAILURE,
-        "System call failure"),
+        "System call failure."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_FILE_INVALID_PATH,
         "Invalid file path."),
@@ -232,7 +232,7 @@ static struct aws_error_info errors[] = {
         "User does not have permission to perform the requested action."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_STREAM_UNSEEKABLE,
-        "Stream does not support seek operations"),
+        "Stream does not support seek operations."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_C_STRING_BUFFER_NOT_NULL_TERMINATED,
         "A c-string like buffer was passed but a null terminator was not found within the bounds of the buffer."),
@@ -244,7 +244,7 @@ static struct aws_error_info errors[] = {
         "Attempt to divide a number by zero."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_INVALID_FILE_HANDLE,
-        "Invalid file handle"),
+        "Invalid file handle."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_OPERATION_INTERUPTED,
         "The operation was interrupted."
@@ -255,16 +255,25 @@ static struct aws_error_info errors[] = {
     ),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_PLATFORM_NOT_SUPPORTED,
-        "Feature not supported on this platform"),
+        "Feature not supported on this platform."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_INVALID_UTF8,
-        "Invalid UTF-8"),
+        "Invalid UTF-8."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_GET_HOME_DIRECTORY_FAILED,
-        "Failed to get home directory"),
+        "Failed to get home directory."),
     AWS_DEFINE_ERROR_INFO_COMMON(
         AWS_ERROR_INVALID_XML,
-        "Invalid XML document"),
+        "Invalid XML document."),
+    AWS_DEFINE_ERROR_INFO_COMMON(
+        AWS_ERROR_FILE_OPEN_FAILURE,
+        "Failed opening file."),
+    AWS_DEFINE_ERROR_INFO_COMMON(
+        AWS_ERROR_FILE_READ_FAILURE,
+        "Failed reading from file."),
+    AWS_DEFINE_ERROR_INFO_COMMON(
+        AWS_ERROR_FILE_WRITE_FAILURE,
+        "Failed writing to file."),
 };
 /* clang-format on */
 

--- a/source/log_writer.c
+++ b/source/log_writer.c
@@ -27,8 +27,8 @@ static int s_aws_file_writer_write(struct aws_log_writer *writer, const struct a
 
     size_t length = output->len;
     if (fwrite(output->bytes, 1, length, impl->log_file) < length) {
-        int errno_value = errno; /* Always cache errno before potential side-effect */
-        return aws_translate_and_raise_io_error(errno_value);
+        int errno_value = ferror(impl->log_file) ? errno : 0; /* Always cache errno before potential side-effect */
+        return aws_translate_and_raise_io_error_or(errno_value, AWS_ERROR_FILE_WRITE_FAILURE);
     }
 
     return AWS_OP_SUCCESS;

--- a/source/logging.c
+++ b/source/logging.c
@@ -502,8 +502,8 @@ static int s_noalloc_stderr_logger_log(
 
     int write_result = AWS_OP_SUCCESS;
     if (fwrite(format_buffer, 1, format_data.amount_written, impl->file) < format_data.amount_written) {
-        int errno_value = errno; /* Always cache errno before potential side-effect */
-        aws_translate_and_raise_io_error(errno_value);
+        int errno_value = ferror(impl->file) ? errno : 0; /* Always cache errno before potential side-effect */
+        aws_translate_and_raise_io_error_or(errno_value, AWS_ERROR_FILE_WRITE_FAILURE);
         write_result = AWS_OP_ERR;
     }
 

--- a/source/posix/file.c
+++ b/source/posix/file.c
@@ -18,7 +18,7 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
     FILE *f = fopen(aws_string_c_str(file_path), aws_string_c_str(mode));
     if (!f) {
         int errno_cpy = errno; /* Always cache errno before potential side-effect */
-        aws_translate_and_raise_io_error(errno_cpy);
+        aws_translate_and_raise_io_error_or(errno_cpy, AWS_ERROR_FILE_OPEN_FAILURE);
         AWS_LOGF_ERROR(
             AWS_LS_COMMON_IO,
             "static: Failed to open file. path:'%s' mode:'%s' errno:%d aws-error:%d(%s)",
@@ -285,7 +285,7 @@ int aws_fseek(FILE *file, int64_t offset, int whence) {
     int errno_value = errno; /* Always cache errno before potential side-effect */
 
     if (result != 0) {
-        return aws_translate_and_raise_io_error(errno_value);
+        return aws_translate_and_raise_io_error_or(errno_value, AWS_ERROR_STREAM_UNSEEKABLE);
     }
 
     return AWS_OP_SUCCESS;

--- a/source/windows/file.c
+++ b/source/windows/file.c
@@ -44,7 +44,7 @@ FILE *aws_fopen_safe(const struct aws_string *file_path, const struct aws_string
     aws_wstring_destroy(w_file_path);
 
     if (error) {
-        aws_translate_and_raise_io_error(error);
+        aws_translate_and_raise_io_error_or(error, AWS_ERROR_FILE_OPEN_FAILURE);
         AWS_LOGF_ERROR(
             AWS_LS_COMMON_IO,
             "static: Failed to open file. path:'%s' mode:'%s' errno:%d aws-error:%d(%s)",
@@ -508,7 +508,7 @@ bool aws_path_exists(const struct aws_string *path) {
 int aws_fseek(FILE *file, int64_t offset, int whence) {
     if (_fseeki64(file, offset, whence)) {
         int errno_value = errno; /* Always cache errno before potential side-effect */
-        return aws_translate_and_raise_io_error(errno_value);
+        return aws_translate_and_raise_io_error_or(errno_value, AWS_ERROR_STREAM_UNSEEKABLE);
     }
 
     return AWS_OP_SUCCESS;


### PR DESCRIPTION
I wanted to raise something more specific than AWS_ERROR_SYS_CALL_FAILURE when an S3 operation failed due to an failed fwrite() to disk. Then it seemed weird to add a WRITE_FAILURE code, but no READ_FAILURE or OPEN_FAILURE codes.

**Description of changes:**
- New error codes: `AWS_ERROR_FILE_(OPEN/READ/WRITE)_FAILURE`
- Add new variant of `aws_translate_and_raise_io_error()` that lets you suggest a fallback error-code if no good match is found

**Debatable Issues:**
aws-c-io already has AWS_IO_STREAM_READ_FAILED. This makes it weird to add AWS_ERROR_FILE_READ_FAILURE to aws-c-common. In a perfect world, we'd move the error from aws-c-io to aws-c-common and possibly rename it, but either of those actions would be a breaking change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
