### PR TITLE
Fixup IPv6 validation logic

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: v0.9.73
+  BUILDER_VERSION: v0.9.74
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-c-common

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,9 +4,9 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: gcc_default
+  BUILDER_VERSION: v0.9.73
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  BUILDER_SOURCE: channels
+  BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-c-common
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,9 +4,9 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: v0.9.72
+  BUILDER_VERSION: gcc_default
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  BUILDER_SOURCE: releases
+  BUILDER_SOURCE: channels
   PACKAGE_NAME: aws-c-common
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-9 --coverage --coverage-exclude=source/external/
+          ./builder build -p ${{ env.PACKAGE_NAME }} --coverage --coverage-exclude=source/external/

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,4 +28,4 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} --coverage --coverage-exclude=source/external/
+          ./builder build -p ${{ env.PACKAGE_NAME }} --compiler=gcc --coverage --coverage-exclude=source/external/

--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -177,7 +177,7 @@ jobs:
             && mv $FINAL_REPORT_DIR/${{ steps.artifact.outputs.name }}.zip .
       - name: Upload zip artifact of CBMC proof results to GitHub Actions
         if: ${{ env.REPO_VISIBILITY == 'public' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.name }}.zip

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -108,7 +108,6 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
 
         if (digit_count > 4 || /* too many digits in group */
             group_count > 8) { /* too many groups */
-            AWS_LOGF_DEBUG(0, "here %d", group_count);
             return false;
         }
     }

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -5,6 +5,7 @@
 #include <aws/common/host_utils.h>
 #include <aws/common/string.h>
 #include <inttypes.h>
+#include <aws/common/logging.h>
 
 #ifdef _MSC_VER /* Disable sscanf warnings on windows. */
 #    pragma warning(disable : 4204)
@@ -18,10 +19,6 @@
 
 static bool s_is_ipv6_char(uint8_t value) {
     return aws_isxdigit(value) || value == ':';
-}
-
-static bool s_ends_with(struct aws_byte_cursor cur, uint8_t ch) {
-    return cur.len > 0 && cur.ptr[cur.len - 1] == ch;
 }
 
 bool aws_host_utils_is_ipv4(struct aws_byte_cursor host) {
@@ -79,24 +76,39 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
     bool is_split = aws_byte_cursor_next_split(&host, '%', &substr);
     AWS_ASSERT(is_split); /* function is guaranteed to return at least one split */
 
-    if (!is_split || substr.len == 0 || s_ends_with(substr, ':') ||
+    if (!is_split || substr.len < 2 || substr.len > 39 || 
         !aws_byte_cursor_satisfies_pred(&substr, s_is_ipv6_char)) {
         return false;
     }
 
-    uint8_t group_count = 0;
-    bool has_double_colon = false;
-    struct aws_byte_cursor group = {0};
-    while (aws_byte_cursor_next_split(&substr, ':', &group)) {
-        ++group_count;
+    if ((substr.ptr[0] == ':' && substr.ptr[1] != ':') || /* no single colon at start */
+        (substr.ptr[substr.len - 1] == ':' && substr.ptr[substr.len - 2] != ':'))  { /* no single colon at end */ 
+        return false;
+    }
 
-        if (group_count > 8 ||                                         /* too many groups */
-            group.len > 4 ||                                           /* too many chars in group */
-            (has_double_colon && group.len == 0 && group_count > 2)) { /* only one double colon allowed */
-            return false;
+    uint8_t group_count = 1; /* string itself is the first group and then every new : we encounter is new group */
+    uint8_t digit_count = 0;
+    bool has_double_colon = false;
+
+    for (size_t i = 0; i < substr.len; ++i) {
+        if (substr.ptr[i] == ':') {
+            ++group_count;
+            digit_count = 0;
+
+            if (i > 0 && substr.ptr[i - 1] == ':') {
+                if (has_double_colon) { /* one double colon max */
+                    return false;
+                }
+                has_double_colon = true;
+            }
+        } else {
+            ++digit_count;
         }
 
-        has_double_colon = has_double_colon || group.len == 0;
+        if (digit_count > 4 || /* too many digits in group */
+            group_count > 8 ) { /* too many groups */
+            return false;
+        }
     }
 
     /* second split is optional zone part */
@@ -110,5 +122,5 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
         }
     }
 
-    return has_double_colon ? group_count < 7 : group_count == 8;
+    return has_double_colon ? group_count <= 7 : group_count == 8;
 }

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -65,6 +65,8 @@ static struct aws_byte_cursor s_percent_uri_enc = AWS_BYTE_CUR_INIT_FROM_STRING_
  * ipv6 can be embedded in url, in which case % must be uri encoded as %25.
  * Implementation is fairly trivial and just iterates through the string
  * keeping track of the spec above.
+ * Note: there is no single rfc for IPv6 address - base format defined in RFC 5952, 
+ * zoneId and uri extensions defined in RFC 6874 and RFC 3986
  */
 bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
     if (host.len == 0) {
@@ -99,6 +101,7 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
                     return false;
                 }
                 has_double_colon = true;
+                --group_count; /* avoid double counting groups */
             }
         } else {
             ++digit_count;
@@ -106,6 +109,7 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
 
         if (digit_count > 4 || /* too many digits in group */
             group_count > 8) { /* too many groups */
+            AWS_LOGF_DEBUG(0, "here %d", group_count);
             return false;
         }
     }
@@ -121,5 +125,5 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
         }
     }
 
