### PR TITLE
Suppress MSAN false positive

### DIFF
--- a/include/aws/common/macros.h
+++ b/include/aws/common/macros.h
@@ -163,6 +163,15 @@ enum { AWS_CACHE_LINE = 64 };
 #    define AWS_SUPPRESS_UBSAN
 #endif
 
+#if defined(__has_feature)
+#    if __has_feature(memory_sanitizer)
+#        define AWS_SUPPRESS_MSAN __attribute__((no_sanitize("memory")))
+#    endif
+#endif
+#if !defined(AWS_SUPPRESS_MSAN)
+#    define AWS_SUPPRESS_MSAN
+#endif
+
 /* If this is C++, restrict isn't supported. If this is not at least C99 on gcc and clang, it isn't supported.
  * If visual C++ building in C mode, the restrict definition is __restrict.
  * This just figures all of that out based on who's including this header file. */

--- a/source/allocator_sba.c
+++ b/source/allocator_sba.c
@@ -406,7 +406,7 @@ static void *s_sba_alloc(struct small_block_allocator *sba, size_t size) {
     return aws_mem_acquire(sba->allocator, size);
 }
 
-AWS_SUPPRESS_ASAN AWS_SUPPRESS_HWASAN AWS_SUPPRESS_TSAN static void s_sba_free(
+AWS_SUPPRESS_ASAN AWS_SUPPRESS_HWASAN AWS_SUPPRESS_TSAN AWS_SUPPRESS_MSAN static void s_sba_free(
     struct small_block_allocator *sba,
     void *addr) {
     if (!addr) {


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*

`s_sba_free` false-positively triggers MSAN.

*Description of changes:*

Similarly to how it was fixed for other sanitizers, suppress MSAN findings for `s_sba_free`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
