### PR TITLE
Support relative paths when prebuilding dependencies with CMake

### DIFF
--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -36,6 +36,7 @@ function(aws_prebuild_dependency)
     list(APPEND cmakeCommand ${cmakeOptionalVariables})
 
     # The following variables should always be used.
+    list(APPEND cmakeCommand -B${depBinaryDir})
     list(APPEND cmakeCommand ${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
     list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${ESCAPED_PREFIX_PATH})
@@ -57,7 +58,6 @@ function(aws_prebuild_dependency)
     # Configure dependency project.
     execute_process(
         COMMAND ${cmakeCommand}
-        WORKING_DIRECTORY ${depBinaryDir}
         RESULT_VARIABLE result
     )
 
@@ -67,8 +67,7 @@ function(aws_prebuild_dependency)
 
     # Build and install dependency project into depInstallDir directory.
     execute_process(
-        COMMAND ${CMAKE_COMMAND} --build . --target install
-        WORKING_DIRECTORY ${depBinaryDir}
+        COMMAND ${CMAKE_COMMAND} --build ${depBinaryDir} --target install
         RESULT_VARIABLE result
     )
     if (NOT ${result} EQUAL 0)


### PR DESCRIPTION
**Issue:**
When aws-crt-java started prebuilding AWS-LC, the release pipeline  broke due to a relative path being passed to CMake (see: https://github.com/awslabs/aws-crt-java/pull/851)

Since the AwsPrebuildDependency changed the working directory while running CMake, the relative path became invalid.

**Description of changes:**
Instead of changing the working directory while running CMake, use the `-B<path-to-build>` option (which exists prior to CMake 3.13 even though it's not documented, note that it's a bit weird pre-3.13 with no space after the B))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
