### PR TITLE
Add QNX cross-compilation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ else ()
 
         if (NOT ANDROID AND NOT CMAKE_THREAD_LIBS_INIT)
             check_symbol_exists(pthread_mutexattr_init "<pthread.h>" HAVE_PTHREAD_MUTEXATTR_INIT)
-            if (NOT HAVE_PTHREAD_MUTEXATTR_INIT)
+            if (NOT HAVE_PTHREAD_MUTEXATTR_INIT AND NOT QNX)
                 # fsanitize=... results in GLIBC library to provide some pthread APIs but not all
                 list(APPEND PLATFORM_LIBS pthread)
             endif()
@@ -202,7 +202,7 @@ aws_check_headers(${PROJECT_NAME} ${HEADERS_TO_CHECK})
 
 #apple source already includes the definitions we want, and setting this posix source
 #version causes it to revert to an older version. So don't turn it on there, we don't need it.
-if (UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} MATCHES FreeBSD|OpenBSD)
+if (UNIX AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} MATCHES FreeBSD|OpenBSD AND NOT QNX)
     #this only gets applied to aws-c-common (not its consumers).
     target_compile_definitions(${PROJECT_NAME} PRIVATE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500)
 endif()
@@ -225,9 +225,15 @@ set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1)
 # To make these paths work, add the location we're storing them as a search path.
 target_include_directories(${PROJECT_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/source/external/libcbor)
+if (NOT QNX)
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
+else()
+target_include_directories(${PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+endif()
 # When we install, the generated header will be at the INSTALL_INTERFACE:include location,
 # but at build time we need to explicitly include this here
 target_include_directories(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
This contribution adds cross-compilation support for QNX operating system to aws-c-common.

*Motivation*
QNX is an industry standard real-time operating system for embedded systems, particularly for vehicles, featuring safety focused features. It has also recently been made free for non-commercial use through the QNX Everywhere program, aiming for students, researchers and hobbyists to experiment with the OS.

Given that aws-c-common is a core package supporting multiple AWS dependencies, it would be great to enable aws-c-common to run natively on free version of QNX OS.

*Description of changes:*

- Remove `pthread` from `PLATFORM_LIBS` since QNX does not have explicit pthread library but rather included in QNX libc
- Add conditionals for unsupported compile definitions
- Add `INSTALL_INTERFACE` path customization for QNX

*How to build for QNX*
The build-files and instructions for cross compiling aws-c-common for QNX are present at [qnx-ports](https://github.com/qnx-ports/build-files/tree/main/ports/aws-c-common). A free QNX8 license can be obtained [here](https://blackberry.qnx.com/en/products/qnx-everywhere).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
