### PR TITLE
check if numa available or not before loading numa functions

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -363,7 +363,6 @@ void aws_common_library_init(struct aws_allocator *allocator) {
                     AWS_LS_COMMON_GENERAL,
                     "static: numa_available() returns -1, numa functions are not available. Skip loading the other "
                     "numa functions.");
-                AWS_FATAL_ASSERT(-1);
             } else {
                 *(void **)(&g_numa_num_configured_nodes_ptr) = dlsym(g_libnuma_handle, "numa_num_configured_nodes");
                 if (g_numa_num_configured_nodes_ptr) {

--- a/source/common.c
+++ b/source/common.c
@@ -358,26 +358,33 @@ void aws_common_library_init(struct aws_allocator *allocator) {
             } else {
                 AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_available() failed to load");
             }
-
-            *(void **)(&g_numa_num_configured_nodes_ptr) = dlsym(g_libnuma_handle, "numa_num_configured_nodes");
-            if (g_numa_num_configured_nodes_ptr) {
-                AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_configured_nodes() loaded");
+            if (g_numa_available_ptr() == -1) {
+                AWS_LOGF_INFO(
+                    AWS_LS_COMMON_GENERAL,
+                    "static: numa_available() returns -1, numa functions are not available. Skip loading the other "
+                    "numa functions.");
+                AWS_FATAL_ASSERT(-1);
             } else {
-                AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_configured_nodes() failed to load");
-            }
+                *(void **)(&g_numa_num_configured_nodes_ptr) = dlsym(g_libnuma_handle, "numa_num_configured_nodes");
+                if (g_numa_num_configured_nodes_ptr) {
+                    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_configured_nodes() loaded");
+                } else {
+                    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_configured_nodes() failed to load");
+                }
 
-            *(void **)(&g_numa_num_possible_cpus_ptr) = dlsym(g_libnuma_handle, "numa_num_possible_cpus");
-            if (g_numa_num_possible_cpus_ptr) {
-                AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_possible_cpus() loaded");
-            } else {
-                AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_possible_cpus() failed to load");
-            }
+                *(void **)(&g_numa_num_possible_cpus_ptr) = dlsym(g_libnuma_handle, "numa_num_possible_cpus");
+                if (g_numa_num_possible_cpus_ptr) {
+                    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_possible_cpus() loaded");
+                } else {
+                    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_num_possible_cpus() failed to load");
+                }
 
-            *(void **)(&g_numa_node_of_cpu_ptr) = dlsym(g_libnuma_handle, "numa_node_of_cpu");
-            if (g_numa_node_of_cpu_ptr) {
-                AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_node_of_cpu() loaded");
-            } else {
-                AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_node_of_cpu() failed to load");
+                *(void **)(&g_numa_node_of_cpu_ptr) = dlsym(g_libnuma_handle, "numa_node_of_cpu");
+                if (g_numa_node_of_cpu_ptr) {
+                    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_node_of_cpu() loaded");
+                } else {
+                    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "static: numa_node_of_cpu() failed to load");
+                }
             }
 
         } else {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-c-common/issues/1162

*Description of changes:*
> Before any other calls in this library can be used numa_available() must be called. If it returns -1, all other functions in this library are undefined. 

Referring to https://linux.die.net/man/3/numa_available. So, if `numa_available()` return -1, skip loading any other functions from libnuma.

- We are lacking tests for numa functionalities, which is a concern.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
