### PR TITLE
Fix Cmake Prebuild Remove -S Option

### DIFF
--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -27,7 +27,7 @@ function(aws_prebuild_dependency)
 
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
     set(cmakeCommand "COMMAND" "${CMAKE_COMMAND}")
-    list(APPEND cmakeCommand -S ${AWS_PREBUILD_SOURCE_DIR})
+    list(APPEND cmakeCommand ${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
     list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_PREFIX=${depInstallDir})

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -28,7 +28,6 @@ function(aws_prebuild_dependency)
     # Convert prefix path from list to escaped string, to be passed on command line
     string(REPLACE ";" "\\\\;" ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
     # For execute_process to accept a dynamically constructed command, it should be passed in a list format.
-
     set(cmakeCommand "${CMAKE_COMMAND}")
     list(APPEND cmakeCommand ${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
*Description of changes:*
- remove -S from the Cmake command. This option was only added in CMake 3.13 and has the following bug in some versions https://gitlab.kitware.com/cmake/cmake/-/issues/18707. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
