### PR TITLE
aws_cbor_decoder_get_unconsumed_length

### DIFF
--- a/include/aws/common/cbor.h
+++ b/include/aws/common/cbor.h
@@ -305,12 +305,25 @@ struct aws_cbor_decoder *aws_cbor_decoder_destroy(struct aws_cbor_decoder *decod
 /**
  * @brief  Get the length of the remaining bytes of the source. Once the source was decoded, it will be consumed,
  * and result in decrease of the remaining length of bytes.
+ * Note: aws_cbor_decoder_peek_type will also decrease the remaining length, as it decodes the next element
+ * internally.
  *
  * @param decoder
  * @return The length of bytes remaining of the decoder source.
  */
 AWS_COMMON_API
 size_t aws_cbor_decoder_get_remaining_length(const struct aws_cbor_decoder *decoder);
+
+/**
+ * @brief  Get the number of bytes that have not yet been consumed (popped) by the caller.
+ * Unlike aws_cbor_decoder_get_remaining_length, aws_cbor_decoder_peek_type does NOT affect this value.
+ * Only pop/consume operations reduce the unconsumed length.
+ *
+ * @param decoder
+ * @return The number of bytes not yet consumed from the decoder source.
+ */
+AWS_COMMON_API
+size_t aws_cbor_decoder_get_unconsumed_length(const struct aws_cbor_decoder *decoder);
 
 /**
  * @brief  Reset the decoder source to a new src.

--- a/source/cbor.c
+++ b/source/cbor.c
@@ -302,6 +302,9 @@ struct aws_cbor_decoder {
 
     struct aws_cbor_decoder_context cached_context;
 
+    /* Number of bytes from src consumed by peek (cached but not yet popped) */
+    size_t cached_bytes_consumed;
+
     /* Error code during decoding. Fail the decoding process without recovering, */
     int error_code;
 
@@ -324,6 +327,15 @@ struct aws_cbor_decoder *aws_cbor_decoder_destroy(struct aws_cbor_decoder *decod
 }
 
 size_t aws_cbor_decoder_get_remaining_length(const struct aws_cbor_decoder *decoder) {
+    return decoder->src.len;
+}
+
+size_t aws_cbor_decoder_get_unconsumed_length(const struct aws_cbor_decoder *decoder) {
+    if (decoder->cached_context.type != AWS_CBOR_TYPE_UNKNOWN) {
+        /* peek_type decodes the next element and advances src, but from the caller's perspective
+         * those bytes haven't been consumed yet (the item hasn't been popped). Add them back. */
+        return decoder->src.len + decoder->cached_bytes_consumed;
+    }
     return decoder->src.len;
 }
 
@@ -506,6 +518,7 @@ static int s_cbor_decode_next_element(struct aws_cbor_decoder *decoder) {
     }
 
     aws_byte_cursor_advance(&decoder->src, result.read);
+    decoder->cached_bytes_consumed = result.read;
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -569,6 +569,7 @@ add_test_case(cbor_encode_decode_indef_test)
 add_test_case(cbor_decode_error_handling_test)
 add_test_case(cbor_decode_resource_limit_container_size_test)
 add_test_case(cbor_decode_resource_limit_depth_test)
+add_test_case(cbor_decode_remaining_length_after_peek_test)
 
 generate_test_driver(${PROJECT_NAME}-tests)
 

--- a/tests/cbor_test.c
+++ b/tests/cbor_test.c
@@ -549,3 +549,49 @@ CBOR_TEST_CASE(cbor_decode_resource_limit_depth_test) {
     aws_common_library_clean_up();
     return AWS_OP_SUCCESS;
 }
+
+CBOR_TEST_CASE(cbor_decode_remaining_length_after_peek_test) {
+    (void)allocator;
+    (void)ctx;
+    aws_common_library_init(allocator);
+
+    struct aws_cbor_encoder *encoder = aws_cbor_encoder_new(allocator);
+    aws_cbor_encoder_write_uint(encoder, 42);
+    aws_cbor_encoder_write_uint(encoder, 100);
+    struct aws_byte_cursor cursor = aws_cbor_encoder_get_encoded_data(encoder);
+    size_t total_len = cursor.len;
+
+    struct aws_cbor_decoder *decoder = aws_cbor_decoder_new(allocator, cursor);
+    ASSERT_UINT_EQUALS(total_len, aws_cbor_decoder_get_remaining_length(decoder));
+    ASSERT_UINT_EQUALS(total_len, aws_cbor_decoder_get_unconsumed_length(decoder));
+
+    /* peek_type: old API (remaining_length) DOES decrease, new API (unconsumed_length) does NOT */
+    enum aws_cbor_type out_type;
+    ASSERT_SUCCESS(aws_cbor_decoder_peek_type(decoder, &out_type));
+    ASSERT_TRUE(aws_cbor_decoder_get_remaining_length(decoder) < total_len);
+    ASSERT_UINT_EQUALS(total_len, aws_cbor_decoder_get_unconsumed_length(decoder));
+
+    /* after pop, both decrease */
+    uint64_t val;
+    ASSERT_SUCCESS(aws_cbor_decoder_pop_next_unsigned_int_val(decoder, &val));
+    ASSERT_UINT_EQUALS(42, val);
+    size_t after_first_pop = aws_cbor_decoder_get_unconsumed_length(decoder);
+    ASSERT_TRUE(after_first_pop < total_len);
+    ASSERT_UINT_EQUALS(after_first_pop, aws_cbor_decoder_get_remaining_length(decoder));
+
+    /* peek second element: unconsumed_length unchanged, remaining_length decreases */
+    ASSERT_SUCCESS(aws_cbor_decoder_peek_type(decoder, &out_type));
+    ASSERT_UINT_EQUALS(after_first_pop, aws_cbor_decoder_get_unconsumed_length(decoder));
+    ASSERT_TRUE(aws_cbor_decoder_get_remaining_length(decoder) < after_first_pop);
+
+    /* pop second, both should be 0 */
+    ASSERT_SUCCESS(aws_cbor_decoder_pop_next_unsigned_int_val(decoder, &val));
+    ASSERT_UINT_EQUALS(100, val);
+    ASSERT_UINT_EQUALS(0, aws_cbor_decoder_get_remaining_length(decoder));
+    ASSERT_UINT_EQUALS(0, aws_cbor_decoder_get_unconsumed_length(decoder));
+
+    aws_cbor_encoder_destroy(encoder);
+    aws_cbor_decoder_destroy(decoder);
+    aws_common_library_clean_up();
+    return AWS_OP_SUCCESS;
+}


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
- `aws_cbor_decoder_peek_type` will decrease the remaining length as it decode the source internally. 
- which makes it hard to use for the case where people peek, and then check the length to see if there is anything left to decode. 
- Introduce a new api `aws_cbor_decoder_get_unconsumed_length` so that it returns the length that is not consumed yet

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
