### PR TITLE
Integration test for CPU feature detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,19 @@ jobs:
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}
 
+  linux-arm64:
+    runs-on: ubuntu-24.04-arm # latest
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }}
+
   cross_compile:
     name: Cross Compile ${{matrix.arch}}
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.72
+  BUILDER_VERSION: ubuntu-arm
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  BUILDER_SOURCE: releases
+  BUILDER_SOURCE: channels
   PACKAGE_NAME: aws-c-common
   LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
-        arch: [linux-armv6, linux-armv7, linux-arm64, android-armv7]
+        arch: [linux-armv6, linux-armv7, android-armv7]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: ubuntu-arm
+  BUILDER_VERSION: v0.9.72
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  BUILDER_SOURCE: channels
+  BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-c-common
   LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
@@ -305,25 +305,12 @@ jobs:
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}
 
-  linux-arm64:
-    runs-on: ubuntu-24.04-arm # latest
-    steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ env.CRT_CI_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    - name: Build ${{ env.PACKAGE_NAME }} + consumers
-      run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
-        chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }}
-
   cross_compile:
     name: Cross Compile ${{matrix.arch}}
     runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
-        arch: [linux-armv6, linux-armv7, android-armv7]
+        arch: [linux-armv6, linux-armv7, linux-arm64, android-armv7]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ cmake-build*
 # CBMC files
 *.goto
 *.log
+
+# source code for system_info and other test apps
+!bin

