### PR TITLE
Add support for compiling Windows ARM64EC

### DIFF
--- a/cmake/AwsFeatureTests.cmake
+++ b/cmake/AwsFeatureTests.cmake
@@ -51,7 +51,7 @@ check_c_source_compiles("
 
 check_c_source_compiles("
     int main() {
-#if !(defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86))
+#if !(defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)) || defined(_M_ARM64EC_) || defined(_ARM64EC_)
 #    error \"not intel\"
 #endif
         return 0;
@@ -60,7 +60,7 @@ check_c_source_compiles("
 
 check_c_source_compiles("
     int main() {
-#if !(defined(__x86_64__) || defined(_M_X64))
+#if !(defined(__x86_64__) || defined(_M_X64)) || defined(_M_ARM64EC_) || defined(_ARM64EC_)
 #    error \"not intel\"
 #endif
         return 0;
@@ -69,7 +69,7 @@ check_c_source_compiles("
 
 check_c_source_compiles("
     int main() {
-#if !(defined(__aarch64__) || defined(_M_ARM64))
+#if !(defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC_) || defined(_ARM64EC_))
 #    error \"not arm64\"
 #endif
         return 0;
@@ -119,7 +119,7 @@ int main() {
     return 1;
 }" AWS_HAVE_LINUX_IF_LINK_H)
 
-if(MSVC)
+if(MSVC AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64EC")
     check_c_source_compiles("
     #include <intrin.h>
     int main() {


### PR DESCRIPTION
PR Description:

- ARM64EC (Emulation Compatible) is an application binary interface (ABI) for applications running on ARM-based Windows 11 devices. Code built for ARM64EC can interoperate with x64 code running under emulation, leveraging the native performance of ARM hardware.
- This PR adds support for building the AWS-C-Common library targeting Windows ARM64EC. The changes include conditional guards to exclude x64-specific code paths, enabling successful compilation for the ARM64EC architecture.