### PR TITLE
Use _WIN32 not _MSC_VER for MinGW

### DIFF
--- a/include/aws/common/byte_order.inl
+++ b/include/aws/common/byte_order.inl
@@ -13,7 +13,7 @@
 #    include <stdlib.h>
 #else
 #    include <netinet/in.h>
-#endif /* _MSC_VER */
+#endif /* _WIN32 */
 
 AWS_EXTERN_C_BEGIN
 
@@ -39,7 +39,7 @@ AWS_STATIC_IMPL uint64_t aws_hton64(uint64_t x) {
     uint64_t v;
     __asm__("bswap %q0" : "=r"(v) : "0"(x));
     return v;
-#elif defined(_MSC_VER)
+#elif defined(_WIN32)
     return _byteswap_uint64(x);
 #else
     uint32_t low = x & UINT32_MAX;


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*

#1207

*Description of changes:*

We should use `_WIN32` not `_MSC_VER` to support both of Visual C++ and MinGW.

This was missed in https://github.com/awslabs/aws-c-common/pull/801 and https://github.com/awslabs/aws-c-common/pull/822 .

MSYS2 also includes this change:
https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-aws-c-common/001-fix-build-on-mingw-aarch64.patch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
