### PR TITLE
CBMC: Add proof for aws_string_new_from_buf

### DIFF
--- a/verification/cbmc/proofs/aws_string_new_from_buf/Makefile
+++ b/verification/cbmc/proofs/aws_string_new_from_buf/Makefile
@@ -21,3 +21,4 @@ PROJECT_SOURCES += $(SRCDIR)/source/common.c
 PROJECT_SOURCES += $(SRCDIR)/source/string.c
 
 include ../Makefile.common
+

--- a/verification/cbmc/proofs/aws_string_new_from_buf/aws_string_new_from_buf_harness.c
+++ b/verification/cbmc/proofs/aws_string_new_from_buf/aws_string_new_from_buf_harness.c
@@ -24,9 +24,10 @@ void aws_string_new_from_buf_harness() {
 
     /* assertions */
     if (str) {
-        assert(str->len == buf.len);  // length matches 
-        assert(str->bytes[str->len] == 0);  // Null terminated
-        assert_bytes_match(str->bytes, buf.buffer, str->len);  // bytes match
-        assert(aws_string_is_valid(str));  // valid string 
+        assert(str->len == buf.len);
+        assert(str->bytes[str->len] == 0);
+        assert_bytes_match(str->bytes, buf.buffer, str->len);
+        assert(aws_string_is_valid(str));
     }
 }
+

--- a/verification/cbmc/proofs/aws_string_new_from_buf/cbmc-proof.txt
+++ b/verification/cbmc/proofs/aws_string_new_from_buf/cbmc-proof.txt
@@ -1,1 +1,2 @@
 This file marks the directory as containing a CBMC proof
+


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
aws_string_new_from_buf did not have a proof for CBMC verification.

*Description of changes:*
Create a proof harness for aws_string_new_from_buf. The proof verifies that the function returns a valid string given preconditions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
