### PR TITLE
Remove unused external headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ file(GLOB AWS_COMMON_HEADERS
         "include/aws/common/*.inl"
         )
 
-file (GLOB AWS_COMMON_EXTERNAL_HEADERS
-        "include/aws/common/external/*.h")
-
 file (GLOB AWS_COMMON_EXTERNAL_INSTALLED_HEADERS
         "include/aws/common/external/ittnotify.h")
 
@@ -82,7 +79,7 @@ if (WIN32)
 
     list(APPEND PLATFORM_DEFINES WINDOWS_KERNEL_LIB=${WINDOWS_KERNEL_LIB})
     # PSAPI_VERSION=1 is needed to support GetProcessMemoryInfo on both pre and
-    # post Win7 OS's. 
+    # post Win7 OS's.
     list(APPEND PLATFORM_DEFINES PSAPI_VERSION=1)
     list(APPEND PLATFORM_LIBS bcrypt ${WINDOWS_KERNEL_LIB} ws2_32 shlwapi psapi)
 else ()
@@ -173,7 +170,6 @@ file(GLOB COMMON_HEADERS
         ${AWS_COMMON_HEADERS}
         ${AWS_COMMON_OS_HEADERS}
         ${AWS_COMMON_PRIV_HEADERS}
-        ${AWS_COMMON_EXTERNAL_HEADERS}
         ${AWS_TEST_HEADERS}
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- `include/aws/common/external/cJSON.h` was removed from https://github.com/awslabs/aws-c-common/pull/1081. 
- We don't need the CMAKE part to install the header file for cJSON

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
