### PR TITLE
Support Swift CXX Interop 

### DIFF
--- a/include/aws/common/array_list.h
+++ b/include/aws/common/array_list.h
@@ -231,11 +231,11 @@ void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, siz
 AWS_COMMON_API
 void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn);
 
+AWS_EXTERN_C_END
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/array_list.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_ARRAY_LIST_H */

--- a/include/aws/common/atomics.h
+++ b/include/aws/common/atomics.h
@@ -318,11 +318,13 @@ size_t aws_atomic_fetch_xor(volatile struct aws_atomic_var *var, size_t n);
 AWS_STATIC_IMPL
 void aws_atomic_thread_fence(enum aws_memory_order order);
 
+
+AWS_EXTERN_C_END
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/atomics.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif

--- a/include/aws/common/atomics.h
+++ b/include/aws/common/atomics.h
@@ -318,7 +318,6 @@ size_t aws_atomic_fetch_xor(volatile struct aws_atomic_var *var, size_t n);
 AWS_STATIC_IMPL
 void aws_atomic_thread_fence(enum aws_memory_order order);
 
-
 AWS_EXTERN_C_END
 
 #ifndef AWS_NO_STATIC_IMPL

--- a/include/aws/common/atomics.inl
+++ b/include/aws/common/atomics.inl
@@ -127,6 +127,7 @@ AWS_STATIC_IMPL
 size_t aws_atomic_fetch_xor(volatile struct aws_atomic_var *var, size_t n) {
     return aws_atomic_fetch_xor_explicit(var, n, aws_memory_order_seq_cst);
 }
+AWS_EXTERN_C_END
 
 /* Include the backend implementation now, because we'll use its typedefs and #defines below */
 #if defined(__GNUC__) || defined(__clang__)
