### PR TITLE
Detect when AVX is disabled via OSXSAVE

### DIFF
--- a/source/arch/intel/asm/cpuid.c
+++ b/source/arch/intel/asm/cpuid.c
@@ -27,3 +27,14 @@ void aws_run_cpuid(uint32_t eax, uint32_t ecx, uint32_t *abcd) {
     abcd[2] = ecx;
     abcd[3] = edx;
 }
+
+uint64_t aws_run_xgetbv(uint32_t xcr) {
+    /* NOTE: we could have used the _xgetbv() intrinsic in <immintrin.h>, but it's missing from GCC < 9.0:
+     * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71659 */
+
+    /* xgetbv writes high and low of 64bit value to EAX:EDX */
+    uint32_t eax;
+    uint32_t edx;
+    __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
+    return (((uint64_t)eax) << 32) | edx;
+}

--- a/source/arch/intel/msvc/cpuid.c
+++ b/source/arch/intel/msvc/cpuid.c
@@ -5,8 +5,13 @@
 
 #include <aws/common/cpuid.h>
 
+#include <immintrin.h>
 #include <intrin.h>
 
 void aws_run_cpuid(uint32_t eax, uint32_t ecx, uint32_t *abcd) {
     __cpuidex((int32_t *)abcd, eax, ecx);
+}
+
+uint64_t aws_run_xgetbv(uint32_t xcr) {
+    return _xgetbv(xcr);
 }


### PR DESCRIPTION
**Issue #:**
internal V1647663988

[SEV-SNP enabled EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html) crash when using AWS CLI to upload with checksum algorithm CRC64NVME. [AWS CLI v2](https://github.com/aws/aws-cli/tree/v2) uses aws-c-common under the hood to do CRC64NVME.

**Investigation:**
aws-c-common has checks for AVX support, using [CPUID](https://en.wikipedia.org/wiki/CPUID). But apparently, just because CPUID reports that it can do AVX, doesn't necessarily mean it's enabled by the OS. On SEV-SNP enabled instances, AVX is not allowed.

GCC had the same bug until 7.4: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85100

Stackoverflow question: https://stackoverflow.com/questions/72522885/are-the-xgetbv-and-cpuid-checks-sufficient-to-guarantee-avx2-support

**Description of changes:**
* Do further checks before deciding that AVX can be used.
* Move all Intel feature detection into 1 function.
   * This is simpler, it's how we're doing feature detection on some other architectures.
   * Add checks to find the max value that CPUID accepts. We weren't doing this before.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
