### PR TITLE
s_has_vpclmulqdq fix

### DIFF
--- a/source/arch/intel/cpuid.c
+++ b/source/arch/intel/cpuid.c
@@ -116,8 +116,8 @@ static bool s_has_bmi2(void) {
 static bool s_has_vpclmulqdq(void) {
     uint32_t abcd[4];
     /* Check VPCLMULQDQ:
-     * CPUID.(EAX=07H, ECX=0H):ECX.VPCLMULQDQ[bit 20]==1 */
-    uint32_t vpclmulqdq_mask = (1 << 20);
+     * CPUID.(EAX=07H, ECX=0H):ECX.VPCLMULQDQ[bit 10]==1 */
+    uint32_t vpclmulqdq_mask = (1 << 10);
     aws_run_cpuid(7, 0, abcd);
     if ((abcd[2] & vpclmulqdq_mask) != vpclmulqdq_mask) {
         return false;


### PR DESCRIPTION
check correct bit for VPCLMULQDQ

*Issue #, if available:*
https://github.com/awslabs/aws-c-common/issues/1084

*Description of changes:*
s_has_vpclmulqdq() is not checking the co

> rrect bit to detect VPCLMULQDQ.
> According to the documentation it is bit 10. (code is checking bit 20).
> 
> Input Output
> EAX=07H, ECX=0 ECX[bit 10] VPCLMULQDQ
> EAX=07H, ECX=0 EBX[bit 16] AVX512F
> EAX=07H, ECX=0 EBX[bit 31] AVX512VL
> 
> https://en.wikichip.org/wiki/x86/vpclmulqdq


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
