### PR TITLE
Fix `-Wuseless-cast` compiler warnings

### DIFF
--- a/include/aws/common/array_list.inl
+++ b/include/aws/common/array_list.inl
@@ -123,7 +123,7 @@ AWS_STATIC_IMPL
 void aws_array_list_clean_up_secure(struct aws_array_list *AWS_RESTRICT list) {
     AWS_PRECONDITION(AWS_IS_ZEROED(*list) || aws_array_list_is_valid(list));
     if (list->alloc && list->data) {
-        aws_secure_zero((void *)list->data, list->current_size);
+        aws_secure_zero(list->data, list->current_size);
         aws_mem_release(list->alloc, list->data);
     }
 


### PR DESCRIPTION
**Issue #:**
https://github.com/awslabs/aws-c-common/issues/973

This warning exists in GCC only (not Clang), and for C++ only (not C)

**Description of changes:**
- Add `-Wuseless-cast` warning to the "header checker"
- Remove useless casts in `array_list.inl`
- Ignore `-Wuseless-cast` warning in `math.inl`
    - The tricky part is that SOME platforms (Apple and BSD variants) define `size_t` as `unsigned long` and require casting to `uint64_t` (aka `unsigned long long`). While other platforms define `size_t` as `unsigned long long` and warn about useless casts if you cast it to `uint64_t`. My first commit attempted to only do casts on those platforms, but it was more complex than simply ignoring the warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
