### PR TITLE
claim range for aws-crt-kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ have pre-slotted log subjects & error codes for each library. The currently allo
 | [0x3400, 0x3800) | aws-c-iot |
 | [0x3800, 0x3C00) | aws-c-s3 |
 | [0x3C00, 0x4000) | aws-c-sdkutils |
-| [0x4000, 0x4400) | (reserved for future project) |
+| [0x4000, 0x4400) | aws-crt-kotlin |
 | [0x4400, 0x4800) | (reserved for future project) |
 
 Each library should begin its error and log subject values at the beginning of its range and follow in sequence (don't skip codes). Upon

--- a/include/aws/common/package.h
+++ b/include/aws/common/package.h
@@ -10,7 +10,7 @@
  * Preliminary cap on the number of possible aws-c-libraries participating in shared enum ranges for
  * errors, log subjects, and other cross-library enums. Expandable as needed
  */
-#define AWS_PACKAGE_SLOTS 16
+#define AWS_PACKAGE_SLOTS 32
 
 /*
  * Each aws-c-* and aws-crt-* library has a unique package id starting from zero.  These are used to macro-calculate


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
* Claims package ID 16 for `aws-crt-kotlin` (native) bindings.
* Increase max package slots to 32

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
