### PR TITLE
Remove apple-specific pthread_getname compile definition

### DIFF
--- a/cmake/AwsThreadName.cmake
+++ b/cmake/AwsThreadName.cmake
@@ -52,13 +52,6 @@ function(aws_set_thread_name_method target)
     endfunction()
 
     function(aws_set_thread_name_getter_method target)
-        if (APPLE)
-            # All Apple platforms we support have the same function, so no need for
-            # compile-time check.
-            target_compile_definitions(${target} PRIVATE -DAWS_PTHREAD_GETNAME_TAKES_3ARGS)
-            return()
-        endif()
-
         # Some platforms have 2 arg version
         check_c_source_compiles("
             ${c_source_start}


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):* #1220

*Description of changes:*
Removed apple-specific configuration to avoid compile time errors while building on old mac versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
