### PR TITLE
Fix invalid cpu_id for RHEL_5

### DIFF
--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -80,7 +80,7 @@ static int s_test_thread_creation_join_invalid_cpu_id_fn(struct aws_allocator *a
 
     struct aws_thread_options thread_options = *aws_default_thread_options();
     /* invalid cpu_id. Ensure that the cpu_id is best-effort based. */
-    thread_options.cpu_id = 4096;
+    thread_options.cpu_id = 512;
 
     ASSERT_SUCCESS(
         aws_thread_launch(&thread, s_thread_fn, (void *)&test_data, &thread_options), "thread creation failed");


### PR DESCRIPTION
*Description of changes:*
- If the CPU id value is too high, it can result in a seg fault instead of just pthread_create call failing with an error. Lower the value to `512` which will still make it invalid as of now but it won't be too large.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