--- a/bin/system_info/print_system_info.c
+++ b/bin/system_info/print_system_info.c
@@ -46,10 +46,10 @@ int main(void) {
     fprintf(stdout, "       'arm_crypto': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_ARM_CRYPTO) ? "true" : "false");
     fprintf(stdout, "       'amd_sse4_1': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_SSE_4_1) ? "true" : "false");
     fprintf(stdout, "       'amd_sse4_2': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_SSE_4_2) ? "true" : "false");
-    fprintf(stdout, "       'amd_pclmulqdq': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_CLMUL) ? "true" : "false");
+    fprintf(stdout, "       'amd_clmul': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_CLMUL) ? "true" : "false");
     fprintf(stdout, "       'amd_vpclmulqdq': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_VPCLMULQDQ) ? "true" : "false");
     fprintf(stdout, "       'amd_avx2': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_AVX2) ? "true" : "false");
-    fprintf(stdout, "       'amd_avx512f': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_AVX512) ? "true" : "false");
+    fprintf(stdout, "       'amd_avx512': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_AVX512) ? "true" : "false");
     fprintf(stdout, "       'amd_bmi2': %s\n", aws_cpu_has_feature(AWS_CPU_FEATURE_BMI2) ? "true" : "false");
     fprintf(stdout, "   }\n");
 

--- a/bin/system_info/print_system_info.c
+++ b/bin/system_info/print_system_info.c
@@ -53,6 +53,12 @@ int main(void) {
     fprintf(stdout, "       'amd_bmi2': %s\n", aws_cpu_has_feature(AWS_CPU_FEATURE_BMI2) ? "true" : "false");
     fprintf(stdout, "   }\n");
 
+#if defined(AWS_USE_CPU_EXTENSIONS)
+    fprintf(stdout, "  'use cpu extensions': true\n");
+#else
+    fprintf(stdout, "  'use cpu extensions': false\n");
+#endif
+
     fprintf(stdout, "}\n");
     aws_system_environment_release(env);
     aws_logger_clean_up(&logger);

--- a/bin/system_info/print_system_info.c
+++ b/bin/system_info/print_system_info.c
@@ -46,10 +46,10 @@ int main(void) {
     fprintf(stdout, "       'arm_crypto': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_ARM_CRYPTO) ? "true" : "false");
     fprintf(stdout, "       'amd_sse4_1': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_SSE_4_1) ? "true" : "false");
     fprintf(stdout, "       'amd_sse4_2': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_SSE_4_2) ? "true" : "false");
-    fprintf(stdout, "       'amd_clmul': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_CLMUL) ? "true" : "false");
+    fprintf(stdout, "       'amd_pclmulqdq': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_CLMUL) ? "true" : "false");
     fprintf(stdout, "       'amd_vpclmulqdq': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_VPCLMULQDQ) ? "true" : "false");
     fprintf(stdout, "       'amd_avx2': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_AVX2) ? "true" : "false");
-    fprintf(stdout, "       'amd_avx512': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_AVX512) ? "true" : "false");
+    fprintf(stdout, "       'amd_avx512f': %s,\n", aws_cpu_has_feature(AWS_CPU_FEATURE_AVX512) ? "true" : "false");
     fprintf(stdout, "       'amd_bmi2': %s\n", aws_cpu_has_feature(AWS_CPU_FEATURE_BMI2) ? "true" : "false");
     fprintf(stdout, "   }\n");
 

--- a/bin/system_info/test-print-system-info.py
+++ b/bin/system_info/test-print-system-info.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from pathlib import Path
+import platform
+import re
+from subprocess import run
+from typing import Dict, List, Optional
+
+PARSER = argparse.ArgumentParser(
+    description="Run print-sys-info to detect CPU features. Fail if the results seem wrong.")
+PARSER.add_argument("print-sys-info-path",
+                    help="Path to print-sys-info app")
+
+
+def main():
+    args = PARSER.parse_args()
+
+    if args.print_sys_info:
+        app = Path(args.print_sys_info_path)
+        if not app.exists:
+            exit("FAILED: file not found: {app}")
+    else:
+        app = find_app()
+
+    app_features_yesno: Dict[str, bool] = detect_features_from_app(app)
+
+    os_features_list = detect_features_from_os()
+
+
+def find_app(build_dir: Optional[str]) -> Path:
+    build_dir = find_build_dir()
+
+    app_name = 'print-sys-info'
+    if os.name == 'nt':
+        app_name = app_name + '.exe'
+
+    for file in build_dir.glob(f"**/{app_name}"):
+        return file
+
+    exit("FAILED: Can't find print-sys-info. Pass location as argument")
+
+
+def find_build_dir() -> Path:
+    dir = Path(__file__).parent
+    while dir is not None:
+        for build_dir in dir.glob('build'):
+            return build_dir
+        dir = dir.parent
+
+    exit("FAILED: Can't find print-sys-info. Pass location as argument")
+
+
+def detect_features_from_app(app_path: Path) -> Dict[str, bool]:
+    result = run([str(app_path)],
+                 capture_output=True,
+                 text=True)
+    print(result.stderr)
+    print(result.stdout)
+    if result.returncode != 0:
+        exit(f"FAILED: {app_path.name} exited with {result.returncode}")
+
+    lines = result.stdout.splitlines()
+
+    machine = platform.machine().lower()
+    if machine in ['x86_64', 'amd64']:
+        machine = 'amd'
+    elif machine.startswith('arm') or machine == 'aarch64':
+        machine = 'arm'
+    else:
+        print(f"SKIP TEST: unknown platform.machine(): {machine}")
+        exit(0)
+
+    # looking for lines like:
+    #        'arm_crypto': true,
+    #        'amd_sse4_1': false
+    features = {}
+    for line in lines:
+        if m := re.search(f"'{machine}_(.+)': (false|true)", line):
+            name = m.group(1)
+            is_present = m.group(2) == 'true'
+            features[name] = is_present
+    if not features:
+        raise RuntimeError("Cannot find features text in stdout ???")
+
+    return features
+
+
+def detect_features_from_os() -> List[str]:
+    features = []
+
+    try:
+        with open('/proc/cpuinfo') as f:
+            cpuinfo_text = f.read()
+    except:
+        exit("SKIP TEST: currently, this test only works on machines with /proc/cpuinfo")
+
+    # for line in cpuinfo_text:
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/system_info/test-print-system-info.py
+++ b/bin/system_info/test-print-system-info.py
@@ -114,6 +114,14 @@ def detect_features_from_app(app_path: Path) -> Dict[str, bool]:
             name = m.group(1)
             is_present = m.group(2) == 'true'
             features[name] = is_present
+
+    # if aws-c-common compiled with -DUSE_CPU_EXTENSIONS=OFF, skip this this test
+    for line in lines:
+        m = re.search(f"'use cpu extensions': false", line)
+        if m:
+            print("SKIP TEST: aws-c-common compiled with -DUSE_CPU_EXTENSIONS=OFF")
+            exit(0)
+
     if not features:
         raise RuntimeError("Cannot find features text in stdout ???")
 

--- a/bin/system_info/test-print-system-info.py
+++ b/bin/system_info/test-print-system-info.py
@@ -9,27 +9,30 @@ from typing import Dict, List, Optional
 
 PARSER = argparse.ArgumentParser(
     description="Run print-sys-info to detect CPU features. Fail if the results seem wrong.")
-PARSER.add_argument("print-sys-info-path",
+PARSER.add_argument("--print-sys-info-path",
                     help="Path to print-sys-info app")
+PARSER.add_argument("--build-dir",
+                    help="Search this dir for print-sys-info app")
 
 
 def main():
     args = PARSER.parse_args()
 
-    if args.print_sys_info:
+    if args.print_sys_info_path:
         app = Path(args.print_sys_info_path)
-        if not app.exists:
-            exit("FAILED: file not found: {app}")
     else:
-        app = find_app()
+        app = find_app(args.build_dir)
 
     app_features_yesno: Dict[str, bool] = detect_features_from_app(app)
 
     os_features_list = detect_features_from_os()
 
+    # TODO: compare app_features_yesno and os_features_list
+
 
 def find_app(build_dir: Optional[str]) -> Path:
-    build_dir = find_build_dir()
+    if build_dir is None:
+        build_dir = find_build_dir()
 
     app_name = 'print-sys-info'
     if os.name == 'nt':
@@ -38,7 +41,8 @@ def find_app(build_dir: Optional[str]) -> Path:
     for file in build_dir.glob(f"**/{app_name}"):
         return file
 
-    exit("FAILED: Can't find print-sys-info. Pass location as argument")
+    exit(f"FAILED: Can't find '{app_name}' under: {build_dir}."
+         "\nPass --build-dir to hint location.")
 
 
 def find_build_dir() -> Path:
@@ -48,13 +52,14 @@ def find_build_dir() -> Path:
             return build_dir
         dir = dir.parent
 
-    exit("FAILED: Can't find print-sys-info. Pass location as argument")
+    exit("FAILED: Can't find build dir. Pass --build-dir to hint location.")
 
 
 def detect_features_from_app(app_path: Path) -> Dict[str, bool]:
     result = run([str(app_path)],
                  capture_output=True,
                  text=True)
+    print(f"--- {app_path} ---")
     print(result.stderr)
     print(result.stdout)
     if result.returncode != 0:
@@ -76,7 +81,8 @@ def detect_features_from_app(app_path: Path) -> Dict[str, bool]:
     #        'amd_sse4_1': false
     features = {}
     for line in lines:
-        if m := re.search(f"'{machine}_(.+)': (false|true)", line):
+        m = re.search(f"'{machine}_(.+)': (false|true)", line)
+        if m:
             name = m.group(1)
             is_present = m.group(2) == 'true'
             features[name] = is_present
@@ -89,13 +95,24 @@ def detect_features_from_app(app_path: Path) -> Dict[str, bool]:
 def detect_features_from_os() -> List[str]:
     features = []
 
+    cpuinfo_path = '/proc/cpuinfo'
     try:
-        with open('/proc/cpuinfo') as f:
+        with open(cpuinfo_path) as f:
             cpuinfo_text = f.read()
     except:
-        exit("SKIP TEST: currently, this test only works on machines with /proc/cpuinfo")
+        print(f"SKIP TEST: currently, this test only works on machines with /proc/cpuinfo")
+        exit(0)
 
-    # for line in cpuinfo_text:
+    # looking for line like: flags           : fpu vme de pse ...
+    print(f"--- {cpuinfo_path} ---")
+    for line in cpuinfo_text.splitlines():
+        print(line)
+        m = re.match(r"flags\s+:(.*)", line)
+        if m:
+            flags = m.group(1).split()
+            return flags
+
+    exit(f"FAILED: Cannot detect 'flags' in {cpuinfo_path}")
 
 
 if __name__ == '__main__':

--- a/builder.json
+++ b/builder.json
@@ -22,6 +22,6 @@
     },
     "test_steps": [
         "test",
-        ["python3", "{source_dir}/bin/system_info/test-print-system-info.py", "{install_dir}/bin/print-sys-info{exe}"]
+        ["python3", "{source_dir}/bin/system_info/test-print-system-info.py", "--build-dir", "{build_dir}"]
     ]
 }

--- a/builder.json
+++ b/builder.json
@@ -19,5 +19,9 @@
                 ["dir", "/s", "/b"]
             ]
         }
-    }
+    },
+    "test_steps": [
+        "test",
+        ["python3", "{source_dir}/bin/system_info/test-print-system-info.py", "{install_dir}/bin/print-sys-info{exe}"]
+    ]
 }


### PR DESCRIPTION
**Issue:**
I accidentally committed broken CPU-feature-detection code in https://github.com/awslabs/aws-c-common/pull/1182 (fixed the next day by https://github.com/awslabs/aws-c-common/pull/1184)

This kind of accident slipped through because I was in a rush, and we don't have unit tests to double-check this particular code. Unit tests for feature detection are hard because these features vary wildly machine to machine.

**Description of changes:**
Add an integration test that checks CPU-feature-detection against linux's easy-to-parse `/proc/cpuinfo`.

This test is skipped on platforms like Windows and Apple where there's no simple way to query CPU features

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
