### PR TITLE
(take 2) Detect when AVX is disabled via OSXSAVE

### DIFF
--- a/source/arch/intel/asm/cpuid.c
+++ b/source/arch/intel/asm/cpuid.c
@@ -32,9 +32,9 @@ uint64_t aws_run_xgetbv(uint32_t xcr) {
     /* NOTE: we could have used the _xgetbv() intrinsic in <immintrin.h>, but it's missing from GCC < 9.0:
      * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71659 */
 
-    /* xgetbv writes high and low of 64bit value to EAX:EDX */
-    uint32_t eax;
-    uint32_t edx;
-    __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
-    return (((uint64_t)eax) << 32) | edx;
+    /* xgetbv writes high and low of 64bit value to EDX:EAX */
+    uint32_t xcrhigh;
+    uint32_t xcrlow;
+    __asm__ __volatile__("xgetbv" : "=a"(xcrlow), "=d"(xcrhigh) : "c"(xcr));
+    return (((uint64_t)xcrhigh) << 32) | xcrlow;
 }

--- a/source/arch/intel/cpuid.c
+++ b/source/arch/intel/cpuid.c
@@ -73,8 +73,7 @@ static void s_cache_cpu_features(void) {
         return;
     }
     aws_run_cpuid(0x7, 0x0, abcd);
-    s_cpu_features[AWS_CPU_FEATURE_BMI2] = abcd[1] & (1 << 8);        /* bmi2 = EBX[bit 8] */
-    s_cpu_features[AWS_CPU_FEATURE_VPCLMULQDQ] = abcd[2] & (1 << 10); /* vpclmulqdq = ECX[bit 10] */
+    s_cpu_features[AWS_CPU_FEATURE_BMI2] = abcd[1] & (1 << 8); /* bmi2 = EBX[bit 8] */
 
     /* NOTE: It SHOULD be impossible for a CPU to support AVX2 without supporting AVX.
      * But we've received crash reports where the AVX2 feature check passed
@@ -91,7 +90,8 @@ static void s_cache_cpu_features(void) {
      * check should stop them from running our AVX/AVX2 code paths. */
     if (feature_avx) {
         if (avx_usable) {
-            s_cpu_features[AWS_CPU_FEATURE_AVX2] = abcd[1] & (1 << 5); /* AVX2 = EBX[bit 5] */
+            s_cpu_features[AWS_CPU_FEATURE_AVX2] = abcd[1] & (1 << 5);        /* AVX2 = EBX[bit 5] */
+            s_cpu_features[AWS_CPU_FEATURE_VPCLMULQDQ] = abcd[2] & (1 << 10); /* vpclmulqdq = ECX[bit 10] */
         }
         if (avx512_usable) {
             s_cpu_features[AWS_CPU_FEATURE_AVX512] = abcd[1] & (1 << 16); /*  AVX-512 Foundation = EBX[bit 16] */

--- a/source/arch/intel/cpuid.c
+++ b/source/arch/intel/cpuid.c
@@ -90,6 +90,9 @@ static void s_cache_cpu_features(void) {
      * We don't know for sure what was up with those machines, but this extra
      * check should stop them from running our AVX/AVX2 code paths. */
     if (feature_avx) {
+        if (avx_usable) {
+            s_cpu_features[AWS_CPU_FEATURE_AVX2] = abcd[1] & (1 << 5); /* AVX2 = EBX[bit 5] */
+        }
         if (avx512_usable) {
             s_cpu_features[AWS_CPU_FEATURE_AVX512] = abcd[1] & (1 << 16); /*  AVX-512 Foundation = EBX[bit 16] */
         }


### PR DESCRIPTION
**Issue:**
There were some bugs in the previous PR: https://github.com/awslabs/aws-c-common/pull/1182

**Description of changes:**
* Fix bug where high and low bits of XGETBV were reversed
* Add back AVX2 feature detection (accidentally omitted from previous PR)
* VPCLMULQDQ also depends on AVX being usable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
