### PR TITLE
Make UBSan errors fatal

### DIFF
--- a/cmake/AwsSanitizers.cmake
+++ b/cmake/AwsSanitizers.cmake
@@ -67,8 +67,17 @@ function(aws_add_sanitizers target)
     endforeach()
 
     if(PRESENT_SANITIZERS)
-        target_compile_options(${target} PRIVATE -fno-omit-frame-pointer -fsanitize=${PRESENT_SANITIZERS})
-        target_link_libraries(${target} PUBLIC "-fno-omit-frame-pointer -fsanitize=${PRESENT_SANITIZERS}")
+        set(sanitizer_flags -fno-omit-frame-pointer -fsanitize=${PRESENT_SANITIZERS})
+
+        # By default UBSan only prints a diagnostic and continues. Turn violations into hard failures so
+        # they surface as test errors rather than being silently recovered from.
+        if("${PRESENT_SANITIZERS}" MATCHES "undefined")
+            list(APPEND sanitizer_flags -fno-sanitize-recover=all)
+        endif()
+
+        target_compile_options(${target} PRIVATE ${sanitizer_flags})
+        string(REPLACE ";" " " sanitizer_link_flags "${sanitizer_flags}")
+        target_link_libraries(${target} PUBLIC "${sanitizer_link_flags}")
 
         string(REPLACE "," ";" PRESENT_SANITIZERS "${PRESENT_SANITIZERS}")
         set(${target}_SANITIZERS ${PRESENT_SANITIZERS} PARENT_SCOPE)

--- a/source/byte_buf.c
+++ b/source/byte_buf.c
@@ -1826,7 +1826,7 @@ int aws_byte_cursor_utf8_parse_i64(struct aws_byte_cursor cursor, int64_t *dst) 
         return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
     }
 
-    *dst = is_neg ? -(int64_t)u64 : (int64_t)u64;
+    *dst = is_neg ? (int64_t)(0 - u64) : (int64_t)u64;
     return AWS_OP_SUCCESS;
 }
 

--- a/source/encoding.c
+++ b/source/encoding.c
@@ -314,6 +314,10 @@ static int s_base64_encode(
     struct aws_byte_buf *AWS_RESTRICT output,
     bool do_url_safe_encoding) {
 
+    if (AWS_UNLIKELY(to_encode->len == 0)) {
+        return AWS_OP_SUCCESS;
+    }
+
     size_t encoded_length = 0;
     if (do_url_safe_encoding) {
         if (AWS_UNLIKELY(aws_base64_url_compute_encoded_len(to_encode->len, &encoded_length))) {


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*
By default, UBSan only reports UB without failing the process. This leads to all UBSan errors silently being ignored in CI since logs are not printed for successful tests. 

*Description of changes:*

UBSan provides a special option, `-fno-sanitize-recover`, which makes encountered errors fatal. The downside is that UBSan now fails on the first error, so when there are multiple errors, multiple CI runs might be required to catch them all.

Fix two UB:

1. Signed integer overflow.
2. Pointer arithmetic with NULL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
