### PR TITLE
Fix casing on Windows header files

### DIFF
--- a/source/arch/arm/windows/cpuid.c
+++ b/source/arch/arm/windows/cpuid.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include <Windows.h>
+#include <windows.h>
 #include <aws/common/cpuid.h>
 
 bool aws_cpu_has_feature(enum aws_cpu_feature_name feature_name) {

--- a/source/arch/arm/windows/cpuid.c
+++ b/source/arch/arm/windows/cpuid.c
@@ -13,8 +13,8 @@
  * permissions and limitations under the License.
  */
 
-#include <windows.h>
 #include <aws/common/cpuid.h>
+#include <windows.h>
 
 bool aws_cpu_has_feature(enum aws_cpu_feature_name feature_name) {
     switch (feature_name) {


### PR DESCRIPTION
*Issue #, if available:*

(n/a)

*Description of changes:*

This change corrects Windows-specific header names to use canonical casing, which helps with cross-compilation on non-Windows hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
