### PR TITLE
Fix tests on big-endian

### DIFF
--- a/tests/alloc_test.c
+++ b/tests/alloc_test.c
@@ -197,12 +197,12 @@ static void s_threaded_realloc_worker(void *user_data) {
         size_t old_size = size;
         size = rand() % 1024;
         if (old_size) {
-            AWS_FATAL_ASSERT(0 == memcmp(alloc, &thread_data->thread_idx, 1));
+            AWS_FATAL_ASSERT(*(uint8_t*)alloc == (uint8_t)thread_data->thread_idx);
         }
         AWS_FATAL_ASSERT(0 == aws_mem_realloc(test_allocator, &alloc, old_size, size));
         /* If there was a value, make sure it's still there */
         if (old_size && size) {
-            AWS_FATAL_ASSERT(0 == memcmp(alloc, &thread_data->thread_idx, 1));
+            AWS_FATAL_ASSERT(*(uint8_t*)alloc == (uint8_t)thread_data->thread_idx);
         }
         if (size) {
             memset(alloc, (int)thread_data->thread_idx, size);


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):* https://github.com/awslabs/aws-c-common/issues/1175

*Description of changes:* `thread_idx` needs to be casted to a single byte type to avoid endianes affecting the result of the check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
