### PR TITLE
Fix signature of aws_backtrace_log

### DIFF
--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -295,7 +295,7 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
         AWS_LS_COMMON_GENERAL, "aws_backtrace_print: backtrace requested, but logging is unsupported on this platform");
 }
 
-void aws_backtrace_log() {
+void aws_backtrace_log(int) {
     AWS_LOGF_TRACE(
         AWS_LS_COMMON_GENERAL, "aws_backtrace_log: backtrace requested, but logging is unsupported on this platform");
 }


### PR DESCRIPTION
Fix the signature of system_info.c aws_backtrace_log(int) for cases where AWS_OS_WINDOWS_DESKTOP is not defined

*Description of changes:*

Fix the signature of system_info.c aws_backtrace_log(int) for cases where AWS_OS_WINDOWS_DESKTOP is not defined

Without this the build may fail with a message like `error: number of arguments doesn't match prototype`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
