### PR TITLE
Eventloop type defines

### DIFF
--- a/include/aws/common/platform.h
+++ b/include/aws/common/platform.h
@@ -30,6 +30,7 @@
 #        define AWS_USE_SECITEM
 #    else
 #        define AWS_OS_MACOS
+#        define AWS_USE_KQUEUE
 #    endif
 #elif __linux__
 #    define AWS_OS_LINUX

--- a/include/aws/common/platform.h
+++ b/include/aws/common/platform.h
@@ -20,10 +20,14 @@
 #    include "TargetConditionals.h"
 #    if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #        define AWS_OS_IOS
+#        define AWS_USE_DISPATCH_QUEUE
+#        define AWS_USE_SECITEM
 #    elif defined(TARGET_OS_WATCH) && TARGET_OS_WATCH
 #        define AWS_OS_WATCHOS
 #    elif defined(TARGET_OS_TV) && TARGET_OS_TV
 #        define AWS_OS_TVOS
+#        define AWS_USE_DISPATCH_QUEUE
+#        define AWS_USE_SECITEM
 #    else
 #        define AWS_OS_MACOS
 #    endif


### PR DESCRIPTION
aws-crt-swift and XCode cannot differentiate between iOS, tvOS, macOS at build and also does not use CMakeLists.txt files. When determining platform defines, we can also define the expected eventloop type for apple devices here for use in aws-c-io, aws-crt-swift, and anywhere else where the platform specific defines need to be accessed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
