### PR TITLE
Add reset src api for aws_cbor_decoder

### DIFF
--- a/include/aws/common/cbor.h
+++ b/include/aws/common/cbor.h
@@ -313,6 +313,17 @@ AWS_COMMON_API
 size_t aws_cbor_decoder_get_remaining_length(const struct aws_cbor_decoder *decoder);
 
 /**
+ * @brief  Reset the decoder source to a new src.
+ * The previous src will be discarded regardless of the unconsumed bytes.
+ * The decoder will clear its cache if any.
+ *
+ * @param decoder
+ * @param src   The src data to decode from..
+ */
+AWS_COMMON_API
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+
+/**
  * @brief Decode the next element and store it in the decoder cache if there was no element cached.
  * If there was element cached, just return the type of the cached element.
  *
@@ -414,9 +425,9 @@ AWS_COMMON_API
 int aws_cbor_decoder_pop_next_array_start(struct aws_cbor_decoder *decoder, uint64_t *out_size);
 
 /**
- * @brief Get the next AWS_CBOR_TYPE_MAP_START element. Only consume the AWS_CBOR_TYPE_MAP_START element and set the
- * size of array to *out_size, not the content of the map. The next *out_size pair of cbor data items as key and value
- * will be the content of the array for a valid cbor data,
+ * @brief Get the next AWS_CBOR_TYPE_MAP_START element.
+ * Only consume the AWS_CBOR_TYPE_MAP_START element and set the size of array to *out_size, not the content of the map.
+ * The next *out_size pair of cbor data items as key and value will be the content of the array for a valid cbor data,
  *
  * Notes: For indefinite-length, this function will fail with "AWS_ERROR_CBOR_UNEXPECTED_TYPE". The designed way to
  * handle indefinite-length is:
@@ -432,12 +443,12 @@ AWS_COMMON_API
 int aws_cbor_decoder_pop_next_map_start(struct aws_cbor_decoder *decoder, uint64_t *out_size);
 
 /**
- * @brief Get the next AWS_CBOR_TYPE_TAG element. Only consume the AWS_CBOR_TYPE_TAG element and set the
- * tag value to *out_tag_val, not the content of the tagged. The next cbor data item will be the content of the tagged
- * value for a valid cbor data.
+ * @brief Get the next AWS_CBOR_TYPE_TAG element.
+ * Only consume the AWS_CBOR_TYPE_TAG element and set the tag ID value to *out_tag_val, not the content of the tagged.
+ * The next cbor data item will be the content of the tagged value for a valid cbor data.
  *
  * @param decoder
- * @param out_size store the size of map if succeed.
+ * @param out_tag_val store the value of tag ID.
  * @return AWS_OP_SUCCESS successfully consumed the next element and get the result, otherwise AWS_OP_ERR.
  */
 AWS_COMMON_API

--- a/source/cbor.c
+++ b/source/cbor.c
@@ -320,6 +320,11 @@ size_t aws_cbor_decoder_get_remaining_length(const struct aws_cbor_decoder *deco
     return decoder->src.len;
 }
 
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src) {
+    decoder->src = src;
+    decoder->cached_context.type = AWS_CBOR_TYPE_UNKNOWN;
+}
+
 #define LIBCBOR_VALUE_CALLBACK(field, callback_type, cbor_type)                                                        \
     static void s_##field##_callback(void *ctx, callback_type val) {                                                   \
         struct aws_cbor_decoder *decoder = ctx;                                                                        \

--- a/tests/cbor_test.c
+++ b/tests/cbor_test.c
@@ -438,21 +438,19 @@ CBOR_TEST_CASE(cbor_decode_error_handling_test) {
     struct aws_cbor_decoder *decoder = aws_cbor_decoder_new(allocator, invalid_cbor);
     ASSERT_FAILS(aws_cbor_decoder_peek_type(decoder, &out_type));
     ASSERT_UINT_EQUALS(AWS_ERROR_INVALID_CBOR, aws_last_error());
-    aws_cbor_decoder_destroy(decoder);
 
     /* 2. Empty cursor */
     struct aws_byte_cursor empty = {0};
-    decoder = aws_cbor_decoder_new(allocator, empty);
+    aws_cbor_decoder_reset_src(decoder, empty);
     ASSERT_FAILS(aws_cbor_decoder_peek_type(decoder, &out_type));
     ASSERT_UINT_EQUALS(AWS_ERROR_INVALID_CBOR, aws_last_error());
-    aws_cbor_decoder_destroy(decoder);
 
     /* 3. Try get wrong type */
     struct aws_cbor_encoder *encoder = aws_cbor_encoder_new(allocator);
     uint64_t val = 1;
     aws_cbor_encoder_write_uint(encoder, val);
     struct aws_byte_cursor final_cursor = aws_cbor_encoder_get_encoded_data(encoder);
-    decoder = aws_cbor_decoder_new(allocator, final_cursor);
+    aws_cbor_decoder_reset_src(decoder, final_cursor);
     uint64_t out = 0;
     ASSERT_FAILS(aws_cbor_decoder_pop_next_array_start(decoder, &out));
     ASSERT_UINT_EQUALS(AWS_ERROR_CBOR_UNEXPECTED_TYPE, aws_last_error());
@@ -463,7 +461,6 @@ CBOR_TEST_CASE(cbor_decode_error_handling_test) {
     ASSERT_FAILS(aws_cbor_decoder_consume_next_whole_data_item(decoder));
     ASSERT_FAILS(aws_cbor_decoder_peek_type(decoder, &out_type));
     ASSERT_UINT_EQUALS(AWS_ERROR_INVALID_CBOR, aws_last_error());
-    aws_cbor_decoder_destroy(decoder);
 
     /* 4. Consume data items with size */
     struct aws_byte_cursor val_1 = aws_byte_cursor_from_c_str("my test");
@@ -476,13 +473,13 @@ CBOR_TEST_CASE(cbor_decode_error_handling_test) {
     aws_cbor_encoder_write_tag(encoder, AWS_CBOR_TAG_NEGATIVE_BIGNUM);
     aws_cbor_encoder_write_bytes(encoder, val_1);
     final_cursor = aws_cbor_encoder_get_encoded_data(encoder);
-    decoder = aws_cbor_decoder_new(allocator, final_cursor);
+    aws_cbor_decoder_reset_src(decoder, final_cursor);
     ASSERT_SUCCESS(aws_cbor_decoder_peek_type(decoder, &out_type));
     ASSERT_UINT_EQUALS(AWS_CBOR_TYPE_MAP_START, out_type);
     ASSERT_SUCCESS(aws_cbor_decoder_consume_next_whole_data_item(decoder));
     ASSERT_UINT_EQUALS(0, aws_cbor_decoder_get_remaining_length(decoder));
-    aws_cbor_decoder_destroy(decoder);
 
+    aws_cbor_decoder_destroy(decoder);
     aws_cbor_encoder_destroy(encoder);
     aws_common_library_clean_up();
     return AWS_OP_SUCCESS;


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*

- add `aws_cbor_decoder_reset_src`, so that the decoder object can be reused.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
