### PR TITLE
Tests require compiler extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,10 +192,11 @@ target_compile_options(${PROJECT_NAME} PUBLIC ${PLATFORM_CFLAGS})
 # Check public headers, to ensure they're safe for any 3rdparty to include
 set(HEADERS_TO_CHECK ${AWS_COMMON_HEADERS})
 
-# HACK: don't check rw_lock.h, which fails in esoteric circumstances (building without compiler extensions).
-# Currently, this file is only used by aws-c-*** libs, which always build with extensions.
-get_filename_component(IGNORE_HEADER "include/aws/common/rw_lock.h" ABSOLUTE)
-list(REMOVE_ITEM HEADERS_TO_CHECK ${IGNORE_HEADER})
+# HACK: don't check rw_lock.h, which can fail in esoteric circumstances
+# (building without compiler extensions, and without defining _POSIX_C_SOURCE or _XOPEN_SOURCE).
+# Currently, this file is only used by aws-c-*** libs, which are fine.
+get_filename_component(NAUGHTY_HEADER "include/aws/common/rw_lock.h" ABSOLUTE)
+list(REMOVE_ITEM HEADERS_TO_CHECK ${NAUGHTY_HEADER})
 
 aws_check_headers(${PROJECT_NAME} ${HEADERS_TO_CHECK})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,15 @@ aws_set_common_properties(${PROJECT_NAME} NO_WEXTRA)
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_COMMON")
 target_compile_options(${PROJECT_NAME} PUBLIC ${PLATFORM_CFLAGS})
 
-aws_check_headers(${PROJECT_NAME} ${AWS_COMMON_HEADERS})
+# Check public headers, to ensure they're safe for any 3rdparty to include
+set(HEADERS_TO_CHECK ${AWS_COMMON_HEADERS})
+
+# HACK: don't check rw_lock.h, which fails in esoteric circumstances (building without compiler extensions).
+# Currently, this file is only used by aws-c-*** libs, which always build with extensions.
+get_filename_component(IGNORE_HEADER "include/aws/common/rw_lock.h" ABSOLUTE)
+list(REMOVE_ITEM HEADERS_TO_CHECK ${IGNORE_HEADER})
+
+aws_check_headers(${PROJECT_NAME} ${HEADERS_TO_CHECK})
 
 #apple source already includes the definitions we want, and setting this posix source
 #version causes it to revert to an older version. So don't turn it on there, we don't need it.

--- a/cmake/AwsCheckHeaders.cmake
+++ b/cmake/AwsCheckHeaders.cmake
@@ -61,6 +61,9 @@ function(aws_check_headers_internal target std is_cxx)
         CXX_STANDARD ${std}
         CXX_STANDARD_REQUIRED 0
         C_STANDARD 99
+        # Forbid public headers from relying on compiler extensions
+        CXX_EXTENSIONS OFF
+        C_EXTENSIONS OFF
     )
 
     # Ensure our headers can be included by an application with its warnings set very high.

--- a/cmake/AwsTestHarness.cmake
+++ b/cmake/AwsTestHarness.cmake
@@ -53,7 +53,13 @@ function(generate_test_driver driver_exe_name)
 
     target_link_libraries(${driver_exe_name} PRIVATE ${PROJECT_NAME})
 
-    set_target_properties(${driver_exe_name} PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
+    set_target_properties(${driver_exe_name} PROPERTIES
+        LINKER_LANGUAGE C
+        C_STANDARD 99
+        # Our ASSERT(...) macros rely on (widely supported) ##__VA_ARGS__ extension
+        C_EXTENSIONS ON
+    )
+
     target_compile_definitions(${driver_exe_name} PRIVATE AWS_UNSTABLE_TESTING_API=1)
     target_include_directories(${driver_exe_name} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
@@ -75,7 +81,11 @@ function(generate_cpp_test_driver driver_exe_name)
     add_executable(${driver_exe_name} ${CMAKE_CURRENT_BINARY_DIR}/test_runner.cpp ${TESTS})
     target_link_libraries(${driver_exe_name} PRIVATE ${PROJECT_NAME})
 
-    set_target_properties(${driver_exe_name} PROPERTIES LINKER_LANGUAGE CXX)
+    set_target_properties(${driver_exe_name} PROPERTIES
+        LINKER_LANGUAGE CXX
+        # Our ASSERT(...) macros rely on (widely supported) ##__VA_ARGS__ extension
+        CXX_EXTENSIONS ON
+    )
     if (MSVC)
         if(AWS_STATIC_MSVC_RUNTIME_LIBRARY OR STATIC_CRT)
             target_compile_options(${driver_exe_name} PRIVATE "/MT$<$<CONFIG:Debug>:d>")


### PR DESCRIPTION
**Issue:**

aws-crt-cpp fails while building test files, if user sets `CXXFLAGS=-std=c++11`.

This was happening in [aws-crt-builder's CI](https://github.com/awslabs/aws-crt-builder/blob/160150b3abcbfad9a21641ace57e68e0185329ad/.github/workflows/sanity-test.yml#L229), and [this PR](https://github.com/awslabs/aws-crt-builder/pull/319) started failing because of it.

**Diagnosis:**

Here's what I found:

* Our tests rely on the [`## __VA_ARGS__`](https://gcc.gnu.org/onlinedocs/gcc/Variadic-Macros.html) compiler extension, due to its usage within our [`ASSERT(...)`](https://github.com/awslabs/aws-c-common/blob/d80b00560f0ebb441538b3ab40192a242afeaa80/include/aws/testing/aws_test_harness.h#L96) macros.
    * We use it so that custom failure messages are optional
    * Apparently, this compiler extension is widely supported, because this code has been here for 7 years, and we never realized it was problematic

* CMake defaults to building with compiler extensions ON
    *  With extensions ON, the `-std=gnu99` compiler flag will be used, instead of `-std=c99` flag

* Our tests fail to compile if user changes does something that makes compiler extensions OFF by default. This can be done in a variety of ways, including...
    * `CXXFLAGS=-std=c++11`
    * `CFLAGS=-std=c99`
    * `CMAKE_C_EXTENSIONS_DEFAULT=OFF`

This leaves us with two options:
1) Ensure compiler extensions are enabled when building tests
2) Change the ASSERT(...) macros, so they don't rely on the extension.

I investigated changing the ASSERT(...) macros, having differently named ASSERTF(...) macros for custom messages, but this was a massive breaking change for our downstream libraries that use these macros. I'll leave it in this [less-macro-magic](https://github.com/awslabs/aws-c-common/tree/less-macro-magic) branch, that we can pick up if we ever need to do this in the future.

I'm going to go with the less disruptive option 1 fix for now...

**Description of changes:**

* Ensure compiler extensions are turned ON for tests
* Ensure public headers are not relying on compiler extensions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
