### PR TITLE
Add IS_CXX option to sanitizer cmake module

### DIFF
--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -7,27 +7,18 @@ include(CheckCXXCompilerFlag)
 option(ENABLE_SANITIZERS "Enable sanitizers in debug builds" OFF)
 set(SANITIZERS "address;undefined" CACHE STRING "List of sanitizers to build with")
 
-# This function checks if a given sanitizer is available.
-# Parameters:
-#  sanitizer: The sanitizer to check.
-#  [out_variable]: The variable to assign the result to. Defaults to HAS_SANITIZER_${sanitizer}.
+# This function checks if a sanitizer is available
 # Options:
-#  IS_CXX: This option switches the function to check the CXX compiler.
+#  sanitizer: The sanitizer to check
+#  out_variable: The variable to assign the result to. Defaults to HAS_SANITIZER_${sanitizer}
 function(aws_check_sanitizer sanitizer)
-    set(options IS_CXX)
-    cmake_parse_arguments(ARG "${options}" "" "" ${ARGN})
-
-    # Determine the number of extra parameters passed to the function.
-    list(LENGTH ARG_UNPARSED_ARGUMENTS extra_count)
-
+    list(LENGTH ARGN extra_count)
     if(${extra_count} EQUAL 0)
-        # Use the default out variable.
         set(out_variable HAS_SANITIZER_${sanitizer})
         # Sanitize the variable name to remove illegal characters
         string(MAKE_C_IDENTIFIER ${out_variable} out_variable)
     elseif(${extra_count} EQUAL 1)
-        # Use the out variable provided by a function caller.
-        set(out_variable ${ARG_UNPARSED_ARGUMENTS})
+        set(out_variable ${ARGN})
     else()
         message(FATAL_ERROR "Error: aws_check_sanitizer() called with multiple out variables")
     endif()
@@ -42,10 +33,11 @@ function(aws_check_sanitizer sanitizer)
 
         # Need to set this here so that the flag is passed to the linker
         set(CMAKE_REQUIRED_FLAGS ${sanitizer_test_flag})
-        if(ARG_IS_CXX)
-            check_cxx_compiler_flag(${sanitizer_test_flag} ${out_variable})
-        else()
+        if(${CMAKE_C_COMPILER_LOADED})
             check_c_compiler_flag(${sanitizer_test_flag} ${out_variable})
+        endif()
+        if(${CMAKE_CXX_COMPILER_LOADED})
+            check_cxx_compiler_flag(${sanitizer_test_flag} ${out_variable})
         endif()
     else()
         set(${out_variable} 0 PARENT_SCOPE)
@@ -53,24 +45,14 @@ function(aws_check_sanitizer sanitizer)
 endfunction()
 
 # This function enables sanitizers on the given target
-# Parameters:
-#  SANITIZERS: The list of extra sanitizers to enable
 # Options:
-#  IS_CXX: This option switches the function to check the CXX compiler.
+#  SANITIZERS: The list of extra sanitizers to enable
 function(aws_add_sanitizers target)
-    set(options IS_CXX)
     set(multiValueArgs SANITIZERS)
