### PR TITLE
[fix] prebuild set CMAKE_PREFIX_PATH properly

### DIFF
--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -24,7 +24,7 @@ function(aws_prebuild_dependency)
     set(depBinaryDir ${CMAKE_BINARY_DIR}/deps/${AWS_PREBUILD_DEPENDENCY_NAME})
     set(depInstallDir ${depBinaryDir}/install)
     file(MAKE_DIRECTORY ${depBinaryDir})
-
+    message(STATUS "XXXXXXXXXXXX depBinaryDir ${depBinaryDir}")
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -24,12 +24,11 @@ function(aws_prebuild_dependency)
     set(depBinaryDir ${CMAKE_BINARY_DIR}/deps/${AWS_PREBUILD_DEPENDENCY_NAME})
     set(depInstallDir ${depBinaryDir}/install)
     file(MAKE_DIRECTORY ${depBinaryDir})
+
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})
-    list(APPEND cmakeCommand -B ${depBinaryDir})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
-    list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_PREFIX=${depInstallDir})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH})
     list(APPEND cmakeCommand -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
@@ -38,6 +37,15 @@ function(aws_prebuild_dependency)
     if(AWS_PREBUILD_CMAKE_ARGUMENTS)
         list(APPEND cmakeCommand ${AWS_PREBUILD_CMAKE_ARGUMENTS})
     endif()
+
+    # Set cmake prefix path via envrionment variable incase it's already a list.
+    # Some version of cmake will treat the values in the list as separate args.
+    if(WIN32)
+        list(JOIN CMAKE_PREFIX_PATH ";" PREFIX_PATH_ENV_VAR)
+    else()
+        list(JOIN CMAKE_PREFIX_PATH ":" PREFIX_PATH_ENV_VAR)
+    endif()
+    set(ENV{CMAKE_PREFIX_PATH} ${PREFIX_PATH_ENV_VAR})
 
     # Configure dependency project.
     execute_process(

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -26,7 +26,7 @@ function(aws_prebuild_dependency)
     file(MAKE_DIRECTORY ${depBinaryDir})
 
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
-    set(cmakeCommand "COMMAND" "${CMAKE_COMMAND}")
+    set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
     list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
@@ -39,11 +39,13 @@ function(aws_prebuild_dependency)
         list(APPEND cmakeCommand ${AWS_PREBUILD_CMAKE_ARGUMENTS})
     endif()
 
-    list(APPEND cmakeCommand WORKING_DIRECTORY ${depBinaryDir})
-    list(APPEND cmakeCommand RESULT_VARIABLE result)
-
     # Configure dependency project.
-    execute_process(${cmakeCommand})
+    execute_process(
+        COMMAND ${cmakeCommand}
+        WORKING_DIRECTORY ${depBinaryDir}
+        RESULT_VARIABLE result
+    )
+
     if (NOT ${result} EQUAL 0)
         message(FATAL_ERROR "Configuration failed for dependency project ${AWS_PREBUILD_DEPENDENCY_NAME}")
     endif()

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -25,14 +25,13 @@ function(aws_prebuild_dependency)
     set(depInstallDir ${depBinaryDir}/install)
     file(MAKE_DIRECTORY ${depBinaryDir})
 
-    # Conver the prefix path from list to escaped string to be passed as value used by
-    # `-DCMAKE_PREFIX_PATH` for the subprecoess
-    string(REPLACE ";" "\\\\;" ESCAPDED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+    # Convert prefix path from list to escaped string, to be passed on command line
+    string(REPLACE ";" "\\\\;" ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
-    list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${ESCAPDED_PREFIX_PATH})
+    list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${ESCAPED_PREFIX_PATH})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_PREFIX=${depInstallDir})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH})
     list(APPEND cmakeCommand -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -28,6 +28,7 @@ function(aws_prebuild_dependency)
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})
+    list(APPEND cmakeCommand -B ${depBinaryDir})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
     list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_PREFIX=${depInstallDir})

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -25,10 +25,14 @@ function(aws_prebuild_dependency)
     set(depInstallDir ${depBinaryDir}/install)
     file(MAKE_DIRECTORY ${depBinaryDir})
 
