### PR TITLE
Always use timegm() declaration from libc headers

### DIFF
--- a/source/posix/time.c
+++ b/source/posix/time.c
@@ -2,6 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+// For timegm() on glibc/musl
+#define _DEFAULT_SOURCE
 #include <aws/common/time.h>
 
 #if defined(__ANDROID__) && !defined(__LP64__)
@@ -58,11 +61,6 @@ time_t aws_timegm(struct tm *const t) {
 }
 
 #else
-
-#    ifndef __APPLE__
-/* glibc.... you disappoint me.. */
-extern time_t timegm(struct tm *);
-#    endif
 
 time_t aws_timegm(struct tm *const t) {
     return timegm(t);


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):* Otherwise on 32-bit musl-libc the function declaration would be incorrect, causing a 32-bit time_t compat function to be called.

*Description of changes:* It seems like the only part missing to use the libc provided one was to define _DEFAULT_SOURCE.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