-    cmake_parse_arguments(SANITIZER "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    cmake_parse_arguments(SANITIZER "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (NOT ENABLE_SANITIZERS)
         return()
-    endif()
-
-    # A cmake function's option can be forwarded by using a variable with a value set to this option.
-    if(SANITIZER_IS_CXX)
-        set(is_cxx IS_CXX)
-    else()
-        set(is_cxx "")
     endif()
 
     list(APPEND SANITIZER_SANITIZERS ${SANITIZERS})
@@ -81,7 +63,7 @@ function(aws_add_sanitizers target)
         # Sanitize the variable name to remove illegal characters
         string(MAKE_C_IDENTIFIER ${sanitizer_variable} sanitizer_variable)
 
-        aws_check_sanitizer(${sanitizer} ${sanitizer_variable} ${is_cxx})
+        aws_check_sanitizer(${sanitizer} ${sanitizer_variable})
         if(${${sanitizer_variable}})
             if (NOT "${PRESENT_SANITIZERS}" STREQUAL "")
                 set(PRESENT_SANITIZERS "${PRESENT_SANITIZERS},")

--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -2,22 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 option(ENABLE_SANITIZERS "Enable sanitizers in debug builds" OFF)
 set(SANITIZERS "address;undefined" CACHE STRING "List of sanitizers to build with")
 
-# This function checks if a sanitizer is available
+# This function checks if a given sanitizer is available.
+# Parameters:
+#  sanitizer: The sanitizer to check.
+#  [out_variable]: The variable to assign the result to. Defaults to HAS_SANITIZER_${sanitizer}.
 # Options:
-#  sanitizer: The sanitizer to check
-#  out_variable: The variable to assign the result to. Defaults to HAS_SANITIZER_${sanitizer}
+#  IS_CXX: This option switches the function to check the CXX compiler.
 function(aws_check_sanitizer sanitizer)
-    list(LENGTH ARGN extra_count)
+    set(options IS_CXX)
+    cmake_parse_arguments(ARG "${options}" "" "" ${ARGN})
+
+    # Determine the number of extra parameters passed to the function.
+    list(LENGTH ARG_UNPARSED_ARGUMENTS extra_count)
+
     if(${extra_count} EQUAL 0)
+        # Use the default out variable.
         set(out_variable HAS_SANITIZER_${sanitizer})
         # Sanitize the variable name to remove illegal characters
         string(MAKE_C_IDENTIFIER ${out_variable} out_variable)
     elseif(${extra_count} EQUAL 1)
-        set(out_variable ${ARGN})
+        # Use the out variable provided by a function caller.
+        set(out_variable ${ARG_UNPARSED_ARGUMENTS})
     else()
         message(FATAL_ERROR "Error: aws_check_sanitizer() called with multiple out variables")
     endif()
@@ -32,21 +42,35 @@ function(aws_check_sanitizer sanitizer)
 
         # Need to set this here so that the flag is passed to the linker
         set(CMAKE_REQUIRED_FLAGS ${sanitizer_test_flag})
-        check_c_compiler_flag(${sanitizer_test_flag} ${out_variable})
+        if(ARG_IS_CXX)
+            check_cxx_compiler_flag(${sanitizer_test_flag} ${out_variable})
+        else()
+            check_c_compiler_flag(${sanitizer_test_flag} ${out_variable})
+        endif()
     else()
         set(${out_variable} 0 PARENT_SCOPE)
     endif()
 endfunction()
 
 # This function enables sanitizers on the given target
-# Options:
+# Parameters:
 #  SANITIZERS: The list of extra sanitizers to enable
+# Options:
+#  IS_CXX: This option switches the function to check the CXX compiler.
 function(aws_add_sanitizers target)
+    set(options IS_CXX)
     set(multiValueArgs SANITIZERS)
-    cmake_parse_arguments(SANITIZER "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    cmake_parse_arguments(SANITIZER "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (NOT ENABLE_SANITIZERS)
         return()
+    endif()
+
+    # A cmake function's option can be forwarded by using a variable with a value set to this option.
+    if(SANITIZER_IS_CXX)
+        set(is_cxx IS_CXX)
+    else()
+        set(is_cxx "")
     endif()
 
     list(APPEND SANITIZER_SANITIZERS ${SANITIZERS})
@@ -57,7 +81,7 @@ function(aws_add_sanitizers target)
         # Sanitize the variable name to remove illegal characters
         string(MAKE_C_IDENTIFIER ${sanitizer_variable} sanitizer_variable)
 
-        aws_check_sanitizer(${sanitizer} ${sanitizer_variable})
+        aws_check_sanitizer(${sanitizer} ${sanitizer_variable} ${is_cxx})
         if(${${sanitizer_variable}})
             if (NOT "${PRESENT_SANITIZERS}" STREQUAL "")
                 set(PRESENT_SANITIZERS "${PRESENT_SANITIZERS},")


### PR DESCRIPTION
*Issue #, if available:*

`aws_check_sanitizer` checks for the sanitizer flags using `check_c_compiler_flag`. However, for C++ projects C language could be not enabled, which leads to the following error:
```
CMake Error at /usr/share/cmake3/Modules/CheckCSourceCompiles.cmake:109 (try_compile):
  Unknown extension ".c" for file
    aws-iot-device-sdk-cpp-v2/samples/mqtt5/mqtt5_pubsub/cmake-build-tsan/CMakeFiles/CMakeTmp/src.c
  try_compile() works only for enabled languages.  Currently these are:
    CXX
  See project() command to enable other languages.
``` 

A possible solution could be to add `enable_language(C)` before calling `check_c_compiler_flag`. But I'm not sure that C++ and C compilers have the same set of the sanitizer options. And even if they do currently, this might change.

So, using `check_cxx_compiler_flag` for C++ project looks like a more correct approach.

*Description of changes:*

Add `IS_CXX` option to `aws_check_sanitizer` and `aws_add_sanitizers` CMake functions.
This change does not break or change the existing usages of these functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