+    # Conver the prefix path from list to escaped string to be passed as value used by
+    # `-DCMAKE_PREFIX_PATH` for the subprecoess
+    string(REPLACE ";" "\\\\;" ESCAPDED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+    list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${ESCAPDED_PREFIX_PATH})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_PREFIX=${depInstallDir})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH})
     list(APPEND cmakeCommand -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
@@ -37,15 +41,6 @@ function(aws_prebuild_dependency)
     if(AWS_PREBUILD_CMAKE_ARGUMENTS)
         list(APPEND cmakeCommand ${AWS_PREBUILD_CMAKE_ARGUMENTS})
     endif()
-
-    # Set cmake prefix path via envrionment variable incase it's already a list.
-    # Some version of cmake will treat the values in the list as separate args.
-    if(WIN32)
-        list(JOIN CMAKE_PREFIX_PATH ";" PREFIX_PATH_ENV_VAR)
-    else()
-        list(JOIN CMAKE_PREFIX_PATH ":" PREFIX_PATH_ENV_VAR)
-    endif()
-    set(ENV{CMAKE_PREFIX_PATH} ${PREFIX_PATH_ENV_VAR})
 
     # Configure dependency project.
     execute_process(

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -24,7 +24,6 @@ function(aws_prebuild_dependency)
     set(depBinaryDir ${CMAKE_BINARY_DIR}/deps/${AWS_PREBUILD_DEPENDENCY_NAME})
     set(depInstallDir ${depBinaryDir}/install)
     file(MAKE_DIRECTORY ${depBinaryDir})
-    message(STATUS "XXXXXXXXXXXX depBinaryDir ${depBinaryDir}")
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})


### PR DESCRIPTION
*Issue #, if available:*

- sometimes the prebuild uses a _random_ path as the build path (Maybe inherent from the main cmake project??)
- eg: https://github.com/awslabs/aws-crt-cpp/actions/runs/11280312454/job/31373012913?pr=665#step:3:902
- After the adding the -B explicit as the build path fixes the issue:
```
 -- XXXXXXXXXXXX depBinaryDir /root/aws-crt-cpp/build/aws-crt-cpp/deps/S2N
CMake Warning:
  Ignoring extra path from command line:

   "/root/aws-crt-cpp/build/install"

cmakeCommand /usr/bin/cmake;-S;/root/aws-crt-cpp/crt/s2n;
-DCMAKE_BUILD_TYPE=RelWithDebInfo;
-DCMAKE_PREFIX_PATH=/root/aws-crt-cpp/build/aws-crt-cpp/deps/AWSLC/install/;/root/aws-crt-cpp/build/install;
-DCMAKE_INSTALL_PREFIX=/root/aws-crt-cpp/build/aws-crt-cpp/deps/S2N/install;
-DCMAKE_INSTALL_RPATH=;
-DBUILD_SHARED_LIBS=;
-DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF;
-DBUILD_TESTING=OFF

```


### After more digging
- It's not random, it's from some other `CMAKE_PREFIX_PATH`
- We add the new install path to the `CMAKE_PREFIX_PATH`, so the `CMAKE_PREFIX_PATH` is now a list
- We add `CMAKE_PREFIX_PATH` variable into the list of args to call for Cmake `execute_process`, it seems like based on the version of CMAKE, cmake sometimes confuses about those values. And treat the second value in the `CMAKE_PREFIX_PATH` list as a separate args for cmake to take.
- You can see **-DCMAKE_PREFIX_PATH=/root/aws-crt-cpp/build/aws-crt-cpp/deps/AWSLC/install/;/root/aws-crt-cpp/build/install;** I assume some version of cmake just took it as `-DCMAKE_PREFIX_PATH=/root/aws-crt-cpp/build/aws-crt-cpp/deps/AWSLC/install/` and `/root/aws-crt-cpp/build/install`
- I tried a lot different way to set the `CMAKE_PREFIX_PATH` properly, and MOST failed.
- I have to set the environment variable of CMAKE_PREFIX_PATH instead of passing it to as the commend line args for Cmake, which seems to work.

*Description of changes:*
- Set the CMAKE_PREFIX_PATH as environment variables incase of multiple cmake prefix path needs to be set,
- With the fix, https://github.com/awslabs/aws-crt-cpp/actions/runs/11283228222/job/31382255479?pr=665 works
- Updated to use the escape for the string to pass in

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
