### PR TITLE
Fix WSL Crash

### DIFF
--- a/source/posix/system_info.c
+++ b/source/posix/system_info.c
@@ -50,7 +50,7 @@ size_t aws_system_info_processor_count(void) {
 
 uint16_t aws_get_cpu_group_count(void) {
     if (g_numa_num_configured_nodes_ptr) {
-        return (uint16_t)g_numa_num_configured_nodes_ptr();
+        return aws_max_u16(1, (uint16_t)g_numa_num_configured_nodes_ptr());
     }
 
     return 1U;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-cli/issues/8320

*Description of changes:*
- On WSL, it is possible that Numa is present but `g_numa_num_configured_nodes_ptr` returns 0 which breaks assumption of our system that cpu_group_count will be at least 1 and crashes at https://github.com/awslabs/aws-c-s3/blob/main/source/s3_platform_info.c#L317. `aws_get_cpu_count_for_group` can also return 0 but we do throw proper error if it is 0. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
