### PR TITLE
Fix aws_host_utils_is_ipv6 function

### DIFF
--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -20,10 +20,6 @@ static bool s_is_ipv6_char(uint8_t value) {
     return aws_isxdigit(value) || value == ':';
 }
 
-static bool s_starts_with(struct aws_byte_cursor cur, uint8_t ch) {
-    return cur.len > 0 && cur.ptr[0] == ch;
-}
-
 static bool s_ends_with(struct aws_byte_cursor cur, uint8_t ch) {
     return cur.len > 0 && cur.ptr[cur.len - 1] == ch;
 }

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -69,22 +69,13 @@ static struct aws_byte_cursor s_percent_uri_enc = AWS_BYTE_CUR_INIT_FROM_STRING_
  * ipv6 literal can be scoped by to zone by appending % followed by zone name
  * ( does not look like there is length reqs on zone name length. this
  * implementation enforces that its > 1 )
- * ipv6 can be embedded in url, in which case it must be wrapped inside []
- * and % be uri encoded as %25.
+ * ipv6 can be embedded in url, in which case % must be uri encoded as %25.
  * Implementation is fairly trivial and just iterates through the string
  * keeping track of the spec above.
  */
 bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
     if (host.len == 0) {
         return false;
-    }
-
-    if (is_uri_encoded) {
-        if (!s_starts_with(host, '[') || !s_ends_with(host, ']')) {
-            return false;
-        }
-        aws_byte_cursor_advance(&host, 1);
-        --host.len;
     }
 
     struct aws_byte_cursor substr = {0};

--- a/tests/host_util_test.c
+++ b/tests/host_util_test.c
@@ -63,11 +63,11 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("z001::8a2e::8745"), false));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::2001:0db8:0000:0000:8a2e:0370:7334"), false));
 
-    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%en0]"), true));
-    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%24en0]"), true));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%en0"), true));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%24en0"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%25en0"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25en0]"), true));
-    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%25]"), true));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25"), true));
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/host_util_test.c
+++ b/tests/host_util_test.c
@@ -46,10 +46,10 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("0:0:0:0:0:0:0:1"), false));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fd00:ec2::23"), false));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fd00:ec2:0:0:0:0:0:23"), false));
-    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[2001:0db8:0000:0000:0000:8a2e:0370:7334]"), true));
-    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1]"), true));
-    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%25en0]"), true));
-    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[2001:db8:85a3:8d3:1319:8a2e:370:7348]"), true));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:0000:0000:0000:8a2e:0370:7334"), true));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1"), true));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25en0"), true));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8:85a3:8d3:1319:8a2e:370:7348"), true));
 
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:0000:0000:0000:8a2e:0370"), false));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:0000:0000:0000:8a2e:0370:"), false));
@@ -63,7 +63,6 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("z001::8a2e::8745"), false));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::2001:0db8:0000:0000:8a2e:0370:7334"), false));
 
-    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25en0"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%en0]"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%24en0]"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%25en0"), true));


### PR DESCRIPTION
*Description of changes:*
- The host will always be stripped of [] and will never be enclosed in it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
