### PR TITLE
Fix CMake Windows ARM typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if (USE_CPU_EXTENSIONS)
                 )
         endif()
     elseif (AWS_ARCH_ARM64 OR AWS_ARCH_ARM32)
-        if (WINDOWS)
+        if (WIN32)
             file(GLOB AWS_COMMON_ARCH_SRC
                 "source/arch/arm/windows/*.c"
                 )


### PR DESCRIPTION
It's [WIN32](https://cmake.org/cmake/help/latest/variable/WIN32.html) not ~WINDOWS~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