@@ -143,6 +144,5 @@ size_t aws_atomic_fetch_xor(volatile struct aws_atomic_var *var, size_t n) {
 
 #include <aws/common/atomics_fallback.inl>
 
-AWS_EXTERN_C_END
 
 #endif /* AWS_COMMON_ATOMICS_INL */

--- a/include/aws/common/atomics.inl
+++ b/include/aws/common/atomics.inl
@@ -144,5 +144,4 @@ AWS_EXTERN_C_END
 
 #include <aws/common/atomics_fallback.inl>
 
-
 #endif /* AWS_COMMON_ATOMICS_INL */

--- a/include/aws/common/byte_order.h
+++ b/include/aws/common/byte_order.h
@@ -66,11 +66,11 @@ AWS_STATIC_IMPL uint16_t aws_hton16(uint16_t x);
  */
 AWS_STATIC_IMPL uint16_t aws_ntoh16(uint16_t x);
 
+AWS_EXTERN_C_END
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/byte_order.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_BYTE_ORDER_H */

--- a/include/aws/common/clock.h
+++ b/include/aws/common/clock.h
@@ -54,11 +54,13 @@ int aws_high_res_clock_get_ticks(uint64_t *timestamp);
 AWS_COMMON_API
 int aws_sys_clock_get_ticks(uint64_t *timestamp);
 
+AWS_EXTERN_C_END
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/clock.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
+
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_CLOCK_H */

--- a/include/aws/common/clock.h
+++ b/include/aws/common/clock.h
@@ -60,7 +60,6 @@ AWS_EXTERN_C_END
 #    include <aws/common/clock.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_CLOCK_H */

--- a/include/aws/common/encoding.h
+++ b/include/aws/common/encoding.h
@@ -224,11 +224,12 @@ AWS_COMMON_API int aws_utf8_decoder_update(struct aws_utf8_decoder *decoder, str
  */
 AWS_COMMON_API int aws_utf8_decoder_finalize(struct aws_utf8_decoder *decoder);
 
+AWS_EXTERN_C_END
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/encoding.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_ENCODING_H */

--- a/include/aws/common/error.h
+++ b/include/aws/common/error.h
@@ -149,11 +149,12 @@ int aws_translate_and_raise_io_error_or(int error_no, int fallback_aws_error_cod
 AWS_COMMON_API
 int aws_translate_and_raise_io_error(int error_no);
 
+
+
+AWS_EXTERN_C_END
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/error.inl>
 #endif /* AWS_NO_STATIC_IMPL */
-
-AWS_EXTERN_C_END
 
 enum aws_common_error {
     AWS_ERROR_SUCCESS = AWS_ERROR_ENUM_BEGIN_RANGE(AWS_C_COMMON_PACKAGE_ID),

--- a/include/aws/common/error.h
+++ b/include/aws/common/error.h
@@ -149,8 +149,6 @@ int aws_translate_and_raise_io_error_or(int error_no, int fallback_aws_error_cod
 AWS_COMMON_API
 int aws_translate_and_raise_io_error(int error_no);
 
-
-
 AWS_EXTERN_C_END
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/error.inl>

--- a/include/aws/common/linked_list.h
+++ b/include/aws/common/linked_list.h
@@ -186,11 +186,11 @@ AWS_STATIC_IMPL void aws_linked_list_move_all_front(
  * Returns true if the node is currently in a list, false otherwise.
  */
 AWS_STATIC_IMPL bool aws_linked_list_node_is_in_list(struct aws_linked_list_node *node);
+AWS_EXTERN_C_END
 
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/linked_list.inl>
 #endif /* AWS_NO_STATIC_IMPL */
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_LINKED_LIST_H */

--- a/include/aws/common/math.h
+++ b/include/aws/common/math.h
@@ -200,11 +200,11 @@ AWS_STATIC_IMPL float aws_max_float(float a, float b);
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
 
+AWS_EXTERN_C_END
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/math.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_MATH_H */

--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -13,8 +13,6 @@
 #include <limits.h>
 #include <stdlib.h>
 
-
-
 #if defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus))
 /*
  * GCC and clang have these super convenient overflow checking builtins...
@@ -59,7 +57,6 @@ AWS_EXTERN_C_BEGIN
 #        pragma GCC diagnostic ignored "-Wuseless-cast" /* Warning is C++ only (not C), and GCC only (not clang) */
 #    endif
 #endif
-
 
 AWS_STATIC_IMPL uint64_t aws_sub_u64_saturating(uint64_t a, uint64_t b) {
     return a <= b ? 0 : a - b;

--- a/include/aws/common/math.inl
+++ b/include/aws/common/math.inl
@@ -13,7 +13,7 @@
 #include <limits.h>
 #include <stdlib.h>
 
-AWS_EXTERN_C_BEGIN
+
 
 #if defined(AWS_HAVE_GCC_OVERFLOW_MATH_EXTENSIONS) && (defined(__clang__) || !defined(__cplusplus))
 /*
@@ -48,6 +48,8 @@ AWS_EXTERN_C_BEGIN
 #    include <aws/common/math.gcc_builtin.inl>
 #endif
 
+AWS_EXTERN_C_BEGIN
+
 #ifdef _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4127) /*Disable "conditional expression is constant" */
@@ -57,6 +59,7 @@ AWS_EXTERN_C_BEGIN
 #        pragma GCC diagnostic ignored "-Wuseless-cast" /* Warning is C++ only (not C), and GCC only (not clang) */
 #    endif
 #endif
+
 
 AWS_STATIC_IMPL uint64_t aws_sub_u64_saturating(uint64_t a, uint64_t b) {
     return a <= b ? 0 : a - b;

--- a/include/aws/common/ring_buffer.h
+++ b/include/aws/common/ring_buffer.h
@@ -93,11 +93,12 @@ AWS_COMMON_API bool aws_ring_buffer_buf_belongs_to_pool(
     const struct aws_ring_buffer *ring_buffer,
     const struct aws_byte_buf *buf);
 
+AWS_EXTERN_C_END
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/ring_buffer.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_RING_BUFFER_H */

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -373,11 +373,13 @@ bool aws_c_string_is_valid(const char *str);
 AWS_STATIC_IMPL
 bool aws_char_is_space(uint8_t c);
 
+AWS_EXTERN_C_END
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/string.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
+
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_STRING_H */

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -379,7 +379,6 @@ AWS_EXTERN_C_END
 #    include <aws/common/string.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_STRING_H */

--- a/include/aws/common/zero.h
+++ b/include/aws/common/zero.h
@@ -56,11 +56,12 @@ bool aws_is_mem_zeroed(const void *buf, size_t bufsize);
 AWS_COMMON_API
 void aws_secure_zero(void *pBuf, size_t bufsize);
 
+AWS_EXTERN_C_END
+
 #ifndef AWS_NO_STATIC_IMPL
 #    include <aws/common/zero.inl>
 #endif /* AWS_NO_STATIC_IMPL */
 
-AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_COMMON_ZERO_H */


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-swift/issues/166

*Description of changes:*
- Don't include inl files as part of extern C. We use AWS_EXTERN_C_BEGIN and AWS_EXTERN_C_END within the inl files.
- Ideally, we should add CI in common as well, but I don't know how. I will add CI in crt-swift.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
