### PR TITLE
Don't accidently include both math.msvc.inl and math.gcc_builtin.inl.

### DIFF
--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -44,7 +44,7 @@ AWS_EXTERN_C_BEGIN
 #    endif /*  AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS */
 #endif     /*  defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus)) */
 
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__clang__) || defined(__GNUC__)) && !defined(AWS_HAVE_MSVC_INTRINSICS_X64)
 #    include <aws/common/math.gcc_builtin.inl>
 #endif
 


### PR DESCRIPTION
*Issue #, if available:* #1155

*Description of changes:*
Add additional check to make sure we're not including both `math.msvc.inl` and `math.gcc_builtin.inl`.

Note: I'm not 100% sure this is the most correct solution, so I'd love feedback and I'm happy to iterate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
