### PR TITLE
Fix test skipping

### DIFF
--- a/cmake/AwsTestHarness.cmake
+++ b/cmake/AwsTestHarness.cmake
@@ -59,6 +59,7 @@ function(generate_test_driver driver_exe_name)
 
     foreach(name IN LISTS TEST_CASES)
         add_test(${name} ${driver_exe_name} "${name}")
+        set_tests_properties("${name}" PROPERTIES SKIP_RETURN_CODE ${SKIP_RETURN_CODE_VALUE})
     endforeach()
 
     # Clear test cases in case another driver needs to be generated


### PR DESCRIPTION
*Issue:*

The SKIP code worked in `aws-crt-cpp`'s tests, not in any `aws-c-*` tests

*Description of changes:*
- Set SKIP_RETURN_CODE in CMake script that generates C test runner (the CPP script had it, but not the C script)
- Skip leak checks when a test is skipped
    - this keeps the tests simple, you can bail out in the middle without cleaning up

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
