### PR TITLE
Fix non-ASCII environment variable handling on Windows

### DIFF
--- a/source/windows/environment.c
+++ b/source/windows/environment.c
@@ -10,36 +10,50 @@
 
 struct aws_string *aws_get_env(struct aws_allocator *allocator, const char *name) {
 #ifdef _MSC_VER
-#    pragma warning(push)
-#    pragma warning(disable : 4996)
-#endif
+    /* Convert variable name to wide (env var names are ASCII, which is valid UTF-8) */
+    struct aws_byte_cursor name_cursor = aws_byte_cursor_from_c_str(name);
+    struct aws_wstring *w_name = aws_string_convert_to_wchar_from_byte_cursor(allocator, &name_cursor);
+    if (!w_name) {
+        return NULL;
+    }
+
+    /* Read value as wide characters using _wdupenv_s */
+    wchar_t *w_value = NULL;
+    size_t w_value_len = 0;
+    _wdupenv_s(&w_value, &w_value_len, aws_wstring_c_str(w_name));
+    aws_wstring_destroy(w_name);
+
+    if (w_value == NULL || w_value_len == 0) {
+        free(w_value);
+        return NULL;
+    }
+
+    /* Convert wide value to UTF-8 */
+    struct aws_string *result = aws_string_convert_from_wchar_c_str(allocator, w_value);
+    free(w_value);
+
+    return result;
+#else
     const char *value = getenv(name);
-#ifdef _MSC_VER
-#    pragma warning(pop)
-#endif
 
     if (value == NULL) {
         return NULL;
     }
 
     return aws_string_new_from_c_str(allocator, value);
+#endif
 }
 
 struct aws_string *aws_get_env_nonempty(struct aws_allocator *allocator, const char *name) {
-#ifdef _MSC_VER
-#    pragma warning(push)
-#    pragma warning(disable : 4996)
-#endif
-    const char *value = getenv(name);
-#ifdef _MSC_VER
-#    pragma warning(pop)
-#endif
-
-    if (value == NULL || value[0] == '\0') {
+    struct aws_string *value = aws_get_env(allocator, name);
+    if (value == NULL) {
         return NULL;
     }
-
-    return aws_string_new_from_c_str(allocator, value);
+    if (value->len == 0) {
+        aws_string_destroy(value);
+        return NULL;
+    }
+    return value;
 }
 
 int aws_get_environment_value(
@@ -47,23 +61,7 @@ int aws_get_environment_value(
     const struct aws_string *variable_name,
     struct aws_string **value_out) {
 
-#ifdef _MSC_VER
-#    pragma warning(push)
-#    pragma warning(disable : 4996)
-#endif
-
-    const char *value = getenv(aws_string_c_str(variable_name));
-
-#ifdef _MSC_VER
-#    pragma warning(pop)
-#endif
-
-    if (value == NULL) {
-        *value_out = NULL;
-        return AWS_OP_SUCCESS;
-    }
-
-    *value_out = aws_string_new_from_c_str(allocator, value);
+    *value_out = aws_get_env(allocator, aws_string_c_str(variable_name));
     if (*value_out == NULL) {
         return aws_raise_error(AWS_ERROR_ENVIRONMENT_GET);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -415,6 +415,9 @@ add_test_case(uuid_string_parse_malformed)
 
 add_test_case(test_environment_functions)
 add_test_case(test_env_functions)
+if(WIN32)
+    add_test_case(test_env_non_ascii_path)
+endif()
 
 add_test_case(short_argument_parse)
 add_test_case(long_argument_parse)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -415,9 +415,7 @@ add_test_case(uuid_string_parse_malformed)
 
 add_test_case(test_environment_functions)
 add_test_case(test_env_functions)
-if(WIN32)
-    add_test_case(test_env_non_ascii_path)
-endif()
+add_test_case(test_env_non_ascii_path)
 
 add_test_case(short_argument_parse)
 add_test_case(long_argument_parse)

--- a/tests/environment_test.c
+++ b/tests/environment_test.c
@@ -82,3 +82,31 @@ static int s_test_env_functions_fn(struct aws_allocator *allocator, void *ctx) {
 }
 
 AWS_TEST_CASE(test_env_functions, s_test_env_functions_fn)
+
+static int s_test_env_non_ascii_path_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    /* Set a non-ASCII environment variable. The value 0xE9 is 'é' in the
+     * ANSI code page (CP-1252), simulating a Windows user whose USERPROFILE
+     * contains accented characters. */
+    AWS_STATIC_STRING_FROM_LITERAL(s_var_name, "AWS_TEST_NONASCII_VAR");
+    struct aws_string *ansi_value = aws_string_new_from_c_str(allocator, "C:\\Users\\hom\xE9");
+    aws_set_environment_value(s_var_name, ansi_value);
+    aws_string_destroy(ansi_value);
+
+    /* Read it back through aws_get_env */
+    struct aws_string *value = aws_get_env(allocator, "AWS_TEST_NONASCII_VAR");
+    ASSERT_NOT_NULL(value);
+
+    /* The value should be valid UTF-8. U+00E9 in UTF-8 is the two bytes 0xC3 0xA9. */
+    const char *expected_utf8 = "C:\\Users\\hom\xC3\xA9";
+    ASSERT_TRUE(strcmp(aws_string_c_str(value), expected_utf8) == 0);
+    aws_string_destroy(value);
+
+    /* Clean up */
+    aws_unset_environment_value(s_var_name);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(test_env_non_ascii_path, s_test_env_non_ascii_path_fn)


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
https://github.com/aws/aws-sdk-cpp/issues/3865

*Description of changes:*
On Windows, aws_get_env, aws_get_env_nonempty, and aws_get_environment_value use narrow getenv() which returns bytes in the active ANSI code page (e.g. CP-1252). Downstream,
  aws_fopen_safe converts paths to wide using MultiByteToWideChar(CP_UTF8, ...), assuming the input is UTF-8. For non-ASCII characters (e.g. é = 0xE9 in CP-1252), the encodings
  don't match, the wide path is mangled, and file opens fail silently.

  This causes the profile credentials provider to silently fail when the user's home path contains non-ASCII characters (common with non-English Windows usernames).

  Fix: Replace getenv() with GetEnvironmentVariableW + WideCharToMultiByte(CP_UTF8, ...) so the returned string is proper UTF-8 that round-trips correctly through aws_fopen_safe.

  Added a Windows-only unit test that sets a non-ASCII env var via SetEnvironmentVariableW and verifies aws_get_env returns valid UTF-8.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
