### PR TITLE
Fix weird decimal formatting in tests

### DIFF
--- a/include/aws/testing/aws_test_harness.h
+++ b/include/aws/testing/aws_test_harness.h
@@ -135,7 +135,7 @@ static int s_cunit_failure_message0(
         if (assert_rv != AWS_OP_SUCCESS) {                                                                             \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0(                                                                                  \
-                    "Expected success at %s; got return value %d with last error 0x%04d\n",                            \
+                    "Expected success at %s; got return value %d with last error %d\n",                                \
                     #condition,                                                                                        \
                     assert_rv,                                                                                         \
                     aws_last_error());                                                                                 \
@@ -150,7 +150,7 @@ static int s_cunit_failure_message0(
         if (assert_rv != AWS_OP_ERR) {                                                                                 \
             if (!PRINT_FAIL_INTERNAL0(__VA_ARGS__)) {                                                                  \
                 PRINT_FAIL_INTERNAL0(                                                                                  \
-                    "Expected failure at %s; got return value %d with last error 0x%04d\n",                            \
+                    "Expected failure at %s; got return value %d with last error %d\n",                                \
                     #condition,                                                                                        \
                     assert_rv,                                                                                         \
                     aws_last_error());                                                                                 \
@@ -167,7 +167,7 @@ static int s_cunit_failure_message0(
         if (assert_rv != AWS_OP_ERR) {                                                                                 \
             fprintf(                                                                                                   \
                 AWS_TESTING_REPORT_FD,                                                                                 \
-                "%sExpected error but no error occurred; rv=%d, aws_last_error=%04d (expected %04d): ",                \
+                "%sExpected error but no error occurred; rv=%d, aws_last_error=%d (expected %d): ",                    \
                 FAIL_PREFIX,                                                                                           \
                 assert_rv,                                                                                             \
                 assert_err,                                                                                            \
@@ -180,7 +180,7 @@ static int s_cunit_failure_message0(
         if (assert_err != assert_err_expect) {                                                                         \
             fprintf(                                                                                                   \
                 AWS_TESTING_REPORT_FD,                                                                                 \
-                "%sIncorrect error code; aws_last_error=%04d (expected %04d): ",                                       \
+                "%sIncorrect error code; aws_last_error=%d (expected %d): ",                                           \
                 FAIL_PREFIX,                                                                                           \
                 assert_err,                                                                                            \
                 assert_err_expect);                                                                                    \


### PR DESCRIPTION
When we switched test harness to print errors as decimals in PR https://github.com/awslabs/aws-c-common/pull/1100, we forgot to remove some of the hex decorations


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
