### PR TITLE
chore: make CBMC stubs with zero parameters proper declarations

### DIFF
--- a/verification/cbmc/include/proof_helpers/aws_byte_cursor_read_common.h
+++ b/verification/cbmc/include/proof_helpers/aws_byte_cursor_read_common.h
@@ -6,7 +6,7 @@
 #include <aws/common/byte_buf.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void aws_byte_cursor_read_common_harness() {
+void aws_byte_cursor_read_common_harness(void) {
     /* parameters */
     struct aws_byte_cursor cur;
     DEST_TYPE *dest = malloc(sizeof(*dest));

--- a/verification/cbmc/include/proof_helpers/make_common_data_structures.h
+++ b/verification/cbmc/include/proof_helpers/make_common_data_structures.h
@@ -127,7 +127,7 @@ void hash_proof_destroy_noop(void *p);
 /**
  * Ensures a valid string is allocated, with as much nondet as possible
  */
-struct aws_string *ensure_string_is_allocated_nondet_length();
+struct aws_string *ensure_string_is_allocated_nondet_length(void);
 
 /**
  * Ensures a valid string is allocated, with as much nondet as possible, but len < max

--- a/verification/cbmc/include/proof_helpers/nondet.h
+++ b/verification/cbmc/include/proof_helpers/nondet.h
@@ -12,11 +12,11 @@
 /**
  * Non-determinstic functions used in CBMC proofs
  */
-bool nondet_bool();
-int nondet_int();
-size_t nondet_size_t();
-uint16_t nondet_uint16_t();
-uint32_t nondet_uint32_t();
-uint64_t nondet_uint64_t();
-uint8_t nondet_uint8_t();
-void *nondet_voidp();
+bool nondet_bool(void);
+int nondet_int(void);
+size_t nondet_size_t(void);
+uint16_t nondet_uint16_t(void);
+uint32_t nondet_uint32_t(void);
+uint64_t nondet_uint64_t(void);
+uint8_t nondet_uint8_t(void);
+void *nondet_voidp(void);

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -189,7 +189,7 @@ bool hash_table_state_has_an_empty_slot(const struct hash_table_state *const sta
  */
 void hash_proof_destroy_noop(void *p) {}
 
-struct aws_string *ensure_string_is_allocated_nondet_length() {
+struct aws_string *ensure_string_is_allocated_nondet_length(void) {
     /* Considers any size up to the maximum possible size for the array [bytes] in aws_string */
     return nondet_allocate_string_bounded_length(SIZE_MAX - 1 - sizeof(struct aws_string));
 }

--- a/verification/cbmc/stubs/abort_override_assert_false.c
+++ b/verification/cbmc/stubs/abort_override_assert_false.c
@@ -11,6 +11,6 @@
 
 #include <assert.h>
 
-void abort() {
+void abort(void) {
     assert(0);
 }


### PR DESCRIPTION
*Description of changes:*

C uses '(void)' to denote this, not an empty list of parameters. This will avoid spurious warnings about type conflicts against C headers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
