### PR TITLE
Fixed directory creation to ignore umask, and allow cross process loc…

### DIFF
--- a/source/posix/cross_process_lock.c
+++ b/source/posix/cross_process_lock.c
@@ -46,9 +46,11 @@ struct aws_cross_process_lock *aws_cross_process_lock_try_acquire(
     struct aws_byte_cursor path_prefix = aws_byte_cursor_from_c_str("/tmp/aws_crt_cross_process_lock/");
     struct aws_string *path_to_create = aws_string_new_from_cursor(allocator, &path_prefix);
 
-    /* it's probably there already and we don't care if it is. The open will fail, and we will handle it there
-     * if we can't open it due to permissions. */
-    aws_directory_create(path_to_create);
+    /* It's probably there already and we don't care if it is. */
+    if (!aws_directory_exists(path_to_create)) {
+        /* if this call fails just let it fail on open below. */
+        aws_directory_create(path_to_create);
+    }
     aws_string_destroy(path_to_create);
 
     struct aws_byte_cursor path_suffix = aws_byte_cursor_from_c_str(".lock");

--- a/source/posix/cross_process_lock.c
+++ b/source/posix/cross_process_lock.c
@@ -8,7 +8,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/file.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include <aws/common/error.h>

--- a/source/posix/cross_process_lock.c
+++ b/source/posix/cross_process_lock.c
@@ -41,7 +41,7 @@ struct aws_cross_process_lock *aws_cross_process_lock_try_acquire(
      * The unix standard says /tmp has to be there and be writable. However, while it may be tempting to just use the
      * /tmp/ directory, it often has the sticky bit set which would prevent a subprocess from being able to call open
      * with create on the file. The solution is simple, just write it to a subdirectory inside
-     * /tmp using the same perms as the current process.
+     * /tmp using 0777 (default behavior for directory creation, as aws_directory_create() overrides umask).
      */
     struct aws_byte_cursor path_prefix = aws_byte_cursor_from_c_str("/tmp/aws_crt_cross_process_lock/");
     struct aws_string *path_to_create = aws_string_new_from_cursor(allocator, &path_prefix);

--- a/source/posix/file.c
+++ b/source/posix/file.c
@@ -40,6 +40,9 @@ int aws_directory_create(const struct aws_string *dir_path) {
         return aws_translate_and_raise_io_error(errno_value);
     }
 
+    /* bypass umask by setting the perms we actually requested */
+    chmod(aws_string_c_str(dir_path), S_IRWXU | S_IRWXG | S_IRWXO);
+
     return AWS_OP_SUCCESS;
 }
 

--- a/source/posix/file.c
+++ b/source/posix/file.c
@@ -40,9 +40,6 @@ int aws_directory_create(const struct aws_string *dir_path) {
         return aws_translate_and_raise_io_error(errno_value);
     }
 
-    /* bypass umask by setting the perms we actually requested */
-    chmod(aws_string_c_str(dir_path), S_IRWXU | S_IRWXG | S_IRWXO);
-
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
…k to fall back to read only if it can't open the file in rw mode.

testing on this one is hard to automate. Here's how I verified:

create lock directory as user, create lock as user, make sure it works
create lock dir as user, create lock as root, make sure it works for user
create lock dir as root, create lock as root, make sure it works for user
create lock dir as root, try to create lock as user, make sure it works for user.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
