### PR TITLE
Fix dependency build failure on old cmake versions

### DIFF
--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -36,7 +36,7 @@ function(aws_prebuild_dependency)
     list(APPEND cmakeCommand ${cmakeOptionalVariables})
 
     # The following variables should always be used.
-    list(APPEND cmakeCommand ${AWS_PREBUILD_SOURCE_DIR})
+    list(APPEND cmakeCommand -H${AWS_PREBUILD_SOURCE_DIR})
     list(APPEND cmakeCommand -B${depBinaryDir})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
     list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${ESCAPED_PREFIX_PATH})

--- a/cmake/AwsPrebuildDependency.cmake
+++ b/cmake/AwsPrebuildDependency.cmake
@@ -36,8 +36,8 @@ function(aws_prebuild_dependency)
     list(APPEND cmakeCommand ${cmakeOptionalVariables})
 
     # The following variables should always be used.
-    list(APPEND cmakeCommand -B${depBinaryDir})
     list(APPEND cmakeCommand ${AWS_PREBUILD_SOURCE_DIR})
+    list(APPEND cmakeCommand -B${depBinaryDir})
     list(APPEND cmakeCommand -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
     list(APPEND cmakeCommand -DCMAKE_PREFIX_PATH=${ESCAPED_PREFIX_PATH})
     list(APPEND cmakeCommand -DCMAKE_INSTALL_PREFIX=${depInstallDir})


### PR DESCRIPTION
*Issue #, if available:*

aws-lc can't be prebuilt on Ubuntu 18: https://github.com/awslabs/aws-crt-cpp/issues/691


*Description of changes:*

Apparently, CMake prior to v3.13 requires that the `-B<BUILD_DIRECTORY>` option should come after the source directory argument:
```
cmake source_dir/ -Bbuild_dir
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
