### PR TITLE
Fix a bunch of places we forget to aws_raise_error()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.49
+  BUILDER_VERSION: v0.9.55
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-c-common

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: v0.9.37
+  BUILDER_VERSION: v0.9.55
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-c-common

--- a/include/aws/common/json.h
+++ b/include/aws/common/json.h
@@ -400,7 +400,7 @@ int aws_byte_buf_append_json_string(const struct aws_json_value *value, struct a
  * @param value The aws_json_value to format.
  * @param output The destination for the JSON string
  * @return AWS_OP_SUCCESS if the JSON string was allocated to output without any errors
- *      Will return AWS_ERROR_INVALID_ARGUMENT if the value passed is not an aws_json_value or if there
+ *      Will return AWS_OP_ERR if the value passed is not an aws_json_value or if there
  *      aws an error appending the JSON into the byte buffer.
  */
 AWS_COMMON_API

--- a/source/json.c
+++ b/source/json.c
@@ -397,7 +397,7 @@ int aws_byte_buf_append_json_string(const struct aws_json_value *value, struct a
 
     char *tmp = cJSON_PrintUnformatted(cjson);
     if (tmp == NULL) {
-        return AWS_OP_ERR;
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
     // Append the text to the byte buffer
@@ -415,7 +415,7 @@ int aws_byte_buf_append_json_string_formatted(const struct aws_json_value *value
 
     char *tmp = cJSON_Print(cjson);
     if (tmp == NULL) {
-        return AWS_OP_ERR;
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
     // Append the text to the byte buffer

--- a/source/log_formatter.c
+++ b/source/log_formatter.c
@@ -205,7 +205,7 @@ static int s_default_aws_log_formatter_format(
     struct aws_default_log_formatter_impl *impl = formatter->impl;
 
     if (formatted_output == NULL) {
-        return AWS_OP_ERR;
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
     /*

--- a/source/logging.c
+++ b/source/logging.c
@@ -337,11 +337,11 @@ int aws_thread_id_t_to_string(aws_thread_id_t thread_id, char *buffer, size_t bu
         unsigned char c = bytes[i - 1];
         int written = snprintf(buffer + current_index, bufsz - current_index, "%02x", c);
         if (written < 0) {
-            return AWS_OP_ERR;
+            return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         }
         current_index += written;
         if (bufsz <= current_index) {
-            return AWS_OP_ERR;
+            return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
         }
     }
     return AWS_OP_SUCCESS;

--- a/tests/encoding_test.c
+++ b/tests/encoding_test.c
@@ -1298,7 +1298,7 @@ static int s_utf8_validation_callback_always_fails(const uint32_t codepoint, voi
 static int s_utf8_validation_callback_always_passes(const uint32_t codepoint, void *user_data) {
     (void)codepoint;
     (void)user_data;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 static struct utf8_example s_valid_utf8_examples_for_callback[] = {


### PR DESCRIPTION
Our [error handling](https://github.com/awslabs/aws-c-common/blob/7f55a9ccd6fb32783afdd706612489a1de992886/README.md#error-handling-1) strategy is simple to explain, but easy to get wrong. Inspired by [this PR](https://github.com/awslabs/aws-c-auth/pull/227) that fixed some obviously-incorrect-code, I decided to search for more easy-to-spot accidents:
- cmd-shift-f (case sensitive) `return AWS_(?!OP_)`: look for places we accidentally return error codes, instead of raising them
- cmd-shift-f `AWS_ERROR_SUCCESS`: look for places we misuse AWS_ERROR_SUCCESS, returning it instead of AWS_OP_SUCCESS. This doesn't cause bugs (they're both 0) but it's not right either.
- cmd-shift-f `return AWS_OP_ERR`: Look for places we return AWS_OP_ERR without an error having been raised beforehand. I found A LOT of these mistakes, but I'm sure there are more.

TODO in the future:
- cmd-shift-f `return NULL` (there are 1500+ of these)
- Give more attention to the following files. Which I know have way more problems, but I gave up:
    - json.c in aws-c-common
    -  darwin_pki_utils.c in aws-c-io
    - secure_tunneling.c in aws-c-iot
    - serializer.c in aws-c-iot

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
