### PR TITLE
Fix default thread options for windows to not pin to any cpu_id

### DIFF
--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -21,6 +21,7 @@
 static struct aws_thread_options s_default_options = {
     /* zero will make sure whatever the default for that version of windows is used. */
     .stack_size = 0,
+    .cpu_id = -1,
     .join_strategy = AWS_TJS_MANUAL,
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- cpu_id should be -1 if we don't want to pin to any cpu_id

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
