### PR TITLE
Fix signature of aws_backtrace_log

### DIFF
--- a/source/windows/system_info.c
+++ b/source/windows/system_info.c
@@ -295,7 +295,8 @@ void aws_backtrace_print(FILE *fp, void *call_site_data) {
         AWS_LS_COMMON_GENERAL, "aws_backtrace_print: backtrace requested, but logging is unsupported on this platform");
 }
 
-void aws_backtrace_log() {
+void aws_backtrace_log(int log_level) {
+    (void)log_level;
     AWS_LOGF_TRACE(
         AWS_LS_COMMON_GENERAL, "aws_backtrace_log: backtrace requested, but logging is unsupported on this platform");
 }


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
- original PR https://github.com/awslabs/aws-c-common/pull/1205

*Description of changes:*
- fix the missing signature for `aws_backtrace_log` when `AWS_OS_WINDOWS_DESKTOP` not defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
