### PR TITLE
Fix invalid XML Buffer Overflow Error

### DIFF
--- a/AWSCRTAndroidTestRunner/gradle/wrapper/gradle-wrapper.properties
+++ b/AWSCRTAndroidTestRunner/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 01 11:18:00 PDT 2020
+#Fri May 09 10:40:15 PDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/include/aws/common/xml_parser.h
+++ b/include/aws/common/xml_parser.h
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/* WARNING: This is not a public API. It is only intended for use within the aws-c libraries. */
 #include <aws/common/array_list.h>
 #include <aws/common/byte_buf.h>
 

--- a/source/xml_parser.c
+++ b/source/xml_parser.c
@@ -295,7 +295,7 @@ int aws_xml_node_traverse(
 
         const uint8_t *end_location = memchr(parser->doc.ptr, '>', parser->doc.len);
 
-        if (!end_location || next_location > end_location) {
+        if (!end_location || next_location >= end_location) {
             AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
             aws_raise_error(AWS_ERROR_INVALID_XML);
             goto error;
@@ -380,7 +380,7 @@ int s_node_next_sibling(struct aws_xml_parser *parser) {
     aws_byte_cursor_advance(&parser->doc, next_location - parser->doc.ptr);
     const uint8_t *end_location = memchr(parser->doc.ptr, '>', parser->doc.len);
 
-    if (!end_location || next_location > end_location) {
+    if (!end_location || next_location >= end_location) {
         AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
         return aws_raise_error(AWS_ERROR_INVALID_XML);
     }

--- a/source/xml_parser.c
+++ b/source/xml_parser.c
@@ -232,11 +232,8 @@ int s_advance_to_closing_tag(
                     continue;
                 }
             }
-            size_t skip_len;
-            if (aws_sub_size_checked((size_t)close_find_result.ptr, (size_t)parser->doc.ptr, &skip_len)) {
-                AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
-                return aws_raise_error(AWS_ERROR_INVALID_XML);
-            }
+            size_t skip_len = close_find_result.ptr - parser->doc.ptr;
+
             aws_byte_cursor_advance(&parser->doc, skip_len + closing_cmp_buf.len);
             depth_count--;
             break;

--- a/source/xml_parser.c
+++ b/source/xml_parser.c
@@ -295,7 +295,7 @@ int aws_xml_node_traverse(
 
         const uint8_t *end_location = memchr(parser->doc.ptr, '>', parser->doc.len);
 
-        if (!end_location) {
+        if (!end_location || next_location > end_location) {
             AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
             aws_raise_error(AWS_ERROR_INVALID_XML);
             goto error;
@@ -307,12 +307,7 @@ int aws_xml_node_traverse(
             parent_closed = true;
         }
 
-        size_t node_name_len;
-        if (aws_sub_size_checked((size_t)end_location, (size_t)next_location, &node_name_len)) {
-            AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
-            aws_raise_error(AWS_ERROR_INVALID_XML);
-            goto error;
-        }
+        size_t node_name_len = end_location - next_location;
         aws_byte_cursor_advance(&parser->doc, end_location - parser->doc.ptr + 1);
 
         if (parent_closed) {
@@ -385,16 +380,12 @@ int s_node_next_sibling(struct aws_xml_parser *parser) {
     aws_byte_cursor_advance(&parser->doc, next_location - parser->doc.ptr);
     const uint8_t *end_location = memchr(parser->doc.ptr, '>', parser->doc.len);
 
-    if (!end_location) {
+    if (!end_location || next_location > end_location) {
         AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
         return aws_raise_error(AWS_ERROR_INVALID_XML);
     }
 
-    size_t node_name_len;
-    if (aws_sub_size_checked((size_t)end_location, (size_t)next_location, &node_name_len)) {
-        AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
-        return aws_raise_error(AWS_ERROR_INVALID_XML);
-    }
+    size_t node_name_len = end_location - next_location;
     aws_byte_cursor_advance(&parser->doc, end_location - parser->doc.ptr + 1);
 
     struct aws_byte_cursor node_decl_body = aws_byte_cursor_from_array(next_location + 1, node_name_len - 1);

--- a/source/xml_parser.c
+++ b/source/xml_parser.c
@@ -374,7 +374,8 @@ int s_node_next_sibling(struct aws_xml_parser *parser) {
     const uint8_t *next_location = memchr(parser->doc.ptr, '<', parser->doc.len);
 
     if (!next_location) {
-        return parser->error;
+        AWS_LOGF_ERROR(AWS_LS_COMMON_XML_PARSER, "XML document is invalid.");
+        return aws_raise_error(AWS_ERROR_INVALID_XML);
     }
 
     aws_byte_cursor_advance(&parser->doc, next_location - parser->doc.ptr);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -461,7 +461,7 @@ add_test_case(run_command_test_bad_command)
 add_test_case(cpuid_test)
 
 add_test_case(xml_parser_root_with_text) 
-add_test_case(xml_parser_malformed_test)
+add_test_case(xml_parser_malformed_end_node_character_before_start_test)
 add_test_case(xml_parser_child_with_text)
 add_test_case(xml_parser_siblings_with_text)
 add_test_case(xml_parser_preamble_and_attributes)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -460,7 +460,8 @@ add_test_case(run_command_test_bad_command)
 
 add_test_case(cpuid_test)
 
-add_test_case(xml_parser_root_with_text)
+add_test_case(xml_parser_root_with_text) 
+add_test_case(xml_parser_malformed_test)
 add_test_case(xml_parser_child_with_text)
 add_test_case(xml_parser_siblings_with_text)
 add_test_case(xml_parser_preamble_and_attributes)

--- a/tests/xml_parser_test.c
+++ b/tests/xml_parser_test.c
@@ -95,15 +95,16 @@ static int s_xml_parser_child_with_text_test(struct aws_allocator *allocator, vo
 
 AWS_TEST_CASE(xml_parser_child_with_text, s_xml_parser_child_with_text_test)
 
-const char *malformed = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rootNode>><child1>TestBody</child1></rootNode>";
+const char *malformed_end_node_character_before_start =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rootNode>><child1>TestBody</child1></rootNode>";
 
-static int s_xml_parser_malformed_test(struct aws_allocator *allocator, void *ctx) {
+static int s_xml_parser_malformed_end_node_character_before_start_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     struct child_text_capture capture;
     AWS_ZERO_STRUCT(capture);
 
     struct aws_xml_parser_options options = {
-        .doc = aws_byte_cursor_from_c_str(malformed),
+        .doc = aws_byte_cursor_from_c_str(malformed_end_node_character_before_start),
         .on_root_encountered = s_root_with_child,
         .user_data = &capture,
     };
@@ -112,7 +113,9 @@ static int s_xml_parser_malformed_test(struct aws_allocator *allocator, void *ct
     return AWS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(xml_parser_malformed_test, s_xml_parser_malformed_test)
+AWS_TEST_CASE(
+    xml_parser_malformed_end_node_character_before_start_test,
+    s_xml_parser_malformed_end_node_character_before_start_test)
 
 const char *siblings_with_text =
     "<?xml version=\"1.0\" "

--- a/tests/xml_parser_test.c
+++ b/tests/xml_parser_test.c
@@ -95,6 +95,25 @@ static int s_xml_parser_child_with_text_test(struct aws_allocator *allocator, vo
 
 AWS_TEST_CASE(xml_parser_child_with_text, s_xml_parser_child_with_text_test)
 
+const char *malformed = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rootNode>><child1>TestBody</child1></rootNode>";
+
+static int s_xml_parser_malformed_test(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    struct child_text_capture capture;
+    AWS_ZERO_STRUCT(capture);
+
+    struct aws_xml_parser_options options = {
+        .doc = aws_byte_cursor_from_c_str(malformed),
+        .on_root_encountered = s_root_with_child,
+        .user_data = &capture,
+    };
+    ASSERT_ERROR(AWS_ERROR_INVALID_XML, aws_xml_parse(allocator, &options));
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(xml_parser_malformed_test, s_xml_parser_malformed_test)
+
 const char *siblings_with_text =
     "<?xml version=\"1.0\" "
     "encoding=\"UTF-8\"?><rootNode><child1>TestBody</child1><child2>TestBody2</child2></rootNode>";


### PR DESCRIPTION
*Description of changes:*
Our XML parser assumes that the XML provided is valid and is intended for internal use only. I have fixed buffer overflow for some cases as it's nice to fix them but there might be other issues with invalid XML.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
