### PR TITLE
Best Effort Thread Pinning to CPU_ID

### DIFF
--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -277,7 +277,7 @@ int s_init_pthread_attr(size_t stack_size, int32_t cpu_id, pthread_attr_t *out_a
         CPU_ZERO(&cpuset);
         CPU_SET((uint32_t)cpu_id, &cpuset);
 
-        attr_return = pthread_attr_setaffinity_np(attributes_ptr, sizeof(cpuset), &cpuset);
+        attr_return = pthread_attr_setaffinity_np(out_attributes, sizeof(cpuset), &cpuset);
 
         if (attr_return) {
             AWS_LOGF_ERROR(

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -381,9 +381,9 @@ cleanup:
 
     if (attr_return) {
         s_thread_wrapper_destroy(wrapper);
-        if ((attr_return == EINVAL || attr_return == EDEADLK) && (options && options->cpu_id >= 0)) {
+        if (options && options->cpu_id >= 0) {
             /*
-             * `pthread_create` can fail with an `EINVAL` error or `EAGAIN` on freebasd if the `cpu_id` is
+             * `pthread_create` can fail with an `EINVAL` error or `EDEADLK` on freebasd if the `cpu_id` is
              * restricted/invalid. Since the pinning to a particular `cpu_id` is supposed to be best-effort, try to
              * launch a thread again without pinning to a specific cpu_id.
              */

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -278,7 +278,7 @@ int s_init_pthread_attr(size_t stack_size, int32_t cpu_id, pthread_attr_t *out_a
 
         if (attr_return) {
             AWS_LOGF_ERROR(AWS_LS_COMMON_THREAD, "pthread_attr_setaffinity_np() failed with %d.", attr_return);
-            return attr_return;
+            /* ignore the error */
         }
     }
 #endif /* AWS_AFFINITY_METHOD == AWS_AFFINITY_METHOD_PTHREAD_ATTR */

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -336,7 +336,7 @@ int aws_thread_launch(
 
     attr_return = pthread_create(&thread->thread_id, attributes_ptr, thread_fn, (void *)wrapper);
 
-    if (attr_return == EINVAL && options->cpu_id >= 0) {
+    if (attr_return == EINVAL && options && options->cpu_id >= 0) {
         /* try without cpu_id */
         AWS_LOGF_DEBUG(
             AWS_LS_COMMON_THREAD,

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -301,6 +301,7 @@ int aws_thread_launch(
                     "id=%p: pthread_attr_setaffinity_np() failed with %d. Continuing without cpu affinity",
                     (void *)thread,
                     attr_return);
+                goto cleanup;
             }
         }
 #endif /* AWS_AFFINITY_METHOD == AWS_AFFINITY_METHOD_PTHREAD_ATTR */

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -266,18 +266,18 @@ int s_init_pthread_attr(size_t stack_size, int32_t cpu_id, pthread_attr_t *out_a
  * Thread affinity is also not supported on Android systems, and honestly, if you're running android on a NUMA
  * configuration, you've got bigger problems. */
 #if AWS_AFFINITY_METHOD == AWS_AFFINITY_METHOD_PTHREAD_ATTR
-    if (cpu_id >= 0) {
+    if (options->cpu_id >= 0) {
         AWS_LOGF_INFO(
             AWS_LS_COMMON_THREAD,
             "id=%p: cpu affinity of cpu_id %d was specified, attempting to honor the value.",
             (void *)thread,
-            cpu_id);
+            options->cpu_id);
 
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
-        CPU_SET((uint32_t)cpu_id, &cpuset);
+        CPU_SET((uint32_t)options->cpu_id, &cpuset);
 
-        attr_return = pthread_attr_setaffinity_np(attributes_ptr, sizeof(cpuset), &cpuset);
+        attr_return = pthread_attr_setaffinity_np(out_attributes, sizeof(cpuset), &cpuset);
 
         if (attr_return) {
             AWS_LOGF_ERROR(
@@ -343,28 +343,9 @@ int aws_thread_launch(
 
     attr_return = pthread_create(&thread->thread_id, attributes_ptr, thread_fn, (void *)wrapper);
 
-    if (attr_return == EINVAL && options->cpu_id >= 0) {
-        /* try without cpu_id */
-        AWS_LOGF_DEBUG(
-            AWS_LS_COMMON_THREAD,
-            "id=%p: pthread_create() failed with %d and cpu_id:%d, trying without cpu_id",
-            (void *)thread,
-            attr_return,
-            options->cpu_id);
-        if (attributes_ptr) {
-            pthread_attr_destroy(attributes_ptr);
-        }
-        wrapper->membind = false;
-        attr_return = s_init_pthread_attr(options->stack_size, options->cpu_id, &attributes);
-        if (attr_return) {
-            goto cleanup;
-        }
-        attributes_ptr = &attributes;
-        attr_return = pthread_create(&thread->thread_id, attributes_ptr, thread_fn, (void *)wrapper);
-    }
-
     if (attr_return) {
-        AWS_LOGF_ERROR(AWS_LS_COMMON_THREAD, "id=%p: pthread_create() failed with %d", (void *)thread, attr_return);
+        if (att)
+            AWS_LOGF_ERROR(AWS_LS_COMMON_THREAD, "id=%p: pthread_create() failed with %d", (void *)thread, attr_return);
         if (is_managed_thread) {
             aws_thread_decrement_unjoined_count();
         }

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -388,7 +388,7 @@ cleanup:
                 if (options && options->cpu_id >= 0) {
                     /*
                      * Sometimes, `pthread_create` can fail with an `EINVAL` error if the `cpu_id` is restricted. Since
-                     * the pinning to a particular `cpu_id` is supposed to be best effort, try to launch a thread
+                     * the pinning to a particular `cpu_id` is supposed to be best-effort, try to launch a thread
                      * again without pinning to a specific cpu_id.
                      */
                     struct aws_thread_options new_options = *options;

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -266,16 +266,16 @@ int s_init_pthread_attr(size_t stack_size, int32_t cpu_id, pthread_attr_t *out_a
  * Thread affinity is also not supported on Android systems, and honestly, if you're running android on a NUMA
  * configuration, you've got bigger problems. */
 #if AWS_AFFINITY_METHOD == AWS_AFFINITY_METHOD_PTHREAD_ATTR
-    if (options->cpu_id >= 0) {
+    if (cpu_id >= 0) {
         AWS_LOGF_INFO(
             AWS_LS_COMMON_THREAD,
             "id=%p: cpu affinity of cpu_id %d was specified, attempting to honor the value.",
             (void *)thread,
-            options->cpu_id);
+            cpu_id);
 
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
-        CPU_SET((uint32_t)options->cpu_id, &cpuset);
+        CPU_SET((uint32_t)cpu_id, &cpuset);
 
         attr_return = pthread_attr_setaffinity_np(attributes_ptr, sizeof(cpuset), &cpuset);
 
@@ -354,6 +354,7 @@ int aws_thread_launch(
         if (attributes_ptr) {
             pthread_attr_destroy(attributes_ptr);
         }
+        wrapper->membind = false;
         attr_return = s_init_pthread_attr(options->stack_size, options->cpu_id, &attributes);
         if (attr_return) {
             goto cleanup;

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -392,7 +392,7 @@ cleanup:
                      */
                     AWS_LOGF_INFO(
                         AWS_LS_COMMON_THREAD,
-                        "id=%p: Attempting to launch the thread again without specifying cpu_id",
+                        "id=%p: Attempting to launch the thread again without pinning to a cpu_id",
                         (void *)thread);
                     struct aws_thread_options new_options = *options;
                     new_options.cpu_id = -1;

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -296,12 +296,11 @@ int aws_thread_launch(
             attr_return = pthread_attr_setaffinity_np(attributes_ptr, sizeof(cpuset), &cpuset);
 
             if (attr_return) {
-                AWS_LOGF_ERROR(
+                AWS_LOGF_WARN(
                     AWS_LS_COMMON_THREAD,
-                    "id=%p: pthread_attr_setaffinity_np() failed with %d.",
+                    "id=%p: pthread_attr_setaffinity_np() failed with %d. Continuing without cpu affinity",
                     (void *)thread,
                     attr_return);
-                goto cleanup;
             }
         }
 #endif /* AWS_AFFINITY_METHOD == AWS_AFFINITY_METHOD_PTHREAD_ATTR */

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -268,10 +268,7 @@ int s_init_pthread_attr(size_t stack_size, int32_t cpu_id, pthread_attr_t *out_a
 #if AWS_AFFINITY_METHOD == AWS_AFFINITY_METHOD_PTHREAD_ATTR
     if (cpu_id >= 0) {
         AWS_LOGF_INFO(
-            AWS_LS_COMMON_THREAD,
-            "id=%p: cpu affinity of cpu_id %d was specified, attempting to honor the value.",
-            (void *)thread,
-            cpu_id);
+            AWS_LS_COMMON_THREAD, "cpu affinity of cpu_id %d was specified, attempting to honor the value.", cpu_id);
 
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
@@ -280,11 +277,7 @@ int s_init_pthread_attr(size_t stack_size, int32_t cpu_id, pthread_attr_t *out_a
         attr_return = pthread_attr_setaffinity_np(out_attributes, sizeof(cpuset), &cpuset);
 
         if (attr_return) {
-            AWS_LOGF_ERROR(
-                AWS_LS_COMMON_THREAD,
-                "id=%p: pthread_attr_setaffinity_np() failed with %d.",
-                (void *)thread,
-                attr_return);
+            AWS_LOGF_ERROR(AWS_LS_COMMON_THREAD, "pthread_attr_setaffinity_np() failed with %d.", attr_return);
             return attr_return;
         }
     }

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -386,8 +386,13 @@ cleanup:
         switch (attr_return) {
             case EINVAL:
                 if (options && options->cpu_id >= 0) {
+                    /*
+                     * Sometimes, `pthread_create` can fail with an `EINVAL` error if the `cpu_id` is restricted. Since
+                     * the pinning to a particular `cpu_id` is supposed to be best effort, try to launch a thread
+                     * again without pinning to a specific cpu_id.
+                     */
                     struct aws_thread_options new_options = *options;
-                    // new_options.cpu_id = -1;
+                    new_options.cpu_id = -1;
                     return aws_thread_launch(thread, func, arg, &new_options);
                 }
                 return aws_raise_error(AWS_ERROR_THREAD_INVALID_SETTINGS);

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -348,7 +348,7 @@ int aws_thread_launch(
             pthread_attr_destroy(attributes_ptr);
         }
         wrapper->membind = false;
-        attr_return = s_init_pthread_attr(options->stack_size, options->cpu_id, &attributes);
+        attr_return = s_init_pthread_attr(options->stack_size, -1, &attributes);
         if (attr_return) {
             goto cleanup;
         }

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -381,7 +381,7 @@ cleanup:
 
     if (attr_return) {
         s_thread_wrapper_destroy(wrapper);
-        if ((attr_return == EINVAL || attr_return == EAGAIN) && (options && options->cpu_id >= 0)) {
+        if ((attr_return == EINVAL || attr_return == EDEADLK) && (options && options->cpu_id >= 0)) {
             /*
              * `pthread_create` can fail with an `EINVAL` error or `EAGAIN` on freebasd if the `cpu_id` is
              * restricted/invalid. Since the pinning to a particular `cpu_id` is supposed to be best-effort, try to

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -386,10 +386,14 @@ cleanup:
             case EINVAL:
                 if (options && options->cpu_id >= 0) {
                     /*
-                     * Sometimes, `pthread_create` can fail with an `EINVAL` error if the `cpu_id` is restricted. Since
+                     * `pthread_create` can fail with an `EINVAL` error if the `cpu_id` is restricted. Since
                      * the pinning to a particular `cpu_id` is supposed to be best-effort, try to launch a thread
                      * again without pinning to a specific cpu_id.
                      */
+                    AWS_LOGF_INFO(
+                        AWS_LS_COMMON_THREAD,
+                        "id=%p: Attempting to launch the thread again without specifying cpu_id",
+                        (void *)thread);
                     struct aws_thread_options new_options = *options;
                     new_options.cpu_id = -1;
                     return aws_thread_launch(thread, func, arg, &new_options);

--- a/source/posix/thread.c
+++ b/source/posix/thread.c
@@ -387,7 +387,7 @@ cleanup:
             case EINVAL:
                 if (options && options->cpu_id >= 0) {
                     struct aws_thread_options new_options = *options;
-                    new_options.cpu_id = -1;
+                    // new_options.cpu_id = -1;
                     return aws_thread_launch(thread, func, arg, &new_options);
                 }
                 return aws_raise_error(AWS_ERROR_THREAD_INVALID_SETTINGS);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_test_case(aws_load_error_strings_test)
 add_test_case(aws_assume_compiles_test)
 
 add_test_case(thread_creation_join_test)
+add_test_case(thread_creation_join_invalid_cpu_id_test)
 add_test_case(thread_atexit_test)
 add_test_case(test_managed_thread_join)
 add_test_case(test_managed_thread_join_timeout)

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -70,6 +70,47 @@ static int s_test_thread_creation_join_fn(struct aws_allocator *allocator, void 
 
 AWS_TEST_CASE(thread_creation_join_test, s_test_thread_creation_join_fn)
 
+static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    aws_common_library_init(allocator);
+    struct thread_test_data test_data = {.allocator = allocator};
+
+    struct aws_thread thread;
+    aws_thread_init(&thread, allocator);
+
+    struct aws_thread_options thread_options = *aws_default_thread_options();
+    /* invalid CPU id, make sure that cpu id is best effort based */
+    thread_options.cpu_id = INT32_MAX;
+
+    ASSERT_SUCCESS(
+        aws_thread_launch(&thread, s_thread_fn, (void *)&test_data, &thread_options), "thread creation failed");
+    ASSERT_INT_EQUALS(
+        AWS_THREAD_JOINABLE, aws_thread_get_detach_state(&thread), "thread state should have returned JOINABLE");
+    ASSERT_SUCCESS(aws_thread_join(&thread), "thread join failed");
+    ASSERT_TRUE(
+        aws_thread_thread_id_equal(test_data.thread_id, aws_thread_get_id(&thread)),
+        "get_thread_id should have returned the same id as the thread calling current_thread_id");
+    ASSERT_INT_EQUALS(
+        AWS_THREAD_JOIN_COMPLETED,
+        aws_thread_get_detach_state(&thread),
+        "thread state should have returned JOIN_COMPLETED");
+
+    if (AWS_OP_SUCCESS == test_data.get_thread_name_error) {
+        ASSERT_CURSOR_VALUE_STRING_EQUALS(
+            aws_byte_cursor_from_c_str("MyThreadName"), test_data.thread_name, "thread name equals");
+    } else {
+        ASSERT_INT_EQUALS(test_data.get_thread_name_error, AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+    }
+
+    aws_string_destroy(test_data.thread_name);
+    aws_thread_clean_up(&thread);
+    aws_common_library_clean_up();
+
+    return 0;
+}
+
+AWS_TEST_CASE(thread_creation_join_invalid_cpu_id_test, s_test_thread_creation_join_invalid_cpu_id_fn)
+
 static uint32_t s_atexit_call_count = 0;
 static void s_thread_atexit_fn(void *user_data) {
     (void)user_data;

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -80,7 +80,7 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
 
     struct aws_thread_options thread_options = *aws_default_thread_options();
     /* invalid CPU id, make sure that cpu id is best effort based */
-    thread_options.cpu_id = INT32_MAX;
+    thread_options.cpu_id = 512;
 
     ASSERT_SUCCESS(
         aws_thread_launch(&thread, s_thread_fn, (void *)&test_data, &thread_options), "thread creation failed");

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -80,7 +80,7 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
 
     struct aws_thread_options thread_options = *aws_default_thread_options();
     /* invalid CPU id, make sure that cpu id is best effort based */
-    thread_options.cpu_id = 512;
+    thread_options.cpu_id = INT32_MAX;
 
     ASSERT_SUCCESS(
         aws_thread_launch(&thread, s_thread_fn, (void *)&test_data, &thread_options), "thread creation failed");

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -95,13 +95,6 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
         aws_thread_get_detach_state(&thread),
         "thread state should have returned JOIN_COMPLETED");
 
-    if (AWS_OP_SUCCESS == test_data.get_thread_name_error) {
-        ASSERT_CURSOR_VALUE_STRING_EQUALS(
-            aws_byte_cursor_from_c_str("MyThreadName"), test_data.thread_name, "thread name equals");
-    } else {
-        ASSERT_INT_EQUALS(test_data.get_thread_name_error, AWS_ERROR_PLATFORM_NOT_SUPPORTED);
-    }
-
     aws_string_destroy(test_data.thread_name);
     aws_thread_clean_up(&thread);
     aws_common_library_clean_up();

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -80,7 +80,7 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
 
     struct aws_thread_options thread_options = *aws_default_thread_options();
     /* invalid cpu_id. Ensure that the cpu_id is best-effort based. */
-    thread_options.cpu_id = INT32_MAX;
+    thread_options.cpu_id = 1024;
 
     ASSERT_SUCCESS(
         aws_thread_launch(&thread, s_thread_fn, (void *)&test_data, &thread_options), "thread creation failed");

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -79,7 +79,7 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
     aws_thread_init(&thread, allocator);
 
     struct aws_thread_options thread_options = *aws_default_thread_options();
-    /* invalid CPU id, make sure that cpu id is best effort based */
+    /* invalid cpu_id. Ensure that the cpu_id is best-effort based. */
     thread_options.cpu_id = INT32_MAX;
 
     ASSERT_SUCCESS(

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -80,7 +80,7 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
 
     struct aws_thread_options thread_options = *aws_default_thread_options();
     /* invalid cpu_id. Ensure that the cpu_id is best-effort based. */
-    thread_options.cpu_id = 1024;
+    thread_options.cpu_id = 4096;
 
     ASSERT_SUCCESS(
         aws_thread_launch(&thread, s_thread_fn, (void *)&test_data, &thread_options), "thread creation failed");


### PR DESCRIPTION
*Description of changes:*
Sometimes, `pthread_create` can fail with an `EINVAL` error, or on FreeBSD, it can fail with an `EDEADLK` error if the `cpu_id` is restricted. Since pinning to a particular `cpu_id` is supposed to be best-effort, try to launch a thread again without pinning to a specific `cpu_id`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
