### PR TITLE
Fix out variable in cmake sanitizer module

### DIFF
--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -11,13 +11,15 @@ set(SANITIZERS "address;undefined" CACHE STRING "List of sanitizers to build wit
 #  sanitizer: The sanitizer to check
 #  out_variable: The variable to assign the result to. Defaults to HAS_SANITIZER_${sanitizer}
 function(aws_check_sanitizer sanitizer)
-
-    if(NOT ${ARGN})
-        set(out_variable "${ARGN}")
-    else()
+    list(LENGTH ARGN extra_count)
+    if(${extra_count} EQUAL 0)
         set(out_variable HAS_SANITIZER_${sanitizer})
         # Sanitize the variable name to remove illegal characters
         string(MAKE_C_IDENTIFIER ${out_variable} out_variable)
+    elseif(${extra_count} EQUAL 1)
+        set(out_variable ${ARGN})
+    else()
+        message(FATAL_ERROR "Error: aws_check_sanitizer() called with multiple out variables")
     endif()
 
     if(ENABLE_SANITIZERS)


### PR DESCRIPTION
*Issue #, if available:*

The `aws_check_sanitizer` cmake function incorrectly handles the out parameter. The issue is with `if(NOT ${ARGN})` check.

When an extra parameter is passed to the function (e.g., `aws_check_sanitizer("thread" CUSTOM_OUT_VAR)`), `if(NOT ${ARGN})` checks the value of this extra parameter. This means that `${CUSTOM_OUT_VAR}` will be used as out variable only if it's undefined/false:
```
aws_check_sanitizer("thread" CUSTOM_OUT_VAR)  # sets ${CUSTOM_OUT_VAR} to 1
aws_check_sanitizer("thread" CUSTOM_OUT_VAR)  # the second call sets ${HAS_SANITIZER_thread} to 1
```

When no extra parameter is passed (e.g., `aws_check_sanitizer("thread")`), this check essentially transforms to `if(NOT)`. Which looks kind of weird, but in practice works fine.

*Description of changes:*

Check for the number of passed parameter to determine which variable to use as out parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
