### PR TITLE
Make aws_byte_cursor_from_string NULL tolerant

### DIFF
--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -333,6 +333,7 @@ struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src)
  * Creates an aws_byte_cursor from an existing string.
  * If the src is NULL, returns empty cursor
  */
+AWS_COMMON_API
 struct aws_byte_cursor aws_byte_cursor_from_optional_string(const struct aws_string *src);
 
 /**

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -325,16 +325,16 @@ bool aws_byte_buf_write_from_whole_string(
 
 /**
  * Creates an aws_byte_cursor from an existing string.
+ * If the src is NULL, it returns an empty cursor
  */
 AWS_COMMON_API
 struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src);
 
 /**
  * Creates an aws_byte_cursor from an existing string.
- * If the src is NULL, returns empty cursor
  */
 AWS_COMMON_API
-struct aws_byte_cursor aws_byte_cursor_from_optional_string(const struct aws_string *src);
+struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src);
 
 /**
  * If the string was dynamically allocated, clones it. If the string was statically allocated (i.e. has no allocator),

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -330,6 +330,12 @@ AWS_COMMON_API
 struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src);
 
 /**
+ * Creates an aws_byte_cursor from an existing string.
+ * If the src is NULL, returns empty cursor
+ */
+struct aws_byte_cursor aws_byte_cursor_from_optional_string(const struct aws_string *src);
+
+/**
  * If the string was dynamically allocated, clones it. If the string was statically allocated (i.e. has no allocator),
  * returns the original string.
  */

--- a/include/aws/common/string.h
+++ b/include/aws/common/string.h
@@ -331,12 +331,6 @@ AWS_COMMON_API
 struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src);
 
 /**
- * Creates an aws_byte_cursor from an existing string.
- */
-AWS_COMMON_API
-struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src);
-
-/**
  * If the string was dynamically allocated, clones it. If the string was statically allocated (i.e. has no allocator),
  * returns the original string.
  */

--- a/source/string.c
+++ b/source/string.c
@@ -425,15 +425,6 @@ struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src)
     return aws_byte_cursor_from_array(aws_string_bytes(src), src->len);
 }
 
-/**
- * Creates an aws_byte_cursor from an existing string.
- * If the src is NULL, returns empty cursor
- */
-struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src) {
-
-    return aws_byte_cursor_from_string(src);
-}
-
 struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, const struct aws_string *str) {
     AWS_PRECONDITION(allocator);
     AWS_PRECONDITION(aws_string_is_valid(str));

--- a/source/string.c
+++ b/source/string.c
@@ -420,6 +420,20 @@ struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src)
     return aws_byte_cursor_from_array(aws_string_bytes(src), src->len);
 }
 
+/**
+ * Creates an aws_byte_cursor from an existing string.
+ * If the src is NULL, returns empty cursor
+ */
+struct aws_byte_cursor aws_byte_cursor_from_optional_string(const struct aws_string *src) {
+    if (!src) {
+        struct aws_byte_cursor cursor;
+        AWS_ZERO_STRUCT(cursor);
+        return cursor;
+    }
+
+    return aws_byte_cursor_from_string(src);
+}
+
 struct aws_string *aws_string_clone_or_reuse(struct aws_allocator *allocator, const struct aws_string *str) {
     AWS_PRECONDITION(allocator);
     AWS_PRECONDITION(aws_string_is_valid(str));

--- a/source/string.c
+++ b/source/string.c
@@ -416,7 +416,12 @@ bool aws_byte_buf_write_from_whole_string(
  * Creates an aws_byte_cursor from an existing string.
  */
 struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src) {
-    AWS_PRECONDITION(aws_string_is_valid(src));
+    if (!src) {
+        struct aws_byte_cursor cursor;
+        AWS_ZERO_STRUCT(cursor);
+        return cursor;
+    }
+
     return aws_byte_cursor_from_array(aws_string_bytes(src), src->len);
 }
 
@@ -424,12 +429,7 @@ struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src)
  * Creates an aws_byte_cursor from an existing string.
  * If the src is NULL, returns empty cursor
  */
-struct aws_byte_cursor aws_byte_cursor_from_optional_string(const struct aws_string *src) {
-    if (!src) {
-        struct aws_byte_cursor cursor;
-        AWS_ZERO_STRUCT(cursor);
-        return cursor;
-    }
+struct aws_byte_cursor aws_byte_cursor_from_string(const struct aws_string *src) {
 
     return aws_byte_cursor_from_string(src);
 }


### PR DESCRIPTION
*Description of changes:*
Makes aws_byte_cursor_from_string return an empty cursor instead of crashing in debug builds for a NULL string. This change makes it easier to utilize this function. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
