### PR TITLE
Fix wrong libdir on some platforms

### DIFF
--- a/cmake/AwsSharedLibSetup.cmake
+++ b/cmake/AwsSharedLibSetup.cmake
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-include(GNUInstallDirs)
-
 function(aws_prepare_shared_lib_exports target)
+    # Included here, not at file scope, so this module is safe to include before project(): GNUInstallDirs needs
+    # an enabled language to pick the right libdir (e.g. "lib64" vs "lib" on 64-bit Linux).
+    include(GNUInstallDirs)
+
     if (BUILD_SHARED_LIBS)
         install(TARGETS ${target}
                 EXPORT ${target}-targets


### PR DESCRIPTION
*Issue #, and/or reason for changes (REQUIRED):*

Including `AwsSharedLibSetup.cmake` before `project()` leads to its file-scoped `include(GNUInstallDirs)` being executed before any language is enabled, which

1) emits CMake warning:
```
CMake Warning (author) at /cmake/Modules/GNUInstallDirs.cmake:448 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
```
2) sets `CMAKE_INSTALL_LIBDIR` to `lib` even on platforms where it should be `lib64`.

For example, Fedora x64 CI job always [used](https://github.com/awslabs/aws-c-common/actions/runs/28041535192/job/83281317998#step:3:2020) the following install dir:
```
-- Installing: /root/aws-c-common/build/install/lib64/libaws-c-common.a
```

After https://github.com/awslabs/aws-c-common/pull/1250 this [became](https://github.com/awslabs/aws-c-common/actions/runs/33115381902/job/98668573016#step:3:2027)
```
-- Installing: /root/aws-c-common/build/install/lib/libaws-c-common.a
```

*Description of changes:*

Move ` include(GNUInstallDirs)` out of file scope into `aws_prepare_shared_lib_exports`, the only function using `CMAKE_INSTALL_LIBDIR`.  This function is called after project is defined, so the arch is known and the libdir resolves correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
