### PR TITLE
Fix host parsing for IPv6 URI

### DIFF
--- a/source/uri.c
+++ b/source/uri.c
@@ -382,12 +382,12 @@ static void s_parse_authority(struct uri_parser *parser, struct aws_byte_cursor 
          * brackets.
          * Ignore the sqaure brackets.
          */
-        size_t host_name_offset = is_IPv6_literal ? -1 : 0;
+        size_t host_name_offset = is_IPv6_literal ? 1 : 0;
         size_t host_name_length_correction = is_IPv6_literal ? 2 : 0;
         if (!port_delim) {
             parser->uri->port = 0;
             parser->uri->host_name.ptr = authority_parse_csr.ptr + host_name_offset;
-            parser->uri->host_name.len = port_delim - authority_parse_csr.ptr - host_name_length_correction;
+            parser->uri->host_name.len = authority_parse_csr.len - host_name_length_correction;
             return;
         }
 

--- a/source/uri.c
+++ b/source/uri.c
@@ -382,7 +382,7 @@ static void s_parse_authority(struct uri_parser *parser, struct aws_byte_cursor 
          * brackets.
          * Ignore the sqaure brackets.
          */
-        size_t host_name_offset = is_IPv6_literal ? 1 : 0;
+        size_t host_name_offset = is_IPv6_literal ? -1 : 0;
         size_t host_name_length_correction = is_IPv6_literal ? 2 : 0;
         if (!port_delim) {
             parser->uri->port = 0;

--- a/source/uri.c
+++ b/source/uri.c
@@ -382,16 +382,17 @@ static void s_parse_authority(struct uri_parser *parser, struct aws_byte_cursor 
          * brackets.
          * Ignore the square brackets.
          */
-        size_t host_name_offset = is_IPv6_literal ? 1 : 0;
-        size_t host_name_length_correction = is_IPv6_literal ? 2 : 0;
+        parser->uri->host_name = authority_parse_csr;
+        if (is_IPv6_literal) {
+            aws_byte_cursor_advance(&parser->uri->host_name, 1);
+            parser->uri->host_name.len--;
+        }
         if (!port_delim) {
             parser->uri->port = 0;
-            parser->uri->host_name.ptr = authority_parse_csr.ptr + host_name_offset;
-            parser->uri->host_name.len = authority_parse_csr.len - host_name_length_correction;
             return;
         }
 
-        parser->uri->host_name.ptr = authority_parse_csr.ptr + host_name_offset;
+        size_t host_name_length_correction = is_IPv6_literal ? 2 : 0;
         parser->uri->host_name.len = port_delim - authority_parse_csr.ptr - host_name_length_correction;
         size_t port_len = authority_parse_csr.len - parser->uri->host_name.len - 1 - host_name_length_correction;
         port_delim += 1;

--- a/source/uri.c
+++ b/source/uri.c
@@ -378,9 +378,9 @@ static void s_parse_authority(struct uri_parser *parser, struct aws_byte_cursor 
 
         const uint8_t *port_delim = memchr(port_search_start, ':', port_search_len);
         /*
-         * RFC-3986 section 3.2.2: A host identified by an IPv6 literal address is represented inside the square
+         * RFC-3986 section 3.2.2: A host identified by an IPv6 literal address is represented inside square
          * brackets.
-         * Ignore the sqaure brackets.
+         * Ignore the square brackets.
          */
         size_t host_name_offset = is_IPv6_literal ? 1 : 0;
         size_t host_name_length_correction = is_IPv6_literal ? 2 : 0;

--- a/tests/uri_test.c
+++ b/tests/uri_test.c
@@ -509,7 +509,7 @@ static int s_test_uri_ipv6_parse(struct aws_allocator *allocator, void *ctx) {
         aws_byte_cursor_from_c_str("[2001:db8:85a3:8d3:1319:8a2e:370:7348%25en0]:443");
     ASSERT_BIN_ARRAYS_EQUALS(expected_authority.ptr, expected_authority.len, uri.authority.ptr, uri.authority.len);
 
-    struct aws_byte_cursor expected_host = aws_byte_cursor_from_c_str("[2001:db8:85a3:8d3:1319:8a2e:370:7348%25en0]");
+    struct aws_byte_cursor expected_host = aws_byte_cursor_from_c_str("2001:db8:85a3:8d3:1319:8a2e:370:7348%25en0");
     ASSERT_BIN_ARRAYS_EQUALS(expected_host.ptr, expected_host.len, uri.host_name.ptr, uri.host_name.len);
 
     ASSERT_UINT_EQUALS(443, uri.port);
@@ -540,7 +540,7 @@ static int s_test_uri_ipv6_no_port_parse(struct aws_allocator *allocator, void *
         aws_byte_cursor_from_c_str("[2001:db8:85a3:8d3:1319:8a2e:370:7348%25en0]");
     ASSERT_BIN_ARRAYS_EQUALS(expected_authority.ptr, expected_authority.len, uri.authority.ptr, uri.authority.len);
 
-    struct aws_byte_cursor expected_host = aws_byte_cursor_from_c_str("[2001:db8:85a3:8d3:1319:8a2e:370:7348%25en0]");
+    struct aws_byte_cursor expected_host = aws_byte_cursor_from_c_str("2001:db8:85a3:8d3:1319:8a2e:370:7348%25en0");
     ASSERT_BIN_ARRAYS_EQUALS(expected_host.ptr, expected_host.len, uri.host_name.ptr, uri.host_name.len);
 
     struct aws_byte_cursor expected_path = aws_byte_cursor_from_c_str("");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If it's IPv6 literal uri like `http://[::1]:80/path`, the host is not `[::1]` and is `::1` only. 
RFC: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2
urllib3:
<img width="1343" alt="image" src="https://github.com/awslabs/aws-c-common/assets/7613045/f018b172-4364-469a-953b-191cb8fc10e1">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
