### PR TITLE
fix typo: `PPROCESSOR_NUMBER` -> `PROCESSOR_NUMBER`

### DIFF
--- a/source/windows/thread.c
+++ b/source/windows/thread.c
@@ -214,8 +214,8 @@ static SetThreadGroupAffinity_fn *s_SetThreadGroupAffinity;
 
 typedef BOOL WINAPI SetThreadIdealProcessorEx_fn(
     HANDLE hThread,
-    PPROCESSOR_NUMBER lpIdealProcessor,
-    PPROCESSOR_NUMBER lpPreviousIdealProcessor);
+    PROCESSOR_NUMBER lpIdealProcessor,
+    PROCESSOR_NUMBER lpPreviousIdealProcessor);
 static SetThreadIdealProcessorEx_fn *s_SetThreadIdealProcessorEx;
 
 typedef HRESULT WINAPI SetThreadDescription_fn(HANDLE hThread, PCWSTR lpThreadDescription);


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
Failing to compile using msys2:

```
C:/codebuild/tmp/output/src1697059352/src/aws-crt-kotlin/crt/aws-c-common/source/windows/thread.c:217:5: error: unknown type name 'PPROCESSOR_NUMBER'; did you mean 'PROCESSOR_ARM720'?
--
PPROCESSOR_NUMBER lpIdealProcessor,
^~~~~~~~~~~~~~~~~
PROCESSOR_ARM720
C:/codebuild/tmp/output/src1697059352/src/aws-crt-kotlin/crt/aws-c-common/source/windows/thread.c:218:5: error: unknown type name 'PPROCESSOR_NUMBER'; did you mean 'PROCESSOR_ARM720'?
PPROCESSOR_NUMBER lpPreviousIdealProcessor);
^~~~~~~~~~~~~~~~~
PROCESSOR_ARM720
```

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
