### PR TITLE
Optimize the size of encoded double values

### DIFF
--- a/source/cbor.c
+++ b/source/cbor.c
@@ -141,8 +141,10 @@ void aws_cbor_encoder_write_float(struct aws_cbor_encoder *encoder, double value
         aws_cbor_encoder_write_single_float(encoder, (float)value);
         return;
     }
+    /* Use INT64_MAX+1 as a threshold so it can be represented as double. */
+    double int64_overflow_threshold = 0x1p63;
     /* Conversation from int to floating-type is implementation defined if loss of precision */
-    if (value <= (double)INT64_MAX && value >= (double)INT64_MIN) {
+    if (value < int64_overflow_threshold && value >= (double)INT64_MIN) {
         /**
          * A prvalue of a floating point type can be converted to a prvalue of an integer type. The conversion
          * truncates; that is, the fractional part is discarded. The behavior is undefined if the truncated value cannot

--- a/source/cbor.c
+++ b/source/cbor.c
@@ -141,9 +141,14 @@ void aws_cbor_encoder_write_float(struct aws_cbor_encoder *encoder, double value
         aws_cbor_encoder_write_single_float(encoder, (float)value);
         return;
     }
-    /* Use INT64_MAX+1 as a threshold so it can be represented as double. */
+    /* INT64_MAX is 2^63-1, which can't be represented in a double's 53-bit significand. So under the default
+     * round-to-nearest mode (double)INT64_MAX rounds up to 2^63. That makes "value <= (double)INT64_MAX" behave as
+     * "value <= 2^63", letting 2^63 sneak into the if block below and reach the (int64_t) cast, where truncating
+     * 2^63 overflows int64, which is UB and causes the wrong value to be encoded on some platforms.
+     * Using strict "< 2^63" excludes it. The lower bound needs no such handling: INT64_MIN (-2^63) is a power of two
+     * and exactly representable, so (double)INT64_MIN is exactly -2^63.
+     */
     double int64_overflow_threshold = 0x1p63;
-    /* Conversation from int to floating-type is implementation defined if loss of precision */
     if (value < int64_overflow_threshold && value >= (double)INT64_MIN) {
         /**
          * A prvalue of a floating point type can be converted to a prvalue of an integer type. The conversion

--- a/tests/cbor_test.c
+++ b/tests/cbor_test.c
@@ -169,7 +169,7 @@ CBOR_TEST_CASE(cbor_encode_decode_double_test) {
     ASSERT_UINT_EQUALS(out_type, expected_encoded_type[index]);
     ASSERT_SUCCESS(aws_cbor_decoder_pop_next_float_val(decoder, &double_result));
     ASSERT_TRUE(values[index++] == double_result);
-    /* 2^63 (whole number in uint64 range, encodes as uint) */
+    /* 2^63 (out of int64 range, encodes as float) */
     ASSERT_SUCCESS(aws_cbor_decoder_peek_type(decoder, &out_type));
     ASSERT_UINT_EQUALS(out_type, expected_encoded_type[index]);
     ASSERT_SUCCESS(aws_cbor_decoder_pop_next_float_val(decoder, &double_result));

--- a/tests/cbor_test.c
+++ b/tests/cbor_test.c
@@ -72,7 +72,7 @@ CBOR_TEST_CASE(cbor_encode_decode_double_test) {
     (void)allocator;
     (void)ctx;
     aws_common_library_init(allocator);
-    enum { VALUE_NUM = 10 };
+    enum { VALUE_NUM = 11 };
 
     /**
      * 1 as unsigned int, takes 1 byte
@@ -85,13 +85,15 @@ CBOR_TEST_CASE(cbor_encode_decode_double_test) {
      * DBL_MAX will be a double takes 9 bytes
      * DBL_MIN will be a double takes 9 bytes
      * HUGE_VAL
+     * 2^63 is out of int64 range and encoded as a float, takes 5 bytes
      */
-    double values[VALUE_NUM] = {1.0, -1.0, 1.1, 1.1f, -1.1f, INFINITY, FLT_MAX, DBL_MAX, DBL_MIN, HUGE_VAL};
-    uint64_t expected_encoded_len[VALUE_NUM] = {1, 1, 9, 5, 5, 5, 5, 9, 9, 5};
+    double values[VALUE_NUM] = {1.0, -1.0, 1.1, 1.1f, -1.1f, INFINITY, FLT_MAX, DBL_MAX, DBL_MIN, HUGE_VAL, 0x1p63};
+    uint64_t expected_encoded_len[VALUE_NUM] = {1, 1, 9, 5, 5, 5, 5, 9, 9, 5, 5};
 
     int expected_encoded_type[VALUE_NUM] = {
         AWS_CBOR_TYPE_UINT,
         AWS_CBOR_TYPE_NEGINT,
+        AWS_CBOR_TYPE_FLOAT,
         AWS_CBOR_TYPE_FLOAT,
         AWS_CBOR_TYPE_FLOAT,
         AWS_CBOR_TYPE_FLOAT,
@@ -163,6 +165,11 @@ CBOR_TEST_CASE(cbor_encode_decode_double_test) {
     ASSERT_SUCCESS(aws_cbor_decoder_pop_next_float_val(decoder, &double_result));
     ASSERT_TRUE(values[index++] == double_result);
     /* HUGE_VAL */
+    ASSERT_SUCCESS(aws_cbor_decoder_peek_type(decoder, &out_type));
+    ASSERT_UINT_EQUALS(out_type, expected_encoded_type[index]);
+    ASSERT_SUCCESS(aws_cbor_decoder_pop_next_float_val(decoder, &double_result));
+    ASSERT_TRUE(values[index++] == double_result);
+    /* 2^63 (whole number in uint64 range, encodes as uint) */
     ASSERT_SUCCESS(aws_cbor_decoder_peek_type(decoder, &out_type));
     ASSERT_UINT_EQUALS(out_type, expected_encoded_type[index]);
     ASSERT_SUCCESS(aws_cbor_decoder_pop_next_float_val(decoder, &double_result));


### PR DESCRIPTION
Narrow the integer conversion in `aws_cbor_encoder_write_float` to 32 bits, so integral values larger than UINT32_MAX could be encoded as a float when lossless instead of a larger 9-byte integer.

The encoding order is the following:
- a 32-bit integer (<= 5 bytes);
- a float if lossless (5 bytes);
- fallback to double (9 bytes).

This also fixes UB for value == 2^63: it no longer reaches the (int64_t) cast, which overflowed int64.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
