### PR TITLE
Fix loading of libnuma.so

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -323,15 +323,15 @@ void aws_common_library_init(struct aws_allocator *allocator) {
            assumptions due to the way loaders and dlload are often implemented and those symbols are defined by things
            like libpthread.so on some unix distros. Sorry about the memory usage here, but it's our only safe choice.
            Also, please don't do numa configurations if memory is your economic bottleneck. */
-        g_libnuma_handle = dlopen("libnuma.so", RTLD_LOCAL);
+        g_libnuma_handle = dlopen("libnuma.so", RTLD_LAZY | RTLD_LOCAL);
 
         /* turns out so versioning is really inconsistent these days */
         if (!g_libnuma_handle) {
-            g_libnuma_handle = dlopen("libnuma.so.1", RTLD_LOCAL);
+            g_libnuma_handle = dlopen("libnuma.so.1", RTLD_LAZY | RTLD_LOCAL);
         }
 
         if (!g_libnuma_handle) {
-            g_libnuma_handle = dlopen("libnuma.so.2", RTLD_LOCAL);
+            g_libnuma_handle = dlopen("libnuma.so.2", RTLD_LAZY | RTLD_LOCAL);
         }
 
         if (g_libnuma_handle) {


### PR DESCRIPTION
*Description of changes:*
- our loading of `libnuma.so` never worked because of `invalid mode for dlopen(): Invalid argument` error. According to https://man7.org/linux/man-pages/man3/dlopen.3.html, RTLD_LAZY or RTLD_NOW must be included in flags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
