### PR TITLE
CrossProcess lock -- don't unlock, just close fd

### DIFF
--- a/source/posix/cross_process_lock.c
+++ b/source/posix/cross_process_lock.c
@@ -133,7 +133,6 @@ cleanup:
 
 void aws_cross_process_lock_release(struct aws_cross_process_lock *instance_lock) {
     if (instance_lock) {
-        flock(instance_lock->locked_fd, LOCK_UN);
         close(instance_lock->locked_fd);
         AWS_LOGF_TRACE(AWS_LS_COMMON_GENERAL, "static: Lock file released for fd %d", instance_lock->locked_fd);
         aws_mem_release(instance_lock->allocator, instance_lock);


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*

>   Locks created by flock() are associated with an open file
       description (see open(2)).  This means that duplicate file
       descriptors (created by, for example, fork(2) or dup(2)) refer to
       the same lock, and this lock may be modified or released using any
       of these file descriptors.  Furthermore, the lock is released
       either by an explicit LOCK_UN operation on any of these duplicate
       file descriptors, or when all such file descriptors have been
       closed.

- So, https://man7.org/linux/man-pages/man2/flock.2.html, when the process is forked, the flock will still be held by the child process, and if the child process decides to release the flock, it releases the lock from the parent as well. Which is not expected
- Instead of unlock it, just close the file descriptor, so that OS will unlock after all the duplicate file descriptor closes.
- It mostly a concern of fork being used with lock held, and Windows doesn't support fork.  So, posix only

*Description of changes:*
- This introduces one concern, if the forked process becomes a orphan process and hang, the lock will be held by the forked process forever. But, I'd argue it's not a case we want to support, and in that case, other process just cannot grab the lock as the hanging process till has the lock, which is arguably an expected behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