-    return has_double_colon ? group_count <= 7 : group_count == 8;
+    return has_double_colon ? group_count <= 8 : group_count == 8;
 }

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/host_utils.h>
+#include <aws/common/logging.h>
 #include <aws/common/string.h>
 #include <inttypes.h>
-#include <aws/common/logging.h>
 
 #ifdef _MSC_VER /* Disable sscanf warnings on windows. */
 #    pragma warning(disable : 4204)
@@ -76,13 +76,12 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
     bool is_split = aws_byte_cursor_next_split(&host, '%', &substr);
     AWS_ASSERT(is_split); /* function is guaranteed to return at least one split */
 
-    if (!is_split || substr.len < 2 || substr.len > 39 || 
-        !aws_byte_cursor_satisfies_pred(&substr, s_is_ipv6_char)) {
+    if (!is_split || substr.len < 2 || substr.len > 39 || !aws_byte_cursor_satisfies_pred(&substr, s_is_ipv6_char)) {
         return false;
     }
 
-    if ((substr.ptr[0] == ':' && substr.ptr[1] != ':') || /* no single colon at start */
-        (substr.ptr[substr.len - 1] == ':' && substr.ptr[substr.len - 2] != ':'))  { /* no single colon at end */ 
+    if ((substr.ptr[0] == ':' && substr.ptr[1] != ':') ||                           /* no single colon at start */
+        (substr.ptr[substr.len - 1] == ':' && substr.ptr[substr.len - 2] != ':')) { /* no single colon at end */
         return false;
     }
 
@@ -106,7 +105,7 @@ bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {
         }
 
         if (digit_count > 4 || /* too many digits in group */
-            group_count > 8 ) { /* too many groups */
+            group_count > 8) { /* too many groups */
             return false;
         }
     }

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/host_utils.h>
-#include <aws/common/logging.h>
 #include <aws/common/string.h>
 #include <inttypes.h>
 

--- a/source/host_utils.c
+++ b/source/host_utils.c
@@ -65,7 +65,7 @@ static struct aws_byte_cursor s_percent_uri_enc = AWS_BYTE_CUR_INIT_FROM_STRING_
  * ipv6 can be embedded in url, in which case % must be uri encoded as %25.
  * Implementation is fairly trivial and just iterates through the string
  * keeping track of the spec above.
- * Note: there is no single rfc for IPv6 address - base format defined in RFC 5952, 
+ * Note: there is no single rfc for IPv6 address - base format defined in RFC 5952,
  * zoneId and uri extensions defined in RFC 6874 and RFC 3986
  */
 bool aws_host_utils_is_ipv6(struct aws_byte_cursor host, bool is_uri_encoded) {

--- a/tests/host_util_test.c
+++ b/tests/host_util_test.c
@@ -51,6 +51,8 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25en0"), true));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8:85a3:8d3:1319:8a2e:370:7348"), true));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001::"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("1:2:3:4:5:6:7::"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::1:2:3:4:5:6:7"), false));
 
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:DB8:85A3::8A2E:370:7334"), false));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), false));
@@ -71,7 +73,6 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(
         aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("z001:0db8:0000:0000:0000:8a2e:0370:7334:8745"), false));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("z001::8a2e::8745"), false));
-    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::2001:0db8:0000:0000:8a2e:0370:7334"), false));
 
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%en0"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%24en0"), true));

--- a/tests/host_util_test.c
+++ b/tests/host_util_test.c
@@ -50,10 +50,20 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1"), true));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25en0"), true));
     ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8:85a3:8d3:1319:8a2e:370:7348"), true));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001::"), false));
+
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:DB8:85A3::8A2E:370:7334"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:DB8:85A3::8A2E:370:7334"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::ffff"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8:85a3:0:0:8a2e:370:7334"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("0:0:0:0:0:0:0:0"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8::"), false));
 
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:0000:0000:0000:8a2e:0370"), false));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:0000:0000:0000:8a2e:0370:"), false));
-    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001::"), false));
     ASSERT_FALSE(
         aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:0000:0000:0000:8a2e:0370:7334:8745"), false));
     ASSERT_FALSE(
@@ -68,6 +78,14 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("[fe80::1%25en0"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25en0]"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%25"), true));
+
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8:85a3:0000:0000:8a2e:0370:7334:1"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8:85a3:0000"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:0db8:85a3:0000:0000:8a2e:0370:7334:"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("g001:0db8:85a3:0000:0000:8a2e:0370:7334"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("2001:db8::85a3::1"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str(":2001:db8:85a3:0000:0000:8a2e:0370:7334"), false));
+    ASSERT_TRUE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("0:0:0:0:0:0:0:0"), false));
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/host_util_test.c
+++ b/tests/host_util_test.c
@@ -73,6 +73,8 @@ static int s_test_is_ipv6(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(
         aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("z001:0db8:0000:0000:0000:8a2e:0370:7334:8745"), false));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("z001::8a2e::8745"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("1:2:3:4:5:6:7:8::"), false));
+    ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("::1:2:3:4:5:6:7:8"), false));
 
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%en0"), true));
     ASSERT_FALSE(aws_host_utils_is_ipv6(aws_byte_cursor_from_c_str("fe80::1%24en0"), true));


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
is ipv6 helper does not always return correct results for zero expansion cases. 

*Description of changes:*
rewrote the logic to be hopefully simpler to follow and less error prone. 
and a whole bunch of test cases


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
